### PR TITLE
feat: Update CI trigger for locale updates

### DIFF
--- a/.github/workflows/update_locales.yaml
+++ b/.github/workflows/update_locales.yaml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - 'src/locales/**.json'
+      - '**/home_registry.json'
     tags-ignore:
       - '*'
   workflow_dispatch:


### PR DESCRIPTION
I've modified the `update_locales.yaml` GitHub Actions workflow for you.

Now, the workflow will also be triggered by changes to any file named `home_registry.json` located anywhere in your repository (using the pattern `**/home_registry.json`).

This ensures that if a `home_registry.json` file is manually updated (e.g., adding a new UI element with text), the `update-locales.py` script runs to:
1. Translate any new text in `home_registry.json` into other supported languages.
2. Synchronize the structure and keys within the `info` objects of `home_registry.json` files according to your project's locale configuration.