### PR TITLE
fix: Correct user_settings shell configuration and remove tests

### DIFF
--- a/src/decl/pluginAPI.ts
+++ b/src/decl/pluginAPI.ts
@@ -33,7 +33,7 @@ export class pluginAPI_t {
 			// 这两个API为可以执行js代码的char提供高级扩展
 
 			// 此函数在合适时机扩充至char的有关代码运行的prompt中，为char更好掌握代码运行的上下文提供基础
-			GetJSCodePrompt?: (arg: chatReplyRequest_t, prompt_struct: prompt_struct_t, detail_level: number) => Promise<string|undefined>;
+			GetJSCodePrompt?: (arg: chatReplyRequest_t, prompt_struct: prompt_struct_t, detail_level: number) => Promise<string | undefined>;
 			// 此函数为char的代码运行提供特殊变量或函数，允许其在代码中使用
 			GetJSCodeContext?: (arg: chatReplyRequest_t, prompt_struct: prompt_struct_t) => Promise<Record<string, any>>;
 		}

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -692,7 +692,6 @@
 		"PageTitle": "用户设置",
 		"apiError": "API 请求失败: ${message}",
 		"generalError": "发生错误: ${message}",
-
 		"userInfo": {
 			"title": "用户信息",
 			"usernameLabel": "用户名:",
@@ -702,7 +701,6 @@
 			"copyPathBtnTitle": "复制路径",
 			"copiedAlert": "路径已复制到剪贴板！"
 		},
-
 		"changePassword": {
 			"title": "修改密码",
 			"currentPasswordLabel": "当前密码:",
@@ -712,7 +710,6 @@
 			"errorMismatch": "新密码两次输入不一致。",
 			"success": "密码修改成功。"
 		},
-
 		"renameUser": {
 			"title": "重命名用户",
 			"newUsernameLabel": "新用户名:",
@@ -720,7 +717,6 @@
 			"confirmMessage": "您确定要更改用户名吗？这将需要您重新登录。",
 			"success": "用户已成功重命名为 “${newUsername}”。您现在将被注销。"
 		},
-
 		"userDevices": {
 			"title": "用户设备/会话",
 			"refreshButtonTitle": "刷新列表",
@@ -732,15 +728,13 @@
 			"revokeConfirm": "您确定要从此设备/会话注销吗？",
 			"revokeSuccess": "设备/会话已成功撤销。"
 		},
-
 		"logout": {
 			"title": "登出",
 			"description": "这将从当前设备注销您的账户。",
 			"buttonText": "登出",
 			"confirmMessage": "您确定要登出吗？",
-      		"successMessage": "已成功登出。即将跳转到登录页面..."
+			"successMessage": "已成功登出。即将跳转到登录页面..."
 		},
-
 		"deleteAccount": {
 			"title": "删除账户",
 			"warning": "警告：此操作将永久删除您的账户和所有相关数据，且无法恢复。",
@@ -750,7 +744,6 @@
 			"usernameMismatch": "输入的用户名与当前用户不匹配。删除操作已取消。",
 			"success": "账户已成功删除。您现在将被注销。"
 		},
-
 		"passwordConfirm": {
 			"title": "确认操作",
 			"message": "为继续此操作，请输入您的当前密码：",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -686,5 +686,36 @@
 			"soundOn": "声音开启",
 			"soundOff": "声音关闭"
 		}
+	},
+	"userSettings": {
+		"title": "用户设置",
+		"header": "用户设置",
+		"common": {
+			"usernameLabel": "用户名:",
+			"passwordLabel": "密码:"
+		},
+		"changePassword": {
+			"title": "修改密码",
+			"currentPasswordLabel": "当前密码:",
+			"newPasswordLabel": "新密码:",
+			"submitButton": "修改密码"
+		},
+		"userDevices": {
+			"title": "用户设备",
+			"viewButton": "查看设备",
+			"noDevicesFound": "未找到该用户的设备。",
+			"revokeButton": "吊销"
+		},
+		"renameUser": {
+			"title": "重命名用户",
+			"currentUsernameLabel": "当前用户名:",
+			"newUsernameLabel": "新用户名:",
+			"submitButton": "重命名用户"
+		},
+		"deleteAccount": {
+			"title": "删除账户",
+			"submitButton": "删除账户",
+			"confirmDelete": "您确定要删除此账户吗？此操作无法撤销。"
+		}
 	}
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -689,33 +689,74 @@
 	},
 	"userSettings": {
 		"title": "用户设置",
-		"header": "用户设置",
-		"common": {
+		"PageTitle": "用户设置",
+		"apiError": "API 请求失败: ${message}",
+		"generalError": "发生错误: ${message}",
+
+		"userInfo": {
+			"title": "用户信息",
 			"usernameLabel": "用户名:",
-			"passwordLabel": "密码:"
+			"creationDateLabel": "账户创建日期:",
+			"folderSizeLabel": "用户数据大小:",
+			"folderPathLabel": "用户数据路径:",
+			"copyPathBtnTitle": "复制路径",
+			"copiedAlert": "路径已复制到剪贴板！"
 		},
+
 		"changePassword": {
 			"title": "修改密码",
 			"currentPasswordLabel": "当前密码:",
 			"newPasswordLabel": "新密码:",
-			"submitButton": "修改密码"
+			"confirmNewPasswordLabel": "确认新密码:",
+			"submitButton": "修改密码",
+			"errorMismatch": "新密码两次输入不一致。",
+			"success": "密码修改成功。"
 		},
-		"userDevices": {
-			"title": "用户设备",
-			"viewButton": "查看设备",
-			"noDevicesFound": "未找到该用户的设备。",
-			"revokeButton": "吊销"
-		},
+
 		"renameUser": {
 			"title": "重命名用户",
-			"currentUsernameLabel": "当前用户名:",
 			"newUsernameLabel": "新用户名:",
-			"submitButton": "重命名用户"
+			"submitButton": "重命名用户",
+			"confirmMessage": "您确定要更改用户名吗？这将需要您重新登录。",
+			"success": "用户已成功重命名为 “${newUsername}”。您现在将被注销。"
 		},
+
+		"userDevices": {
+			"title": "用户设备/会话",
+			"refreshButtonTitle": "刷新列表",
+			"noDevicesFound": "未找到任何设备或会话。",
+			"deviceInfo": "设备ID: ${deviceId}",
+			"thisDevice": "当前设备",
+			"deviceDetails": "最后上线: ${lastSeen} | IP: ${ipAddress} | UA: ${userAgent}",
+			"revokeButton": "撤销",
+			"revokeConfirm": "您确定要从此设备/会话注销吗？",
+			"revokeSuccess": "设备/会话已成功撤销。"
+		},
+
+		"logout": {
+			"title": "登出",
+			"description": "这将从当前设备注销您的账户。",
+			"buttonText": "登出",
+			"confirmMessage": "您确定要登出吗？",
+      		"successMessage": "已成功登出。即将跳转到登录页面..."
+		},
+
 		"deleteAccount": {
 			"title": "删除账户",
-			"submitButton": "删除账户",
-			"confirmDelete": "您确定要删除此账户吗？此操作无法撤销。"
+			"warning": "警告：此操作将永久删除您的账户和所有相关数据，且无法恢复。",
+			"submitButton": "删除我的账户",
+			"confirmMessage1": "警告！您确定要永久删除您的账户吗？此操作无法撤销。",
+			"confirmMessage2": "为确认删除，请输入您的用户名“${username}”：",
+			"usernameMismatch": "输入的用户名与当前用户不匹配。删除操作已取消。",
+			"success": "账户已成功删除。您现在将被注销。"
+		},
+
+		"passwordConfirm": {
+			"title": "确认操作",
+			"message": "为继续此操作，请输入您的当前密码：",
+			"passwordLabel": "密码:",
+			"confirmButton": "确认",
+			"cancelButton": "取消"
 		}
 	}
 }

--- a/src/public/ImportHandlers/Risu/Template/main.mjs
+++ b/src/public/ImportHandlers/Risu/Template/main.mjs
@@ -78,14 +78,14 @@ function buildCharInfo(charData) {
 				if (langCode !== defaultLocaleKey)  //避免覆盖已经由 `chardata.creator_notes` 设置的默认条目
 					info[langCode] = createInfoForLang(noteForLang)
 				else if (!info[defaultLocaleKey].description_markdown && noteForLang)
-				// 如果默认条目的描述为空（可能 chardata.creator_notes 为空），但多语言中有对应默认键的有效条目，则使用它
+					// 如果默认条目的描述为空（可能 chardata.creator_notes 为空），但多语言中有对应默认键的有效条目，则使用它
 					info[defaultLocaleKey] = createInfoForLang(noteForLang)
 
 			}
 
 
 	// 如果 Fount 强制要求 'en' 存在，且 '' 不是 'en' 的有效代理，可以在这里确保 'en' 条目
-	if (!info.en && info[''] && chardata.creator_notes === (chardata.extensions?.creator_notes_multilingual?.en || chardata.creator_notes) ) {
+	if (!info.en && info[''] && chardata.creator_notes === (chardata.extensions?.creator_notes_multilingual?.en || chardata.creator_notes)) {
 		// 如果 '' 的内容实际上是英文内容，并且没有显式的 'en'，可以考虑复制一份
 		// 但更好的做法是让Fount的locale匹配机制处理 '' 和 'en'
 	}

--- a/src/public/ImportHandlers/fount/main.mjs
+++ b/src/public/ImportHandlers/fount/main.mjs
@@ -22,13 +22,13 @@ async function moveWithMerge(src, dest) {
 	if (srcStat.isFile())
 		if (destStat.isFile())
 			await move(src, dest, { overwrite: true })
-		 else
+		else
 			throw new Error(`Cannot move file to directory: ${dest}`)
 	// Source is a directory
 	else if (srcStat.isDirectory())
 		if (destStat.isDirectory())
 			await mergeDirectories(src, dest)
-		 else
+		else
 			throw new Error(`Cannot move directory to file: ${dest}`)
 }
 
@@ -41,10 +41,10 @@ async function mergeDirectories(srcDir, destDir) {
 
 		if (srcStat.isFile())
 			await move(srcPath, destPath, { overwrite: true })
-		 else if (srcStat.isDirectory())
+		else if (srcStat.isDirectory())
 			if (!existsSync(destPath))
 				await move(srcPath, destPath)
-			 else
+			else
 				await mergeDirectories(srcPath, destPath)
 	}
 	await remove(srcDir)

--- a/src/public/shells/chat/main.mjs
+++ b/src/public/shells/chat/main.mjs
@@ -5,6 +5,8 @@ import { loadChat } from './src/server/chat.mjs'
 import { setEndpoints } from './src/server/endpoints.mjs'
 import { cleanFilesInterval } from './src/server/files.mjs'
 
+let loading_count = 0
+
 export default {
 	info: {
 		'': {
@@ -19,10 +21,13 @@ export default {
 		}
 	},
 	Load: (router) => {
+		loading_count++
 		setEndpoints(router)
 	},
 	Unload: () => {
-		clearInterval(cleanFilesInterval)
+		loading_count--
+		if (loading_count === 0)
+			clearInterval(cleanFilesInterval)
 	},
 
 	interfaces: {

--- a/src/public/shells/chat/src/server/chat.mjs
+++ b/src/public/shells/chat/src/server/chat.mjs
@@ -909,38 +909,23 @@ export async function getHeartbeatData(chatid, start) {
 }
 
 // Event Handlers
-events.on('userDeleted', async (payload) => {
+events.on('AfterUserDeleted', async (payload) => {
 	const { username, userId, userDirectoryPath } = payload // Destructure userDirectoryPath
-	console.log(`Chat: Handling userDeleted event for username: ${username}`)
-
 	// Clear from in-memory cache
 	const chatIdsToDeleteFromCache = []
-	for (const [chatId, data] of chatMetadatas.entries()) 
-		if (data.username === username) 
+	for (const [chatId, data] of chatMetadatas.entries())
+		if (data.username === username)
 			chatIdsToDeleteFromCache.push(chatId)
-		
-	
 	chatIdsToDeleteFromCache.forEach(chatId => chatMetadatas.delete(chatId))
-	console.log(`Chat: Cleared ${chatIdsToDeleteFromCache.length} chat entries from in-memory cache for user ${username}.`)
 })
 
-events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
-	console.log(`Chat: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
-
+events.on('AfterUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
 	// Update in-memory cache: chatMetadatas map
-	let updatedInCacheCount = 0
-	for (const [chatId, data] of chatMetadatas.entries()) 
+	for (const [chatId, data] of chatMetadatas.entries())
 		if (data.username === oldUsername) {
 			data.username = newUsername // Update username in the map's value
-			if (data.chatMetadata && data.chatMetadata.username === oldUsername) 
+			if (data.chatMetadata && data.chatMetadata.username === oldUsername)
 				data.chatMetadata.username = newUsername // Update username within the cached object itself
-			
-			updatedInCacheCount++
+			saveChat(chatId)
 		}
-	
-	if (updatedInCacheCount > 0) 
-		console.log(`Chat: Updated ${updatedInCacheCount} chat entries in in-memory cache from ${oldUsername} to ${newUsername}.`)
-	
-
-	console.log(`Chat: Finished processing userRenamed event for ${newUsername}.`)
 })

--- a/src/public/shells/chat/src/server/chat.mjs
+++ b/src/public/shells/chat/src/server/chat.mjs
@@ -4,6 +4,9 @@
 /** @typedef {import('../../../../../decl/basedefs.ts').locale_t} locale_t */
 
 import { getUserByUsername, getUserDictionary, getAllUserNames } from '../../../../../server/auth.mjs'
+import { events } from '../../../../../server/events.mjs';
+import fse from 'npm:fs-extra@^11.0.0';
+import path from 'node:path';
 import { LoadChar } from '../../../../../server/managers/char_manager.mjs'
 import { loadJsonFile, saveJsonFile } from '../../../../../scripts/json_loader.mjs'
 import { getPartInfo } from '../../../../../scripts/locale.mjs'
@@ -906,3 +909,98 @@ export async function getHeartbeatData(chatid, start) {
 		Messages: await Promise.all(chatMetadata.chatLog.slice(start).map(x => x.toData())),
 	}
 }
+
+// Event Handlers
+events.on('userDeleted', async (payload) => {
+      const { username, userId, userDirectoryPath } = payload; // Destructure userDirectoryPath
+      console.log(`Chat: Handling userDeleted event for username: ${username}`);
+
+      // Clear from in-memory cache
+      const chatIdsToDeleteFromCache = [];
+      for (const [chatId, data] of chatMetadatas.entries()) {
+        if (data.username === username) {
+          chatIdsToDeleteFromCache.push(chatId);
+        }
+      }
+      chatIdsToDeleteFromCache.forEach(chatId => chatMetadatas.delete(chatId));
+      console.log(`Chat: Cleared ${chatIdsToDeleteFromCache.length} chat entries from in-memory cache for user ${username}.`);
+
+      // Actual file deletion logic using userDirectoryPath
+      if (userDirectoryPath) {
+        const userChatShellPath = path.join(userDirectoryPath, 'shells', 'chat');
+        if (fse.existsSync(userChatShellPath)) {
+          try {
+            await fse.remove(userChatShellPath); // fse.remove is like rm -rf
+            console.log(`Chat: Successfully deleted chat shell directory for user ${username} at ${userChatShellPath}`);
+          } catch (err) {
+            console.error(`Chat: Error deleting chat shell directory ${userChatShellPath} for user ${username}:`, err);
+          }
+        } else {
+          console.log(`Chat: Chat shell directory for user ${username} not found at ${userChatShellPath}, nothing to delete.`);
+        }
+      } else {
+        console.warn(`Chat: userDirectoryPath not provided in userDeleted event for ${username}. Cannot delete chat files for this user.`);
+      }
+    });
+
+events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+  console.log(`Chat: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+  
+  // Update in-memory cache: chatMetadatas map
+  let updatedInCacheCount = 0;
+  for (const [chatId, data] of chatMetadatas.entries()) {
+    if (data.username === oldUsername) {
+      data.username = newUsername; // Update username in the map's value
+      if (data.chatMetadata && data.chatMetadata.username === oldUsername) {
+        data.chatMetadata.username = newUsername; // Update username within the cached object itself
+      }
+      updatedInCacheCount++;
+    }
+  }
+  if (updatedInCacheCount > 0) {
+    console.log(`Chat: Updated ${updatedInCacheCount} chat entries in in-memory cache from ${oldUsername} to ${newUsername}.`);
+  }
+
+  // Update username in persisted chat files.
+  // The user's main data directory has already been moved by auth.mjs.
+  // So, we use getUserDictionary(newUsername) to get the new base path.
+  try {
+    const newUserChatFilesPath = path.join(getUserDictionary(newUsername), 'shells', 'chat', 'chats');
+    if (fse.existsSync(newUserChatFilesPath)) {
+      const chatFiles = fse.readdirSync(newUserChatFilesPath).filter(file => file.endsWith('.json'));
+      let updatedFilesInSystemCount = 0;
+      for (const fileName of chatFiles) {
+        const chatId = fileName.replace('.json', '');
+        const filePath = path.join(newUserChatFilesPath, fileName);
+        try {
+          let chatFileContent = loadJsonFile(filePath); // loadJsonFile is already imported and used in chat.mjs
+          if (chatFileContent.username === oldUsername) {
+            chatFileContent.username = newUsername;
+            // TODO: Consider if any other fields within chatFileContent need deep updating
+            // (e.g., if oldUsername was stored in other properties).
+            // For now, only updating the top-level 'username' field.
+            saveJsonFile(filePath, chatFileContent); // saveJsonFile is already imported
+            updatedFilesInSystemCount++;
+            
+            // If this chat is in the live cache and was missed by the first loop (e.g. loaded after), update it.
+            const cachedChatData = chatMetadatas.get(chatId);
+            if (cachedChatData && cachedChatData.chatMetadata && cachedChatData.chatMetadata.username === oldUsername) {
+               cachedChatData.chatMetadata.username = newUsername;
+            }
+          }
+        } catch (error) {
+          console.error(`Chat: Error updating username in chat file ${fileName} for ${newUsername}:`, error);
+        }
+      }
+      if (updatedFilesInSystemCount > 0) {
+        console.log(`Chat: Updated ${updatedFilesInSystemCount} chat files for ${newUsername}.`);
+      }
+    } else {
+      console.log(`Chat: No chat directory found for ${newUsername} at ${newUserChatFilesPath}, no chat files to update.`);
+    }
+  } catch (error) {
+    // This might happen if getUserDictionary(newUsername) fails for some reason.
+    console.error(`Chat: Error accessing chat directory for ${newUsername}. Cannot update chat files. Error: ${error.message}`);
+  }
+  console.log(`Chat: Finished processing userRenamed event for ${newUsername}.`);
+});

--- a/src/public/shells/chat/src/server/chat.mjs
+++ b/src/public/shells/chat/src/server/chat.mjs
@@ -910,7 +910,7 @@ export async function getHeartbeatData(chatid, start) {
 
 // Event Handlers
 events.on('AfterUserDeleted', async (payload) => {
-	const { username, userId, userDirectoryPath } = payload // Destructure userDirectoryPath
+	const { username } = payload // Destructure userDirectoryPath
 	// Clear from in-memory cache
 	const chatIdsToDeleteFromCache = []
 	for (const [chatId, data] of chatMetadatas.entries())
@@ -919,7 +919,7 @@ events.on('AfterUserDeleted', async (payload) => {
 	chatIdsToDeleteFromCache.forEach(chatId => chatMetadatas.delete(chatId))
 })
 
-events.on('AfterUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+events.on('AfterUserRenamed', async ({ oldUsername, newUsername }) => {
 	// Update in-memory cache: chatMetadatas map
 	for (const [chatId, data] of chatMetadatas.entries())
 		if (data.username === oldUsername) {

--- a/src/public/shells/discordbot/src/server/bot.mjs
+++ b/src/public/shells/discordbot/src/server/bot.mjs
@@ -137,7 +137,7 @@ export function getBotList(username) {
 }
 
 // Event Handlers
-events.on('BeforeUserDeleted', async ({ username, userId }) => {
+events.on('BeforeUserDeleted', async ({ username }) => {
 	const runningBots = getRunningBotList(username)
 	for (const botname of runningBots)
 		try {
@@ -148,7 +148,7 @@ events.on('BeforeUserDeleted', async ({ username, userId }) => {
 		}
 })
 
-events.on('BeforeUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+events.on('BeforeUserRenamed', async ({ oldUsername, newUsername }) => {
 	const runningBotsOldUser = getRunningBotList(oldUsername)
 	for (const botname of runningBotsOldUser)
 		try {

--- a/src/public/shells/discordbot/src/server/bot.mjs
+++ b/src/public/shells/discordbot/src/server/bot.mjs
@@ -6,7 +6,7 @@ import { getAllUserNames } from '../../../../../server/auth.mjs'
 import { StartJob, EndJob } from '../../../../../server/jobs.mjs'
 import { geti18n } from '../../../../../scripts/i18n.mjs'
 import { createSimpleDiscordInterface } from './default_interface/main.mjs'
-import { events } from '../../../../../server/events.mjs';
+import { events } from '../../../../../server/events.mjs'
 /** @typedef {import('../../../../../decl/charAPI.ts').charAPI_t} charAPI_t */
 
 /**
@@ -138,64 +138,64 @@ export function getBotList(username) {
 
 // Event Handlers
 events.on('userDeleted', async ({ username, userId }) => {
-  console.log(`Discord Bot: Handling userDeleted event for username: ${username}`);
-  const runningBots = getRunningBotList(username);
-  for (const botname of runningBots) {
-    try {
-      await stopBot(username, botname);
-      console.log(`Discord Bot: Stopped bot ${botname} for deleted user ${username}`);
-    } catch (error) {
-      console.error(`Discord Bot: Error stopping bot ${botname} for deleted user ${username}:`, error);
-    }
-  }
+	console.log(`Discord Bot: Handling userDeleted event for username: ${username}`)
+	const runningBots = getRunningBotList(username)
+	for (const botname of runningBots) 
+		try {
+			await stopBot(username, botname)
+			console.log(`Discord Bot: Stopped bot ${botname} for deleted user ${username}`)
+		} catch (error) {
+			console.error(`Discord Bot: Error stopping bot ${botname} for deleted user ${username}:`, error)
+		}
+  
 
-  const userBotsData = getBotsData(username); 
-  if (userBotsData) {
-    for (const botname of Object.keys(userBotsData)) {
-      delete userBotsData[botname]; 
-    }
-    saveShellData(username, 'discordbot', 'bot_configs'); 
-  }
+	const userBotsData = getBotsData(username) 
+	if (userBotsData) {
+		for (const botname of Object.keys(userBotsData)) 
+			delete userBotsData[botname] 
+    
+		saveShellData(username, 'discordbot', 'bot_configs') 
+	}
 
-  const botCache = loadTempData(username, 'discordbot_cache');
-  for (const botname of Object.keys(botCache)) {
-    delete botCache[botname];
-  }
-  console.log(`Discord Bot: Cleaned up data for deleted user ${username}`);
-});
+	const botCache = loadTempData(username, 'discordbot_cache')
+	for (const botname of Object.keys(botCache)) 
+		delete botCache[botname]
+  
+	console.log(`Discord Bot: Cleaned up data for deleted user ${username}`)
+})
 
 events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
-  console.log(`Discord Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+	console.log(`Discord Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
 
-  const runningBotsOldUser = getRunningBotList(oldUsername);
-  for (const botname of runningBotsOldUser) {
-    try {
-      await stopBot(oldUsername, botname);
-      console.log(`Discord Bot: Stopped bot ${botname} for old username ${oldUsername}`);
-    } catch (error) {
-      console.error(`Discord Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error);
-    }
-  }
+	const runningBotsOldUser = getRunningBotList(oldUsername)
+	for (const botname of runningBotsOldUser) 
+		try {
+			await stopBot(oldUsername, botname)
+			console.log(`Discord Bot: Stopped bot ${botname} for old username ${oldUsername}`)
+		} catch (error) {
+			console.error(`Discord Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error)
+		}
+  
 
-  const oldUserBotsData = getBotsData(oldUsername);
-  if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
-    const dataToMove = JSON.parse(JSON.stringify(oldUserBotsData)); 
+	const oldUserBotsData = getBotsData(oldUsername)
+	if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
+		const dataToMove = JSON.parse(JSON.stringify(oldUserBotsData)) 
 
-    saveShellData(newUsername, 'discordbot', 'bot_configs', dataToMove);
+		saveShellData(newUsername, 'discordbot', 'bot_configs', dataToMove)
 
-    const currentOldUserBotsData = getBotsData(oldUsername); 
-    if (currentOldUserBotsData) {
-      for (const botname of Object.keys(currentOldUserBotsData)) {
-        delete currentOldUserBotsData[botname]; 
-      }
-      saveShellData(oldUsername, 'discordbot', 'bot_configs'); 
-    }
-    console.log(`Discord Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`);
-  }
+		const currentOldUserBotsData = getBotsData(oldUsername) 
+		if (currentOldUserBotsData) {
+			for (const botname of Object.keys(currentOldUserBotsData)) 
+				delete currentOldUserBotsData[botname] 
+      
+			saveShellData(oldUsername, 'discordbot', 'bot_configs') 
+		}
+		console.log(`Discord Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`)
+	}
 
-  const oldBotCache = loadTempData(oldUsername, 'discordbot_cache');
-  for (const botname of Object.keys(oldBotCache)) {
-    delete oldBotCache[botname];
-  }
-  console.log(`Discord Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`);
-});
+	const oldBotCache = loadTempData(oldUsername, 'discordbot_cache')
+	for (const botname of Object.keys(oldBotCache)) 
+		delete oldBotCache[botname]
+  
+	console.log(`Discord Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`)
+})

--- a/src/public/shells/discordbot/src/server/bot.mjs
+++ b/src/public/shells/discordbot/src/server/bot.mjs
@@ -137,65 +137,24 @@ export function getBotList(username) {
 }
 
 // Event Handlers
-events.on('userDeleted', async ({ username, userId }) => {
-	console.log(`Discord Bot: Handling userDeleted event for username: ${username}`)
+events.on('BeforeUserDeleted', async ({ username, userId }) => {
 	const runningBots = getRunningBotList(username)
-	for (const botname of runningBots) 
+	for (const botname of runningBots)
 		try {
 			await stopBot(username, botname)
 			console.log(`Discord Bot: Stopped bot ${botname} for deleted user ${username}`)
 		} catch (error) {
 			console.error(`Discord Bot: Error stopping bot ${botname} for deleted user ${username}:`, error)
 		}
-  
-
-	const userBotsData = getBotsData(username) 
-	if (userBotsData) {
-		for (const botname of Object.keys(userBotsData)) 
-			delete userBotsData[botname] 
-    
-		saveShellData(username, 'discordbot', 'bot_configs') 
-	}
-
-	const botCache = loadTempData(username, 'discordbot_cache')
-	for (const botname of Object.keys(botCache)) 
-		delete botCache[botname]
-  
-	console.log(`Discord Bot: Cleaned up data for deleted user ${username}`)
 })
 
-events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
-	console.log(`Discord Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
-
+events.on('BeforeUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
 	const runningBotsOldUser = getRunningBotList(oldUsername)
-	for (const botname of runningBotsOldUser) 
+	for (const botname of runningBotsOldUser)
 		try {
 			await stopBot(oldUsername, botname)
 			console.log(`Discord Bot: Stopped bot ${botname} for old username ${oldUsername}`)
 		} catch (error) {
 			console.error(`Discord Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error)
 		}
-  
-
-	const oldUserBotsData = getBotsData(oldUsername)
-	if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
-		const dataToMove = JSON.parse(JSON.stringify(oldUserBotsData)) 
-
-		saveShellData(newUsername, 'discordbot', 'bot_configs', dataToMove)
-
-		const currentOldUserBotsData = getBotsData(oldUsername) 
-		if (currentOldUserBotsData) {
-			for (const botname of Object.keys(currentOldUserBotsData)) 
-				delete currentOldUserBotsData[botname] 
-      
-			saveShellData(oldUsername, 'discordbot', 'bot_configs') 
-		}
-		console.log(`Discord Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`)
-	}
-
-	const oldBotCache = loadTempData(oldUsername, 'discordbot_cache')
-	for (const botname of Object.keys(oldBotCache)) 
-		delete oldBotCache[botname]
-  
-	console.log(`Discord Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`)
 })

--- a/src/public/shells/discordbot/src/server/bot.mjs
+++ b/src/public/shells/discordbot/src/server/bot.mjs
@@ -6,6 +6,7 @@ import { getAllUserNames } from '../../../../../server/auth.mjs'
 import { StartJob, EndJob } from '../../../../../server/jobs.mjs'
 import { geti18n } from '../../../../../scripts/i18n.mjs'
 import { createSimpleDiscordInterface } from './default_interface/main.mjs'
+import { events } from '../../../../../server/events.mjs';
 /** @typedef {import('../../../../../decl/charAPI.ts').charAPI_t} charAPI_t */
 
 /**
@@ -134,3 +135,67 @@ on_shutdown(async () => {
 export function getBotList(username) {
 	return Object.keys(getBotsData(username))
 }
+
+// Event Handlers
+events.on('userDeleted', async ({ username, userId }) => {
+  console.log(`Discord Bot: Handling userDeleted event for username: ${username}`);
+  const runningBots = getRunningBotList(username);
+  for (const botname of runningBots) {
+    try {
+      await stopBot(username, botname);
+      console.log(`Discord Bot: Stopped bot ${botname} for deleted user ${username}`);
+    } catch (error) {
+      console.error(`Discord Bot: Error stopping bot ${botname} for deleted user ${username}:`, error);
+    }
+  }
+
+  const userBotsData = getBotsData(username); 
+  if (userBotsData) {
+    for (const botname of Object.keys(userBotsData)) {
+      delete userBotsData[botname]; 
+    }
+    saveShellData(username, 'discordbot', 'bot_configs'); 
+  }
+
+  const botCache = loadTempData(username, 'discordbot_cache');
+  for (const botname of Object.keys(botCache)) {
+    delete botCache[botname];
+  }
+  console.log(`Discord Bot: Cleaned up data for deleted user ${username}`);
+});
+
+events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+  console.log(`Discord Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+
+  const runningBotsOldUser = getRunningBotList(oldUsername);
+  for (const botname of runningBotsOldUser) {
+    try {
+      await stopBot(oldUsername, botname);
+      console.log(`Discord Bot: Stopped bot ${botname} for old username ${oldUsername}`);
+    } catch (error) {
+      console.error(`Discord Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error);
+    }
+  }
+
+  const oldUserBotsData = getBotsData(oldUsername);
+  if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
+    const dataToMove = JSON.parse(JSON.stringify(oldUserBotsData)); 
+
+    saveShellData(newUsername, 'discordbot', 'bot_configs', dataToMove);
+
+    const currentOldUserBotsData = getBotsData(oldUsername); 
+    if (currentOldUserBotsData) {
+      for (const botname of Object.keys(currentOldUserBotsData)) {
+        delete currentOldUserBotsData[botname]; 
+      }
+      saveShellData(oldUsername, 'discordbot', 'bot_configs'); 
+    }
+    console.log(`Discord Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`);
+  }
+
+  const oldBotCache = loadTempData(oldUsername, 'discordbot_cache');
+  for (const botname of Object.keys(oldBotCache)) {
+    delete oldBotCache[botname];
+  }
+  console.log(`Discord Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`);
+});

--- a/src/public/shells/telegrambot/src/server/bot.mjs
+++ b/src/public/shells/telegrambot/src/server/bot.mjs
@@ -192,66 +192,24 @@ export function getBotList(username) {
 }
 
 // Event Handlers
-events.on('userDeleted', async ({ username, userId }) => {
-	console.log(`Telegram Bot: Handling userDeleted event for username: ${username}`)
+events.on('BeforeUserDeleted', async ({ username, userId }) => {
 	const runningBots = getRunningBotList(username)
-	for (const botname of runningBots) 
+	for (const botname of runningBots)
 		try {
 			await stopBot(username, botname)
 			console.log(`Telegram Bot: Stopped bot ${botname} for deleted user ${username}`)
 		} catch (error) {
 			console.error(`Telegram Bot: Error stopping bot ${botname} for deleted user ${username}:`, error)
 		}
-  
-
-	// Delete bot configurations
-	// Assuming saveShellData with undefined or null data effectively deletes it,
-	// or we need a dedicated function like deleteShellData(username, shellName, dataName)
-	// For now, saving an empty object. If there's a specific delete function, that would be better.
-	saveShellData(username, 'telegrambot', 'bot_configs', {}) // Clears all bot configs for the user
-
-	// Clear temp data (cache)
-	const botCache = loadTempData(username, 'telegrambot_cache')
-	for (const botname of Object.keys(botCache)) 
-		delete botCache[botname]
-  
-	// If loadTempData returns a mutable object that needs saving, uncomment next line
-	// saveTempData(username, 'telegrambot_cache', botCache); // Or a dedicated function to clear temp data for a user for this shell
-
-	console.log(`Telegram Bot: Cleaned up data for deleted user ${username}`)
 })
 
-events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
-	console.log(`Telegram Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
-
-	// Stop all bots running under the old username
+events.on('BeforeUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
 	const runningBotsOldUser = getRunningBotList(oldUsername)
-	for (const botname of runningBotsOldUser) 
+	for (const botname of runningBotsOldUser)
 		try {
 			await stopBot(oldUsername, botname)
 			console.log(`Telegram Bot: Stopped bot ${botname} for old username ${oldUsername}`)
 		} catch (error) {
 			console.error(`Telegram Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error)
 		}
-  
-
-	// Move bot configurations
-	const oldUserBotsData = getBotsData(oldUsername)
-	if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
-		saveShellData(newUsername, 'telegrambot', 'bot_configs', oldUserBotsData)
-		saveShellData(oldUsername, 'telegrambot', 'bot_configs', {}) // Clear old user's bot configs
-		console.log(`Telegram Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`)
-	}
-
-	// Clear temp data (cache) for the old username
-	const oldBotCache = loadTempData(oldUsername, 'telegrambot_cache')
-	for (const botname of Object.keys(oldBotCache)) 
-		delete oldBotCache[botname]
-  
-	// If loadTempData needs saving, uncomment:
-	// saveTempData(oldUsername, 'telegrambot_cache', oldBotCache);
-
-	// The user will need to restart their bots under the new username.
-	// Active migration of running bot instances is complex and error-prone.
-	console.log(`Telegram Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`)
 })

--- a/src/public/shells/telegrambot/src/server/bot.mjs
+++ b/src/public/shells/telegrambot/src/server/bot.mjs
@@ -192,7 +192,7 @@ export function getBotList(username) {
 }
 
 // Event Handlers
-events.on('BeforeUserDeleted', async ({ username, userId }) => {
+events.on('BeforeUserDeleted', async ({ username }) => {
 	const runningBots = getRunningBotList(username)
 	for (const botname of runningBots)
 		try {
@@ -203,7 +203,7 @@ events.on('BeforeUserDeleted', async ({ username, userId }) => {
 		}
 })
 
-events.on('BeforeUserRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+events.on('BeforeUserRenamed', async ({ oldUsername, newUsername }) => {
 	const runningBotsOldUser = getRunningBotList(oldUsername)
 	for (const botname of runningBotsOldUser)
 		try {

--- a/src/public/shells/telegrambot/src/server/bot.mjs
+++ b/src/public/shells/telegrambot/src/server/bot.mjs
@@ -6,7 +6,7 @@ import { getAllUserNames } from '../../../../../server/auth.mjs' // 获取所有
 import { StartJob, EndJob } from '../../../../../server/jobs.mjs' // Fount 的任务管理
 import { geti18n } from '../../../../../scripts/i18n.mjs' // 国际化
 import { createSimpleTelegramInterface } from './default_interface/main.mjs' // 默认的 Telegram 角色接口
-import { events } from '../../../../../server/events.mjs';
+import { events } from '../../../../../server/events.mjs'
 
 /** @typedef {import('../../../../../decl/charAPI.ts').charAPI_t} charAPI_t */
 
@@ -193,65 +193,65 @@ export function getBotList(username) {
 
 // Event Handlers
 events.on('userDeleted', async ({ username, userId }) => {
-  console.log(`Telegram Bot: Handling userDeleted event for username: ${username}`);
-  const runningBots = getRunningBotList(username);
-  for (const botname of runningBots) {
-    try {
-      await stopBot(username, botname);
-      console.log(`Telegram Bot: Stopped bot ${botname} for deleted user ${username}`);
-    } catch (error) {
-      console.error(`Telegram Bot: Error stopping bot ${botname} for deleted user ${username}:`, error);
-    }
-  }
+	console.log(`Telegram Bot: Handling userDeleted event for username: ${username}`)
+	const runningBots = getRunningBotList(username)
+	for (const botname of runningBots) 
+		try {
+			await stopBot(username, botname)
+			console.log(`Telegram Bot: Stopped bot ${botname} for deleted user ${username}`)
+		} catch (error) {
+			console.error(`Telegram Bot: Error stopping bot ${botname} for deleted user ${username}:`, error)
+		}
+  
 
-  // Delete bot configurations
-  // Assuming saveShellData with undefined or null data effectively deletes it,
-  // or we need a dedicated function like deleteShellData(username, shellName, dataName)
-  // For now, saving an empty object. If there's a specific delete function, that would be better.
-  saveShellData(username, 'telegrambot', 'bot_configs', {}); // Clears all bot configs for the user
+	// Delete bot configurations
+	// Assuming saveShellData with undefined or null data effectively deletes it,
+	// or we need a dedicated function like deleteShellData(username, shellName, dataName)
+	// For now, saving an empty object. If there's a specific delete function, that would be better.
+	saveShellData(username, 'telegrambot', 'bot_configs', {}) // Clears all bot configs for the user
 
-  // Clear temp data (cache)
-  const botCache = loadTempData(username, 'telegrambot_cache');
-  for (const botname of Object.keys(botCache)) {
-    delete botCache[botname];
-  }
-  // If loadTempData returns a mutable object that needs saving, uncomment next line
-  // saveTempData(username, 'telegrambot_cache', botCache); // Or a dedicated function to clear temp data for a user for this shell
+	// Clear temp data (cache)
+	const botCache = loadTempData(username, 'telegrambot_cache')
+	for (const botname of Object.keys(botCache)) 
+		delete botCache[botname]
+  
+	// If loadTempData returns a mutable object that needs saving, uncomment next line
+	// saveTempData(username, 'telegrambot_cache', botCache); // Or a dedicated function to clear temp data for a user for this shell
 
-  console.log(`Telegram Bot: Cleaned up data for deleted user ${username}`);
-});
+	console.log(`Telegram Bot: Cleaned up data for deleted user ${username}`)
+})
 
 events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
-  console.log(`Telegram Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+	console.log(`Telegram Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
 
-  // Stop all bots running under the old username
-  const runningBotsOldUser = getRunningBotList(oldUsername);
-  for (const botname of runningBotsOldUser) {
-    try {
-      await stopBot(oldUsername, botname);
-      console.log(`Telegram Bot: Stopped bot ${botname} for old username ${oldUsername}`);
-    } catch (error) {
-      console.error(`Telegram Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error);
-    }
-  }
+	// Stop all bots running under the old username
+	const runningBotsOldUser = getRunningBotList(oldUsername)
+	for (const botname of runningBotsOldUser) 
+		try {
+			await stopBot(oldUsername, botname)
+			console.log(`Telegram Bot: Stopped bot ${botname} for old username ${oldUsername}`)
+		} catch (error) {
+			console.error(`Telegram Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error)
+		}
+  
 
-  // Move bot configurations
-  const oldUserBotsData = getBotsData(oldUsername);
-  if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
-    saveShellData(newUsername, 'telegrambot', 'bot_configs', oldUserBotsData);
-    saveShellData(oldUsername, 'telegrambot', 'bot_configs', {}); // Clear old user's bot configs
-    console.log(`Telegram Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`);
-  }
+	// Move bot configurations
+	const oldUserBotsData = getBotsData(oldUsername)
+	if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
+		saveShellData(newUsername, 'telegrambot', 'bot_configs', oldUserBotsData)
+		saveShellData(oldUsername, 'telegrambot', 'bot_configs', {}) // Clear old user's bot configs
+		console.log(`Telegram Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`)
+	}
 
-  // Clear temp data (cache) for the old username
-  const oldBotCache = loadTempData(oldUsername, 'telegrambot_cache');
-  for (const botname of Object.keys(oldBotCache)) {
-    delete oldBotCache[botname];
-  }
-  // If loadTempData needs saving, uncomment:
-  // saveTempData(oldUsername, 'telegrambot_cache', oldBotCache);
+	// Clear temp data (cache) for the old username
+	const oldBotCache = loadTempData(oldUsername, 'telegrambot_cache')
+	for (const botname of Object.keys(oldBotCache)) 
+		delete oldBotCache[botname]
+  
+	// If loadTempData needs saving, uncomment:
+	// saveTempData(oldUsername, 'telegrambot_cache', oldBotCache);
 
-  // The user will need to restart their bots under the new username.
-  // Active migration of running bot instances is complex and error-prone.
-  console.log(`Telegram Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`);
-});
+	// The user will need to restart their bots under the new username.
+	// Active migration of running bot instances is complex and error-prone.
+	console.log(`Telegram Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`)
+})

--- a/src/public/shells/telegrambot/src/server/bot.mjs
+++ b/src/public/shells/telegrambot/src/server/bot.mjs
@@ -6,6 +6,7 @@ import { getAllUserNames } from '../../../../../server/auth.mjs' // 获取所有
 import { StartJob, EndJob } from '../../../../../server/jobs.mjs' // Fount 的任务管理
 import { geti18n } from '../../../../../scripts/i18n.mjs' // 国际化
 import { createSimpleTelegramInterface } from './default_interface/main.mjs' // 默认的 Telegram 角色接口
+import { events } from '../../../../../server/events.mjs';
 
 /** @typedef {import('../../../../../decl/charAPI.ts').charAPI_t} charAPI_t */
 
@@ -189,3 +190,68 @@ on_shutdown(async () => {
 export function getBotList(username) {
 	return Object.keys(getBotsData(username))
 }
+
+// Event Handlers
+events.on('userDeleted', async ({ username, userId }) => {
+  console.log(`Telegram Bot: Handling userDeleted event for username: ${username}`);
+  const runningBots = getRunningBotList(username);
+  for (const botname of runningBots) {
+    try {
+      await stopBot(username, botname);
+      console.log(`Telegram Bot: Stopped bot ${botname} for deleted user ${username}`);
+    } catch (error) {
+      console.error(`Telegram Bot: Error stopping bot ${botname} for deleted user ${username}:`, error);
+    }
+  }
+
+  // Delete bot configurations
+  // Assuming saveShellData with undefined or null data effectively deletes it,
+  // or we need a dedicated function like deleteShellData(username, shellName, dataName)
+  // For now, saving an empty object. If there's a specific delete function, that would be better.
+  saveShellData(username, 'telegrambot', 'bot_configs', {}); // Clears all bot configs for the user
+
+  // Clear temp data (cache)
+  const botCache = loadTempData(username, 'telegrambot_cache');
+  for (const botname of Object.keys(botCache)) {
+    delete botCache[botname];
+  }
+  // If loadTempData returns a mutable object that needs saving, uncomment next line
+  // saveTempData(username, 'telegrambot_cache', botCache); // Or a dedicated function to clear temp data for a user for this shell
+
+  console.log(`Telegram Bot: Cleaned up data for deleted user ${username}`);
+});
+
+events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+  console.log(`Telegram Bot: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+
+  // Stop all bots running under the old username
+  const runningBotsOldUser = getRunningBotList(oldUsername);
+  for (const botname of runningBotsOldUser) {
+    try {
+      await stopBot(oldUsername, botname);
+      console.log(`Telegram Bot: Stopped bot ${botname} for old username ${oldUsername}`);
+    } catch (error) {
+      console.error(`Telegram Bot: Error stopping bot ${botname} for old username ${oldUsername}:`, error);
+    }
+  }
+
+  // Move bot configurations
+  const oldUserBotsData = getBotsData(oldUsername);
+  if (oldUserBotsData && Object.keys(oldUserBotsData).length > 0) {
+    saveShellData(newUsername, 'telegrambot', 'bot_configs', oldUserBotsData);
+    saveShellData(oldUsername, 'telegrambot', 'bot_configs', {}); // Clear old user's bot configs
+    console.log(`Telegram Bot: Migrated bot configurations from ${oldUsername} to ${newUsername}`);
+  }
+
+  // Clear temp data (cache) for the old username
+  const oldBotCache = loadTempData(oldUsername, 'telegrambot_cache');
+  for (const botname of Object.keys(oldBotCache)) {
+    delete oldBotCache[botname];
+  }
+  // If loadTempData needs saving, uncomment:
+  // saveTempData(oldUsername, 'telegrambot_cache', oldBotCache);
+
+  // The user will need to restart their bots under the new username.
+  // Active migration of running bot instances is complex and error-prone.
+  console.log(`Telegram Bot: Cleaned up data for old username ${oldUsername}. User ${newUsername} may need to restart bots.`);
+});

--- a/src/public/shells/user_settings/home_registry.json
+++ b/src/public/shells/user_settings/home_registry.json
@@ -1,0 +1,20 @@
+{
+  "home_function_buttons": [
+    {
+      "info": {
+        "en-UK": {
+          "title": "User Settings",
+          "description": "Manage user accounts, settings, passwords, and devices."
+        },
+        "zh-CN": {
+          "title": "用户设置",
+          "description": "管理用户账户、设置、密码和设备。"
+        }
+      },
+      "level": 0,
+      "url": "/shells/user_settings",
+      "button": "<img src=\"/public/imgs/icon.svg\" class=\"text-icon\"/>",
+      "permissions": ["administrator"]
+    }
+  ]
+}

--- a/src/public/shells/user_settings/home_registry.json
+++ b/src/public/shells/user_settings/home_registry.json
@@ -1,20 +1,17 @@
 {
-  "home_function_buttons": [
-    {
-      "info": {
-        "en-UK": {
-          "title": "User Settings",
-          "description": "Manage user accounts, settings, passwords, and devices."
-        },
-        "zh-CN": {
-          "title": "用户设置",
-          "description": "管理用户账户、设置、密码和设备。"
-        }
-      },
-      "level": 0,
-      "url": "/shells/user_settings",
-      "button": "<img src=\"/public/imgs/icon.svg\" class=\"text-icon\"/>",
-      "permissions": ["administrator"]
-    }
-  ]
+	"home_function_buttons": [
+		{
+			"info": {
+				"en-UK": {
+					"title": "User Settings"
+				},
+				"zh-CN": {
+					"title": "用户设置"
+				}
+			},
+			"level": 100,
+			"url": "/shells/user_settings",
+			"button": "<img src=\"https://api.iconify.design/line-md/account.svg\" class=\"text-icon\"/>"
+		}
+	]
 }

--- a/src/public/shells/user_settings/index.css
+++ b/src/public/shells/user_settings/index.css
@@ -1,0 +1,9 @@
+/* 主要依赖 DaisyUI 和 Tailwind，此处可添加特定微调 */
+body {
+	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}
+
+/* 确保图标在按钮中垂直居中 */
+.btn img.text-icon, .btn img.w-4, .btn img.w-5 {
+	vertical-align: middle;
+}

--- a/src/public/shells/user_settings/index.css
+++ b/src/public/shells/user_settings/index.css
@@ -1,9 +1,0 @@
-/* 主要依赖 DaisyUI 和 Tailwind，此处可添加特定微调 */
-body {
-	font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-}
-
-/* 确保图标在按钮中垂直居中 */
-.btn img.text-icon, .btn img.w-4, .btn img.w-5 {
-	vertical-align: middle;
-}

--- a/src/public/shells/user_settings/index.html
+++ b/src/public/shells/user_settings/index.html
@@ -144,4 +144,5 @@
 
 	<script type="module" src="./index.mjs"></script>
 </body>
+
 </html>

--- a/src/public/shells/user_settings/index.html
+++ b/src/public/shells/user_settings/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="darkreader-lock">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title data-i18n="userSettings.title">User Settings</title>
+  
+  <link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" />
+  <link href="/base.css" rel="stylesheet" type="text/css" />
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser"></script>
+  <script type="module" src="/base.mjs"></script>
+  <link rel="stylesheet" href="./index.css" type="text/css" />
+</head>
+<body>
+  <h1 data-i18n="userSettings.header">User Settings</h1>
+
+  <div class="container">
+    <h2 data-i18n="userSettings.changePassword.title">Change Password</h2>
+    <form id="changePasswordForm">
+      <label for="usernameChangePassword" data-i18n="userSettings.common.usernameLabel">Username:</label>
+      <input type="text" id="usernameChangePassword" name="usernameChangePassword" required>
+      <label for="currentPassword" data-i18n="userSettings.changePassword.currentPasswordLabel">Current Password:</label>
+      <input type="password" id="currentPassword" name="currentPassword" required>
+      <label for="newPassword" data-i18n="userSettings.changePassword.newPasswordLabel">New Password:</label>
+      <input type="password" id="newPassword" name="newPassword" required>
+      <button type="submit" data-i18n="userSettings.changePassword.submitButton">Change Password</button>
+    </form>
+  </div>
+
+  <div class="container">
+    <h2 data-i18n="userSettings.userDevices.title">User Devices</h2>
+    <form id="viewDevicesForm">
+      <label for="usernameViewDevices" data-i18n="userSettings.common.usernameLabel">Username:</label>
+      <input type="text" id="usernameViewDevices" name="usernameViewDevices" required>
+      <button type="submit" data-i18n="userSettings.userDevices.viewButton">View Devices</button>
+    </form>
+    <ul id="deviceList"></ul>
+  </div>
+
+  <div class="container">
+    <h2 data-i18n="userSettings.renameUser.title">Rename Username</h2>
+    <form id="renameUserForm">
+      <label for="currentUsernameRename" data-i18n="userSettings.renameUser.currentUsernameLabel">Current Username:</label>
+      <input type="text" id="currentUsernameRename" name="currentUsernameRename" required>
+      <label for="newUsernameRename" data-i18n="userSettings.renameUser.newUsernameLabel">New Username:</label>
+      <input type="text" id="newUsernameRename" name="newUsernameRename" required>
+      <button type="submit" data-i18n="userSettings.renameUser.submitButton">Rename User</button>
+    </form>
+  </div>
+
+  <div class="container">
+    <h2 data-i18n="userSettings.deleteAccount.title">Delete Account</h2>
+    <form id="deleteAccountForm">
+      <label for="usernameDelete" data-i18n="userSettings.common.usernameLabel">Username:</label>
+      <input type="text" id="usernameDelete" name="usernameDelete" required>
+      <label for="passwordDelete" data-i18n="userSettings.common.passwordLabel">Password:</label>
+      <input type="password" id="passwordDelete" name="passwordDelete" required>
+      <button type="submit" class="danger" data-i18n="userSettings.deleteAccount.submitButton">Delete Account</button>
+    </form>
+  </div>
+
+  <script src="index.mjs" type="module"></script>
+</body>
+</html>

--- a/src/public/shells/user_settings/index.html
+++ b/src/public/shells/user_settings/index.html
@@ -1,65 +1,147 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="dark">
+
 <head>
-  <meta charset="UTF-8">
-  <meta name="darkreader-lock">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title data-i18n="userSettings.title">User Settings</title>
-  
-  <link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" />
-  <link href="/base.css" rel="stylesheet" type="text/css" />
-  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser"></script>
-  <script type="module" src="/base.mjs"></script>
-  <link rel="stylesheet" href="./index.css" type="text/css" />
+	<meta charset="UTF-8">
+	<meta name="darkreader-lock">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title data-i18n="userSettings.title"></title>
+	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" />
+	<link href="/base.css" rel="stylesheet" type="text/css" />
+	<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser"></script>
+	<script type="module" src="/base.mjs"></script>
+	<link rel="stylesheet" href="./index.css" type="text/css" />
 </head>
+
 <body>
-  <h1 data-i18n="userSettings.header">User Settings</h1>
+	<div class="container mx-auto p-4">
+		<header class="mb-8">
+			<h1 class="text-3xl font-bold" data-i18n="userSettings.PageTitle"></h1>
+		</header>
 
-  <div class="container">
-    <h2 data-i18n="userSettings.changePassword.title">Change Password</h2>
-    <form id="changePasswordForm">
-      <label for="usernameChangePassword" data-i18n="userSettings.common.usernameLabel">Username:</label>
-      <input type="text" id="usernameChangePassword" name="usernameChangePassword" required>
-      <label for="currentPassword" data-i18n="userSettings.changePassword.currentPasswordLabel">Current Password:</label>
-      <input type="password" id="currentPassword" name="currentPassword" required>
-      <label for="newPassword" data-i18n="userSettings.changePassword.newPasswordLabel">New Password:</label>
-      <input type="password" id="newPassword" name="newPassword" required>
-      <button type="submit" data-i18n="userSettings.changePassword.submitButton">Change Password</button>
-    </form>
-  </div>
+		<main class="space-y-8">
+			<!-- 用户信息 -->
+			<section class="card bg-base-200 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title" data-i18n="userSettings.userInfo.title"></h2>
+					<div class="space-y-2">
+						<p><strong data-i18n="userSettings.userInfo.usernameLabel"></strong> <span id="userInfoUsername" class="font-mono"></span></p>
+						<p><strong data-i18n="userSettings.userInfo.creationDateLabel"></strong> <span id="userInfoCreationDate"></span></p>
+						<p><strong data-i18n="userSettings.userInfo.folderSizeLabel"></strong> <span id="userInfoFolderSize"></span></p>
+						<div class="flex items-center flex-wrap">
+							<strong data-i18n="userSettings.userInfo.folderPathLabel" class="mr-2"></strong>
+							<code id="userInfoFolderPath" class="p-1 bg-base-300 rounded text-sm break-all flex-grow min-w-[200px]"></code>
+							<button id="copyFolderPathBtn" class="btn btn-sm btn-ghost ml-2" data-i18n-title="userSettings.userInfo.copyPathBtnTitle">
+								<img src="https://api.iconify.design/material-symbols/content-copy-outline.svg" class="w-4 h-4" data-i18n-alt="userSettings.userInfo.copyPathBtnTitle" />
+							</button>
+						</div>
+					</div>
+				</div>
+			</section>
 
-  <div class="container">
-    <h2 data-i18n="userSettings.userDevices.title">User Devices</h2>
-    <form id="viewDevicesForm">
-      <label for="usernameViewDevices" data-i18n="userSettings.common.usernameLabel">Username:</label>
-      <input type="text" id="usernameViewDevices" name="usernameViewDevices" required>
-      <button type="submit" data-i18n="userSettings.userDevices.viewButton">View Devices</button>
-    </form>
-    <ul id="deviceList"></ul>
-  </div>
+			<div class="grid md:grid-cols-2 gap-8">
+				<!-- 修改密码 -->
+				<section class="card bg-base-200 shadow-xl">
+					<div class="card-body">
+						<h2 class="card-title" data-i18n="userSettings.changePassword.title"></h2>
+						<form id="changePasswordForm" class="space-y-4">
+							<div class="form-control">
+								<label class="label"><span class="label-text" data-i18n="userSettings.changePassword.currentPasswordLabel"></span></label>
+								<input type="password" id="currentPassword" name="currentPassword" class="input input-bordered" required autocomplete="current-password" />
+							</div>
+							<div class="form-control">
+								<label class="label"><span class="label-text" data-i18n="userSettings.changePassword.newPasswordLabel"></span></label>
+								<input type="password" id="newPassword" name="newPassword" class="input input-bordered" required autocomplete="new-password" />
+							</div>
+							<div class="form-control">
+								<label class="label"><span class="label-text" data-i18n="userSettings.changePassword.confirmNewPasswordLabel"></span></label>
+								<input type="password" id="confirmNewPassword" name="confirmNewPassword" class="input input-bordered" required autocomplete="new-password" />
+							</div>
+							<div class="card-actions justify-end">
+								<button type="submit" class="btn btn-primary" data-i18n="userSettings.changePassword.submitButton"></button>
+							</div>
+						</form>
+					</div>
+				</section>
 
-  <div class="container">
-    <h2 data-i18n="userSettings.renameUser.title">Rename Username</h2>
-    <form id="renameUserForm">
-      <label for="currentUsernameRename" data-i18n="userSettings.renameUser.currentUsernameLabel">Current Username:</label>
-      <input type="text" id="currentUsernameRename" name="currentUsernameRename" required>
-      <label for="newUsernameRename" data-i18n="userSettings.renameUser.newUsernameLabel">New Username:</label>
-      <input type="text" id="newUsernameRename" name="newUsernameRename" required>
-      <button type="submit" data-i18n="userSettings.renameUser.submitButton">Rename User</button>
-    </form>
-  </div>
+				<!-- 重命名用户 -->
+				<section class="card bg-base-200 shadow-xl">
+					<div class="card-body">
+						<h2 class="card-title" data-i18n="userSettings.renameUser.title"></h2>
+						<form id="renameUserForm" class="space-y-4">
+							<div class="form-control">
+								<label class="label"><span class="label-text" data-i18n="userSettings.renameUser.newUsernameLabel"></span></label>
+								<input type="text" id="newUsernameRename" name="newUsernameRename" class="input input-bordered" required />
+							</div>
+							<div class="card-actions justify-end">
+								<button type="submit" class="btn btn-warning" data-i18n="userSettings.renameUser.submitButton"></button>
+							</div>
+						</form>
+					</div>
+				</section>
+			</div>
 
-  <div class="container">
-    <h2 data-i18n="userSettings.deleteAccount.title">Delete Account</h2>
-    <form id="deleteAccountForm">
-      <label for="usernameDelete" data-i18n="userSettings.common.usernameLabel">Username:</label>
-      <input type="text" id="usernameDelete" name="usernameDelete" required>
-      <label for="passwordDelete" data-i18n="userSettings.common.passwordLabel">Password:</label>
-      <input type="password" id="passwordDelete" name="passwordDelete" required>
-      <button type="submit" class="danger" data-i18n="userSettings.deleteAccount.submitButton">Delete Account</button>
-    </form>
-  </div>
+			<!-- 用户设备/会话 -->
+			<section class="card bg-base-200 shadow-xl">
+				<div class="card-body">
+					<div class="flex justify-between items-center mb-4">
+						<h2 class="card-title" data-i18n="userSettings.userDevices.title"></h2>
+						<button id="refreshDevicesBtn" class="btn btn-sm btn-ghost" data-i18n-title="userSettings.userDevices.refreshButtonTitle">
+							<img src="https://api.iconify.design/mdi/refresh.svg" class="w-5 h-5" data-i18n-alt="userSettings.userDevices.refreshButtonTitle" />
+						</button>
+					</div>
+					<div id="deviceListContainer" class="max-h-96 overflow-y-auto">
+						<p id="noDevicesText" class="text-center hidden py-4" data-i18n="userSettings.userDevices.noDevicesFound"></p>
+						<div id="deviceList" class="space-y-3"></div>
+					</div>
+				</div>
+			</section>
 
-  <script src="index.mjs" type="module"></script>
+			<!-- 登出 -->
+			<section class="card bg-base-200 shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title" data-i18n="userSettings.logout.title"></h2>
+					<p data-i18n="userSettings.logout.description"></p>
+					<div class="card-actions justify-end">
+						<button id="logoutBtn" class="btn btn-accent" data-i18n="userSettings.logout.buttonText"></button>
+					</div>
+				</div>
+			</section>
+
+			<!-- 删除账户 -->
+			<section class="card bg-error text-error-content shadow-xl">
+				<div class="card-body">
+					<h2 class="card-title" data-i18n="userSettings.deleteAccount.title"></h2>
+					<p data-i18n="userSettings.deleteAccount.warning"></p>
+					<div class="card-actions justify-end">
+						<button id="deleteAccountBtn" class="btn btn-outline" data-i18n="userSettings.deleteAccount.submitButton"></button>
+					</div>
+				</div>
+			</section>
+		</main>
+	</div>
+
+	<!-- 密码确认模态框 -->
+	<dialog id="passwordConfirmationModal" class="modal">
+		<div class="modal-box">
+			<form method="dialog"> <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button></form>
+			<h3 class="font-bold text-lg" data-i18n="userSettings.passwordConfirm.title"></h3>
+			<p class="py-4" data-i18n="userSettings.passwordConfirm.message"></p>
+			<div class="form-control">
+				<label class="label"><span class="label-text" data-i18n="userSettings.passwordConfirm.passwordLabel"></span></label>
+				<input type="password" id="confirmationPassword" class="input input-bordered w-full" autocomplete="current-password" />
+			</div>
+			<div class="modal-action">
+				<button id="confirmPasswordBtn" class="btn btn-primary" data-i18n="userSettings.passwordConfirm.confirmButton"></button>
+				<button id="cancelPasswordBtn" class="btn" data-i18n="userSettings.passwordConfirm.cancelButton"></button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop"><button>close</button></form>
+	</dialog>
+
+	<!-- 提示消息容器 -->
+	<div id="alertContainer" class="toast toast-bottom toast-end z-[100]"></div>
+
+	<script type="module" src="./index.mjs"></script>
 </body>
 </html>

--- a/src/public/shells/user_settings/index.mjs
+++ b/src/public/shells/user_settings/index.mjs
@@ -69,7 +69,7 @@ el.passwordConfirmationModal.addEventListener('close', () => {
 async function loadUserInfo() {
 	try {
 		const stats = await api.getUserStats()
-		if (!stats.success) throw new Error(stats.message || geti18n('userSettings.apiError', {message: 'Failed to load user info'}))
+		if (!stats.success) throw new Error(stats.message || geti18n('userSettings.apiError', { message: 'Failed to load user info' }))
 
 		el.userInfoUsername.textContent = stats.username
 		el.userInfoCreationDate.textContent = new Date(stats.creationDate).toLocaleDateString()
@@ -84,9 +84,9 @@ el.copyFolderPathBtn.addEventListener('click', async () => {
 	try {
 		await navigator.clipboard.writeText(el.userInfoFolderPath.textContent)
 		showAlert('userSettings.userInfo.copiedAlert', 'success')
-	} catch(err) {
+	} catch (err) {
 		console.error('Failed to copy path: ', err)
-		showAlert('userSettings.generalError', 'error', 5000, { message: 'Failed to copy path.'})
+		showAlert('userSettings.generalError', 'error', 5000, { message: 'Failed to copy path.' })
 	}
 })
 
@@ -102,7 +102,7 @@ el.changePasswordForm.addEventListener('submit', async (event) => {
 
 	try {
 		const result = await api.changePassword(currentPassword, newPassword)
-		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Password change failed'}))
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', { message: 'Password change failed' }))
 
 		showAlert('userSettings.changePassword.success', 'success')
 		form.reset()
@@ -122,7 +122,7 @@ el.renameUserForm.addEventListener('submit', async (event) => {
 	try {
 		const password = await requestPasswordConfirmation()
 		const result = await api.renameUser(newUsername, password)
-		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Rename user failed'}))
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', { message: 'Rename user failed' }))
 
 		showAlert('userSettings.renameUser.success', 'success', 5000, { newUsername })
 		form.reset()
@@ -139,7 +139,7 @@ async function loadAndDisplayDevices() {
 
 	try {
 		const result = await api.getDevices()
-		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Failed to load devices'}))
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', { message: 'Failed to load devices' }))
 
 		el.deviceList.innerHTML = ''
 		if (result.devices.length === 0) {
@@ -189,7 +189,7 @@ async function loadAndDisplayDevices() {
 					try {
 						const password = await requestPasswordConfirmation()
 						const revokeResult = await api.revokeDevice(device.jti, password)
-						if (!revokeResult.success) throw new Error(revokeResult.message || geti18n('userSettings.apiError', {message: 'Revoke failed'}))
+						if (!revokeResult.success) throw new Error(revokeResult.message || geti18n('userSettings.apiError', { message: 'Revoke failed' }))
 						showAlert('userSettings.userDevices.revokeSuccess', 'success')
 						loadAndDisplayDevices()
 					} catch (error) {
@@ -217,7 +217,7 @@ el.logoutBtn.addEventListener('click', async () => {
 
 	try {
 		const result = await api.logoutUser() // 调用新的API端点
-		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Logout failed'}))
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', { message: 'Logout failed' }))
 
 		// 登出成功，显示短暂消息并重定向
 		showAlert('userSettings.logout.successMessage', 'success', 2000)
@@ -244,7 +244,7 @@ el.deleteAccountBtn.addEventListener('click', async () => {
 	try {
 		const password = await requestPasswordConfirmation()
 		const result = await api.deleteAccount(password)
-		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Delete account failed'}))
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', { message: 'Delete account failed' }))
 
 		showAlert('userSettings.deleteAccount.success', 'success', 5000)
 		setTimeout(() => window.location.href = '/login', 3000)

--- a/src/public/shells/user_settings/index.mjs
+++ b/src/public/shells/user_settings/index.mjs
@@ -1,0 +1,90 @@
+import { initTranslations } from '../../scripts/i18n.mjs';
+import {
+  changePassword,
+  viewDevices,
+  revokeDevice,
+  renameUser,
+  deleteAccount
+} from './src/public/endpoints.mjs';
+
+async function initializeUserSettingsShell() {
+  // Initialize translations for the 'userSettings' page/context
+  await initTranslations('userSettings');
+
+  // Change Password
+  document.getElementById('changePasswordForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const username = event.target.usernameChangePassword.value;
+    const currentPassword = event.target.currentPassword.value;
+    const newPassword = event.target.newPassword.value;
+    const result = await changePassword(username, currentPassword, newPassword);
+    alert(result.message); // Assuming result.message is already internationalized server-side
+    if (result.success) event.target.reset();
+  });
+
+  // View Devices
+  document.getElementById('viewDevicesForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const username = event.target.usernameViewDevices.value;
+    const result = await viewDevices(username);
+    const deviceList = document.getElementById('deviceList');
+    deviceList.innerHTML = ''; 
+    if (result.success && result.devices) {
+      if (result.devices.length === 0) {
+        const li = document.createElement('li');
+        // Use window.i18n.get (or just i18n.get if initTranslations makes it global differently)
+        li.textContent = window.i18n.get('userSettings.userDevices.noDevicesFound', 'No devices found for this user.');
+        deviceList.appendChild(li);
+      } else {
+        result.devices.forEach(device => {
+          const li = document.createElement('li');
+          li.textContent = `Device ID: ${device.deviceId} (Expires: ${new Date(device.expiry).toLocaleString()})`;
+          const revokeButton = document.createElement('button');
+          revokeButton.textContent = window.i18n.get('userSettings.userDevices.revokeButton', 'Revoke');
+          revokeButton.onclick = async () => {
+            const revokeResult = await revokeDevice(username, device.deviceId);
+            alert(revokeResult.message); 
+            if (revokeResult.success) {
+              document.getElementById('viewDevicesForm').dispatchEvent(new Event('submit'));
+            }
+          };
+          li.appendChild(revokeButton);
+          deviceList.appendChild(li);
+        });
+      }
+    } else {
+      alert(result.message); 
+    }
+  });
+
+  // Rename User
+  document.getElementById('renameUserForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const currentUsername = event.target.currentUsernameRename.value;
+    const newUsername = event.target.newUsernameRename.value;
+    const result = await renameUser(currentUsername, newUsername);
+    alert(result.message); 
+    if (result.success) event.target.reset();
+  });
+
+  // Delete Account
+  document.getElementById('deleteAccountForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const confirmMessage = window.i18n.get('userSettings.deleteAccount.confirmDelete', 'Are you sure you want to delete this account? This action cannot be undone.');
+    if (!confirm(confirmMessage)) {
+      return;
+    }
+    const username = event.target.usernameDelete.value;
+    const password = event.target.passwordDelete.value;
+    const result = await deleteAccount(username, password);
+    alert(result.message); 
+    if (result.success) event.target.reset();
+  });
+}
+
+// Initialize the shell
+initializeUserSettingsShell().catch(error => {
+  console.error("Error initializing User Settings shell:", error);
+  // Optionally, display a user-friendly error message on the page
+  alert("Failed to initialize user settings page: " + error.message);
+});

--- a/src/public/shells/user_settings/index.mjs
+++ b/src/public/shells/user_settings/index.mjs
@@ -1,90 +1,90 @@
-import { initTranslations } from '../../scripts/i18n.mjs';
+import { initTranslations } from '../../scripts/i18n.mjs'
 import {
-  changePassword,
-  viewDevices,
-  revokeDevice,
-  renameUser,
-  deleteAccount
-} from './src/public/endpoints.mjs';
+	changePassword,
+	viewDevices,
+	revokeDevice,
+	renameUser,
+	deleteAccount
+} from './src/public/endpoints.mjs'
 
 async function initializeUserSettingsShell() {
-  // Initialize translations for the 'userSettings' page/context
-  await initTranslations('userSettings');
+	// Initialize translations for the 'userSettings' page/context
+	await initTranslations('userSettings')
 
-  // Change Password
-  document.getElementById('changePasswordForm').addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const username = event.target.usernameChangePassword.value;
-    const currentPassword = event.target.currentPassword.value;
-    const newPassword = event.target.newPassword.value;
-    const result = await changePassword(username, currentPassword, newPassword);
-    alert(result.message); // Assuming result.message is already internationalized server-side
-    if (result.success) event.target.reset();
-  });
+	// Change Password
+	document.getElementById('changePasswordForm').addEventListener('submit', async (event) => {
+		event.preventDefault()
+		const username = event.target.usernameChangePassword.value
+		const currentPassword = event.target.currentPassword.value
+		const newPassword = event.target.newPassword.value
+		const result = await changePassword(username, currentPassword, newPassword)
+		alert(result.message) // Assuming result.message is already internationalized server-side
+		if (result.success) event.target.reset()
+	})
 
-  // View Devices
-  document.getElementById('viewDevicesForm').addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const username = event.target.usernameViewDevices.value;
-    const result = await viewDevices(username);
-    const deviceList = document.getElementById('deviceList');
-    deviceList.innerHTML = ''; 
-    if (result.success && result.devices) {
-      if (result.devices.length === 0) {
-        const li = document.createElement('li');
-        // Use window.i18n.get (or just i18n.get if initTranslations makes it global differently)
-        li.textContent = window.i18n.get('userSettings.userDevices.noDevicesFound', 'No devices found for this user.');
-        deviceList.appendChild(li);
-      } else {
-        result.devices.forEach(device => {
-          const li = document.createElement('li');
-          li.textContent = `Device ID: ${device.deviceId} (Expires: ${new Date(device.expiry).toLocaleString()})`;
-          const revokeButton = document.createElement('button');
-          revokeButton.textContent = window.i18n.get('userSettings.userDevices.revokeButton', 'Revoke');
-          revokeButton.onclick = async () => {
-            const revokeResult = await revokeDevice(username, device.deviceId);
-            alert(revokeResult.message); 
-            if (revokeResult.success) {
-              document.getElementById('viewDevicesForm').dispatchEvent(new Event('submit'));
-            }
-          };
-          li.appendChild(revokeButton);
-          deviceList.appendChild(li);
-        });
-      }
-    } else {
-      alert(result.message); 
-    }
-  });
+	// View Devices
+	document.getElementById('viewDevicesForm').addEventListener('submit', async (event) => {
+		event.preventDefault()
+		const username = event.target.usernameViewDevices.value
+		const result = await viewDevices(username)
+		const deviceList = document.getElementById('deviceList')
+		deviceList.innerHTML = '' 
+		if (result.success && result.devices) 
+			if (result.devices.length === 0) {
+				const li = document.createElement('li')
+				// Use window.i18n.get (or just i18n.get if initTranslations makes it global differently)
+				li.textContent = window.i18n.get('userSettings.userDevices.noDevicesFound', 'No devices found for this user.')
+				deviceList.appendChild(li)
+			} else 
+				result.devices.forEach(device => {
+					const li = document.createElement('li')
+					li.textContent = `Device ID: ${device.deviceId} (Expires: ${new Date(device.expiry).toLocaleString()})`
+					const revokeButton = document.createElement('button')
+					revokeButton.textContent = window.i18n.get('userSettings.userDevices.revokeButton', 'Revoke')
+					revokeButton.onclick = async () => {
+						const revokeResult = await revokeDevice(username, device.deviceId)
+						alert(revokeResult.message) 
+						if (revokeResult.success) 
+							document.getElementById('viewDevicesForm').dispatchEvent(new Event('submit'))
+            
+					}
+					li.appendChild(revokeButton)
+					deviceList.appendChild(li)
+				})
+      
+		else 
+			alert(result.message) 
+    
+	})
 
-  // Rename User
-  document.getElementById('renameUserForm').addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const currentUsername = event.target.currentUsernameRename.value;
-    const newUsername = event.target.newUsernameRename.value;
-    const result = await renameUser(currentUsername, newUsername);
-    alert(result.message); 
-    if (result.success) event.target.reset();
-  });
+	// Rename User
+	document.getElementById('renameUserForm').addEventListener('submit', async (event) => {
+		event.preventDefault()
+		const currentUsername = event.target.currentUsernameRename.value
+		const newUsername = event.target.newUsernameRename.value
+		const result = await renameUser(currentUsername, newUsername)
+		alert(result.message) 
+		if (result.success) event.target.reset()
+	})
 
-  // Delete Account
-  document.getElementById('deleteAccountForm').addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const confirmMessage = window.i18n.get('userSettings.deleteAccount.confirmDelete', 'Are you sure you want to delete this account? This action cannot be undone.');
-    if (!confirm(confirmMessage)) {
-      return;
-    }
-    const username = event.target.usernameDelete.value;
-    const password = event.target.passwordDelete.value;
-    const result = await deleteAccount(username, password);
-    alert(result.message); 
-    if (result.success) event.target.reset();
-  });
+	// Delete Account
+	document.getElementById('deleteAccountForm').addEventListener('submit', async (event) => {
+		event.preventDefault()
+		const confirmMessage = window.i18n.get('userSettings.deleteAccount.confirmDelete', 'Are you sure you want to delete this account? This action cannot be undone.')
+		if (!confirm(confirmMessage)) 
+			return
+    
+		const username = event.target.usernameDelete.value
+		const password = event.target.passwordDelete.value
+		const result = await deleteAccount(username, password)
+		alert(result.message) 
+		if (result.success) event.target.reset()
+	})
 }
 
 // Initialize the shell
 initializeUserSettingsShell().catch(error => {
-  console.error("Error initializing User Settings shell:", error);
-  // Optionally, display a user-friendly error message on the page
-  alert("Failed to initialize user settings page: " + error.message);
-});
+	console.error('Error initializing User Settings shell:', error)
+	// Optionally, display a user-friendly error message on the page
+	alert('Failed to initialize user settings page: ' + error.message)
+})

--- a/src/public/shells/user_settings/index.mjs
+++ b/src/public/shells/user_settings/index.mjs
@@ -1,90 +1,268 @@
-import { initTranslations } from '../../scripts/i18n.mjs'
-import {
-	changePassword,
-	viewDevices,
-	revokeDevice,
-	renameUser,
-	deleteAccount
-} from './src/public/endpoints.mjs'
+import { initTranslations, geti18n } from '../../scripts/i18n.mjs'
+import { applyTheme } from '../../scripts/theme.mjs'
+import * as api from './src/public/endpoints.mjs'
 
-async function initializeUserSettingsShell() {
-	// Initialize translations for the 'userSettings' page/context
-	await initTranslations('userSettings')
+const REFRESH_TOKEN_EXPIRY_DURATION_STRING = 30 * 24 * 60 * 60 * 1000 // '30d'
 
-	// Change Password
-	document.getElementById('changePasswordForm').addEventListener('submit', async (event) => {
-		event.preventDefault()
-		const username = event.target.usernameChangePassword.value
-		const currentPassword = event.target.currentPassword.value
-		const newPassword = event.target.newPassword.value
-		const result = await changePassword(username, currentPassword, newPassword)
-		alert(result.message) // Assuming result.message is already internationalized server-side
-		if (result.success) event.target.reset()
-	})
+const el = { // DOM 元素引用
+	userInfoUsername: document.getElementById('userInfoUsername'),
+	userInfoCreationDate: document.getElementById('userInfoCreationDate'),
+	userInfoFolderSize: document.getElementById('userInfoFolderSize'),
+	userInfoFolderPath: document.getElementById('userInfoFolderPath'),
+	copyFolderPathBtn: document.getElementById('copyFolderPathBtn'),
+	changePasswordForm: document.getElementById('changePasswordForm'),
+	renameUserForm: document.getElementById('renameUserForm'),
+	deviceListContainer: document.getElementById('deviceListContainer'),
+	deviceList: document.getElementById('deviceList'),
+	noDevicesText: document.getElementById('noDevicesText'),
+	refreshDevicesBtn: document.getElementById('refreshDevicesBtn'),
+	logoutBtn: document.getElementById('logoutBtn'), // 新增：登出按钮
+	deleteAccountBtn: document.getElementById('deleteAccountBtn'),
+	passwordConfirmationModal: document.getElementById('passwordConfirmationModal'),
+	confirmationPasswordInput: document.getElementById('confirmationPassword'),
+	confirmPasswordBtn: document.getElementById('confirmPasswordBtn'),
+	cancelPasswordBtn: document.getElementById('cancelPasswordBtn'),
+	alertContainer: document.getElementById('alertContainer'),
+}
 
-	// View Devices
-	document.getElementById('viewDevicesForm').addEventListener('submit', async (event) => {
-		event.preventDefault()
-		const username = event.target.usernameViewDevices.value
-		const result = await viewDevices(username)
-		const deviceList = document.getElementById('deviceList')
-		deviceList.innerHTML = '' 
-		if (result.success && result.devices) 
-			if (result.devices.length === 0) {
-				const li = document.createElement('li')
-				// Use window.i18n.get (or just i18n.get if initTranslations makes it global differently)
-				li.textContent = window.i18n.get('userSettings.userDevices.noDevicesFound', 'No devices found for this user.')
-				deviceList.appendChild(li)
-			} else 
-				result.devices.forEach(device => {
-					const li = document.createElement('li')
-					li.textContent = `Device ID: ${device.deviceId} (Expires: ${new Date(device.expiry).toLocaleString()})`
-					const revokeButton = document.createElement('button')
-					revokeButton.textContent = window.i18n.get('userSettings.userDevices.revokeButton', 'Revoke')
-					revokeButton.onclick = async () => {
-						const revokeResult = await revokeDevice(username, device.deviceId)
-						alert(revokeResult.message) 
-						if (revokeResult.success) 
-							document.getElementById('viewDevicesForm').dispatchEvent(new Event('submit'))
-            
-					}
-					li.appendChild(revokeButton)
-					deviceList.appendChild(li)
-				})
-      
-		else 
-			alert(result.message) 
-    
-	})
+let passwordConfirmationContext = { resolve: null, reject: null }
 
-	// Rename User
-	document.getElementById('renameUserForm').addEventListener('submit', async (event) => {
-		event.preventDefault()
-		const currentUsername = event.target.currentUsernameRename.value
-		const newUsername = event.target.newUsernameRename.value
-		const result = await renameUser(currentUsername, newUsername)
-		alert(result.message) 
-		if (result.success) event.target.reset()
-	})
+// 辅助函数：显示提示消息
+function showAlert(messageKey, type = 'info', duration = 4000, interpolateParams = {}) {
+	const message = geti18n(messageKey, interpolateParams)
+	const alertId = `alert-${Date.now()}`
+	const alertDiv = document.createElement('div')
+	alertDiv.id = alertId
+	alertDiv.className = `alert alert-${type} shadow-lg`
+	alertDiv.innerHTML = `<div><span>${message}</span></div>`
+	el.alertContainer.appendChild(alertDiv)
+	setTimeout(() => document.getElementById(alertId)?.remove(), duration)
+}
 
-	// Delete Account
-	document.getElementById('deleteAccountForm').addEventListener('submit', async (event) => {
-		event.preventDefault()
-		const confirmMessage = window.i18n.get('userSettings.deleteAccount.confirmDelete', 'Are you sure you want to delete this account? This action cannot be undone.')
-		if (!confirm(confirmMessage)) 
-			return
-    
-		const username = event.target.usernameDelete.value
-		const password = event.target.passwordDelete.value
-		const result = await deleteAccount(username, password)
-		alert(result.message) 
-		if (result.success) event.target.reset()
+// 辅助函数：请求密码确认
+function requestPasswordConfirmation() {
+	return new Promise((resolve, reject) => {
+		passwordConfirmationContext = { resolve, reject }
+		el.confirmationPasswordInput.value = ''
+		el.passwordConfirmationModal.showModal()
+		el.confirmationPasswordInput.focus()
 	})
 }
 
-// Initialize the shell
-initializeUserSettingsShell().catch(error => {
+el.confirmPasswordBtn.addEventListener('click', () => {
+	passwordConfirmationContext.resolve?.(el.confirmationPasswordInput.value)
+	el.passwordConfirmationModal.close()
+})
+
+el.cancelPasswordBtn.addEventListener('click', () => {
+	passwordConfirmationContext.reject?.(new Error('Password confirmation cancelled by user.'))
+	el.passwordConfirmationModal.close()
+})
+
+el.passwordConfirmationModal.addEventListener('close', () => {
+	if (el.passwordConfirmationModal.returnValue !== 'confirmed_via_button_logic_which_is_not_set')
+		passwordConfirmationContext.reject?.(new Error('Password confirmation dialog closed.'))
+
+	passwordConfirmationContext = { resolve: null, reject: null }
+})
+
+async function loadUserInfo() {
+	try {
+		const stats = await api.getUserStats()
+		if (!stats.success) throw new Error(stats.message || geti18n('userSettings.apiError', {message: 'Failed to load user info'}))
+
+		el.userInfoUsername.textContent = stats.username
+		el.userInfoCreationDate.textContent = new Date(stats.creationDate).toLocaleDateString()
+		el.userInfoFolderSize.textContent = stats.folderSize
+		el.userInfoFolderPath.textContent = stats.folderPath
+	} catch (error) {
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+}
+
+el.copyFolderPathBtn.addEventListener('click', async () => {
+	try {
+		await navigator.clipboard.writeText(el.userInfoFolderPath.textContent)
+		showAlert('userSettings.userInfo.copiedAlert', 'success')
+	} catch(err) {
+		console.error('Failed to copy path: ', err)
+		showAlert('userSettings.generalError', 'error', 5000, { message: 'Failed to copy path.'})
+	}
+})
+
+el.changePasswordForm.addEventListener('submit', async (event) => {
+	event.preventDefault()
+	const form = event.target
+	const currentPassword = form.currentPassword.value
+	const newPassword = form.newPassword.value
+	const confirmNewPassword = form.confirmNewPassword.value
+
+	if (newPassword !== confirmNewPassword)
+		return showAlert('userSettings.changePassword.errorMismatch', 'error')
+
+	try {
+		const result = await api.changePassword(currentPassword, newPassword)
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Password change failed'}))
+
+		showAlert('userSettings.changePassword.success', 'success')
+		form.reset()
+	} catch (error) {
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+})
+
+el.renameUserForm.addEventListener('submit', async (event) => {
+	event.preventDefault()
+	const form = event.target
+	const newUsername = form.newUsernameRename.value.trim()
+	if (!newUsername) return
+
+	if (!confirm(geti18n('userSettings.renameUser.confirmMessage'))) return
+
+	try {
+		const password = await requestPasswordConfirmation()
+		const result = await api.renameUser(newUsername, password)
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Rename user failed'}))
+
+		showAlert('userSettings.renameUser.success', 'success', 5000, { newUsername })
+		form.reset()
+		setTimeout(() => window.location.href = '/login', 2000)
+	} catch (error) {
+		if (error.message.includes('cancelled') || error.message.includes('closed')) return
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+})
+
+async function loadAndDisplayDevices() {
+	el.deviceList.innerHTML = '<div class="text-center py-4"><span class="loading loading-dots loading-md"></span></div>'
+	el.noDevicesText.classList.add('hidden')
+
+	try {
+		const result = await api.getDevices()
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Failed to load devices'}))
+
+		el.deviceList.innerHTML = ''
+		if (result.devices.length === 0) {
+			el.noDevicesText.classList.remove('hidden')
+			return
+		}
+
+		let currentRefreshTokenJtiClient = null
+		try {
+			const refreshTokenCookie = document.cookie.split('; ').find(row => row.startsWith('refreshToken='))
+			if (refreshTokenCookie) {
+				const tokenValue = refreshTokenCookie.split('=')[1]
+				const payload = JSON.parse(atob(tokenValue.split('.')[1]))
+				currentRefreshTokenJtiClient = payload.jti
+			}
+		} catch (e) { /* Quietly ignore */ }
+
+		result.devices.forEach(device => {
+			const li = document.createElement('li')
+			li.className = 'p-3 bg-base-100 rounded-lg shadow flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2'
+
+			const deviceInfoDiv = document.createElement('div')
+			const deviceIdText = geti18n('userSettings.userDevices.deviceInfo', { deviceId: device.deviceId })
+
+			let mainText = `${deviceIdText}`
+			if (device.jti === currentRefreshTokenJtiClient)
+				mainText += ` <span class="badge badge-xs badge-success badge-outline">${geti18n('userSettings.userDevices.thisDevice')}</span>`
+
+			deviceInfoDiv.innerHTML = `<strong class="block text-sm">${mainText}</strong>`
+
+			const lastSeenDate = new Date(device.lastSeen || (device.expiry - REFRESH_TOKEN_EXPIRY_DURATION_STRING))
+			const detailsText = geti18n('userSettings.userDevices.deviceDetails', {
+				lastSeen: lastSeenDate.toLocaleString(),
+				ipAddress: device.ipAddress || 'N/A',
+				userAgent: device.userAgent ? device.userAgent.length > 50 ? device.userAgent.substring(0, 47) + '...' : device.userAgent : 'N/A'
+			})
+			deviceInfoDiv.innerHTML += `<small class="block text-xs opacity-70">${detailsText}</small>`
+			li.appendChild(deviceInfoDiv)
+
+			if (device.jti !== currentRefreshTokenJtiClient) {
+				const revokeButton = document.createElement('button')
+				revokeButton.className = 'btn btn-xs btn-error btn-outline self-start sm:self-center'
+				revokeButton.dataset.i18n = 'userSettings.userDevices.revokeButton'
+				revokeButton.textContent = geti18n('userSettings.userDevices.revokeButton')
+				revokeButton.onclick = async () => {
+					if (!confirm(geti18n('userSettings.userDevices.revokeConfirm'))) return
+					try {
+						const password = await requestPasswordConfirmation()
+						const revokeResult = await api.revokeDevice(device.jti, password)
+						if (!revokeResult.success) throw new Error(revokeResult.message || geti18n('userSettings.apiError', {message: 'Revoke failed'}))
+						showAlert('userSettings.userDevices.revokeSuccess', 'success')
+						loadAndDisplayDevices()
+					} catch (error) {
+						if (error.message.includes('cancelled') || error.message.includes('closed')) return
+						showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+					}
+				}
+				li.appendChild(revokeButton)
+			}
+			el.deviceList.appendChild(li)
+		})
+	} catch (error) {
+		el.deviceList.innerHTML = ''
+		el.noDevicesText.classList.remove('hidden')
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+}
+
+el.refreshDevicesBtn.addEventListener('click', loadAndDisplayDevices)
+
+// 新增：登出处理函数
+el.logoutBtn.addEventListener('click', async () => {
+	// 通常登出不需要二次确认，但如果需要可以取消下面的注释
+	// if (!confirm(geti18n('userSettings.logout.confirmMessage'))) return;
+
+	try {
+		const result = await api.logoutUser() // 调用新的API端点
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Logout failed'}))
+
+		// 登出成功，显示短暂消息并重定向
+		showAlert('userSettings.logout.successMessage', 'success', 2000)
+		setTimeout(() => {
+			window.location.href = '/login' // 重定向到登录页面
+		}, 1500) // 延迟一点以便用户看到消息
+
+	} catch (error) {
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+})
+
+
+el.deleteAccountBtn.addEventListener('click', async () => {
+	if (!confirm(geti18n('userSettings.deleteAccount.confirmMessage1'))) return
+
+	const usernameToConfirm = el.userInfoUsername.textContent
+	const enteredUsername = prompt(geti18n('userSettings.deleteAccount.confirmMessage2', { username: usernameToConfirm }))
+
+	if (enteredUsername === null) return
+	if (enteredUsername !== usernameToConfirm)
+		return showAlert('userSettings.deleteAccount.usernameMismatch', 'error')
+
+	try {
+		const password = await requestPasswordConfirmation()
+		const result = await api.deleteAccount(password)
+		if (!result.success) throw new Error(result.message || geti18n('userSettings.apiError', {message: 'Delete account failed'}))
+
+		showAlert('userSettings.deleteAccount.success', 'success', 5000)
+		setTimeout(() => window.location.href = '/login', 3000)
+	} catch (error) {
+		if (error.message.includes('cancelled') || error.message.includes('closed')) return
+		showAlert('userSettings.generalError', 'error', 5000, { message: error.message })
+	}
+})
+
+async function initializeApp() {
+	await initTranslations('userSettings')
+	applyTheme()
+
+	await loadUserInfo()
+	await loadAndDisplayDevices()
+}
+
+initializeApp().catch(error => {
 	console.error('Error initializing User Settings shell:', error)
-	// Optionally, display a user-friendly error message on the page
-	alert('Failed to initialize user settings page: ' + error.message)
+	showAlert('userSettings.generalError', 'error', 0, { message: 'Initialization failed: ' + error.message })
 })

--- a/src/public/shells/user_settings/main.mjs
+++ b/src/public/shells/user_settings/main.mjs
@@ -1,137 +1,136 @@
-import express from 'npm:express@^5.0.1';
 import {
-  getUserByUsername, // Still needed for /view-devices directly
-  changeUserPassword,
-  revokeUserDevice,
-  deleteUserAccount,
-  renameUser
-} from '../../../../server/auth.mjs';
+	getUserByUsername, // Still needed for /view-devices directly
+	changeUserPassword,
+	revokeUserDevice,
+	deleteUserAccount,
+	renameUser
+} from '../../../../server/auth.mjs'
 // events, config, save_config are no longer directly needed here as auth.mjs handles them.
 
 // Placeholder isAdmin middleware (remains unchanged for this task)
 const isAdmin = (req, res, next) => {
-  // In a real scenario, proper admin/permission checks would be here,
-  // likely based on req.user set by the main authentication middleware.
-  // For now, assuming permissions are handled by the shell manager via home_registry.json
-  // or that any authenticated user can access for now.
-  if (req.user) { // Basic check: user must be authenticated
-    next();
-  } else {
-    // If no req.user, means the main authenticate middleware didn't pass them.
-    // This could be due to /api/shells/* not being under main authentication chain,
-    // or if it is, then user isn't logged in.
-    // Shell manager is responsible for ensuring only authorized users can access shell APIs.
-    // This middleware can be a secondary check if needed.
-    // For now, let's assume the shell manager has done its job based on home_registry.json permissions.
-    next(); 
-  }
-};
+	// In a real scenario, proper admin/permission checks would be here,
+	// likely based on req.user set by the main authentication middleware.
+	// For now, assuming permissions are handled by the shell manager via home_registry.json
+	// or that any authenticated user can access for now.
+	if (req.user)  // Basic check: user must be authenticated
+		next()
+	else 
+	// If no req.user, means the main authenticate middleware didn't pass them.
+	// This could be due to /api/shells/* not being under main authentication chain,
+	// or if it is, then user isn't logged in.
+	// Shell manager is responsible for ensuring only authorized users can access shell APIs.
+	// This middleware can be a secondary check if needed.
+	// For now, let's assume the shell manager has done its job based on home_registry.json permissions.
+		next() 
+  
+}
 
 function configureUserSettingsRoutes(router) {
-  router.use(isAdmin); // Apply to all routes in this shell
+	router.use(isAdmin) // Apply to all routes in this shell
 
-  // Change Password
-  router.post('/change-password', async (req, res) => {
-    const { username, currentPassword, newPassword } = req.body;
-    if (!username || !currentPassword || !newPassword) {
-      return res.status(400).json({ success: false, message: 'Missing required fields.' });
-    }
-    try {
-      const result = await changeUserPassword(username, currentPassword, newPassword);
-      return res.status(result.success ? 200 : 401).json(result);
-    } catch (error) {
-      console.error('User Settings Shell: Change password error:', error);
-      return res.status(500).json({ success: false, message: 'Internal server error changing password.' });
-    }
-  });
+	// Change Password
+	router.post('/change-password', async (req, res) => {
+		const { username, currentPassword, newPassword } = req.body
+		if (!username || !currentPassword || !newPassword) 
+			return res.status(400).json({ success: false, message: 'Missing required fields.' })
+    
+		try {
+			const result = await changeUserPassword(username, currentPassword, newPassword)
+			return res.status(result.success ? 200 : 401).json(result)
+		} catch (error) {
+			console.error('User Settings Shell: Change password error:', error)
+			return res.status(500).json({ success: false, message: 'Internal server error changing password.' })
+		}
+	})
 
-  // View Devices
-  router.post('/view-devices', async (req, res) => {
-    const { username } = req.body;
-    if (!username) {
-      return res.status(400).json({ success: false, message: 'Username is required.' });
-    }
-    try {
-      const user = getUserByUsername(username); // Direct call to get user data for device list
-      if (!user || !user.auth || !user.auth.refreshTokens) {
-        return res.status(404).json({ success: false, message: 'User not found or no device information available.' });
-      }
-      const devices = user.auth.refreshTokens.map(token => ({
-        deviceId: token.deviceId,
-        jti: token.jti,
-        expiry: token.expiry,
-      }));
-      return res.json({ success: true, devices });
-    } catch (error) {
-      console.error('User Settings Shell: View devices error:', error);
-      return res.status(500).json({ success: false, message: 'Error fetching devices.' });
-    }
-  });
+	// View Devices
+	router.post('/view-devices', async (req, res) => {
+		const { username } = req.body
+		if (!username) 
+			return res.status(400).json({ success: false, message: 'Username is required.' })
+    
+		try {
+			const user = getUserByUsername(username) // Direct call to get user data for device list
+			if (!user || !user.auth || !user.auth.refreshTokens) 
+				return res.status(404).json({ success: false, message: 'User not found or no device information available.' })
+      
+			const devices = user.auth.refreshTokens.map(token => ({
+				deviceId: token.deviceId,
+				jti: token.jti,
+				expiry: token.expiry,
+			}))
+			return res.json({ success: true, devices })
+		} catch (error) {
+			console.error('User Settings Shell: View devices error:', error)
+			return res.status(500).json({ success: false, message: 'Error fetching devices.' })
+		}
+	})
 
-  // Revoke Device
-  router.post('/revoke-device', async (req, res) => {
-    const { username, deviceId } = req.body;
-    if (!username || !deviceId) {
-      return res.status(400).json({ success: false, message: 'Username and deviceId are required.' });
-    }
-    try {
-      const result = await revokeUserDevice(username, deviceId);
-      return res.status(result.success ? 200 : 404).json(result);
-    } catch (error) {
-      console.error('User Settings Shell: Revoke device error:', error);
-      return res.status(500).json({ success: false, message: 'Error revoking device access.' });
-    }
-  });
+	// Revoke Device
+	router.post('/revoke-device', async (req, res) => {
+		const { username, deviceId } = req.body
+		if (!username || !deviceId) 
+			return res.status(400).json({ success: false, message: 'Username and deviceId are required.' })
+    
+		try {
+			const result = await revokeUserDevice(username, deviceId)
+			return res.status(result.success ? 200 : 404).json(result)
+		} catch (error) {
+			console.error('User Settings Shell: Revoke device error:', error)
+			return res.status(500).json({ success: false, message: 'Error revoking device access.' })
+		}
+	})
 
-  // Rename User
-  router.post('/rename-user', async (req, res) => {
-    const { currentUsername, newUsername } = req.body;
-    if (!currentUsername || !newUsername) {
-      return res.status(400).json({ success: false, message: 'Current and new usernames are required.' });
-    }
-    if (currentUsername === newUsername) {
-      return res.status(400).json({ success: false, message: 'New username cannot be the same as the current username.' });
-    }
-    try {
-      const result = await renameUser(currentUsername, newUsername);
-      return res.status(result.success ? 200 : 400).json(result); // 400 for validation errors like "already exists"
-    } catch (error) {
-      console.error('User Settings Shell: Rename user error:', error);
-      return res.status(500).json({ success: false, message: 'Error renaming user.' });
-    }
-  });
+	// Rename User
+	router.post('/rename-user', async (req, res) => {
+		const { currentUsername, newUsername } = req.body
+		if (!currentUsername || !newUsername) 
+			return res.status(400).json({ success: false, message: 'Current and new usernames are required.' })
+    
+		if (currentUsername === newUsername) 
+			return res.status(400).json({ success: false, message: 'New username cannot be the same as the current username.' })
+    
+		try {
+			const result = await renameUser(currentUsername, newUsername)
+			return res.status(result.success ? 200 : 400).json(result) // 400 for validation errors like "already exists"
+		} catch (error) {
+			console.error('User Settings Shell: Rename user error:', error)
+			return res.status(500).json({ success: false, message: 'Error renaming user.' })
+		}
+	})
 
-  // Delete Account
-  router.post('/delete-account', async (req, res) => {
-    const { username, password } = req.body;
-    if (!username || !password) {
-      return res.status(400).json({ success: false, message: 'Username and password are required.' });
-    }
-    try {
-      const result = await deleteUserAccount(username, password);
-      return res.status(result.success ? 200 : 401).json(result); // 401 for auth failure
-    } catch (error) {
-      console.error('User Settings Shell: Delete account error:', error);
-      return res.status(500).json({ success: false, message: 'Error deleting account.' });
-    }
-  });
+	// Delete Account
+	router.post('/delete-account', async (req, res) => {
+		const { username, password } = req.body
+		if (!username || !password) 
+			return res.status(400).json({ success: false, message: 'Username and password are required.' })
+    
+		try {
+			const result = await deleteUserAccount(username, password)
+			return res.status(result.success ? 200 : 401).json(result) // 401 for auth failure
+		} catch (error) {
+			console.error('User Settings Shell: Delete account error:', error)
+			return res.status(500).json({ success: false, message: 'Error deleting account.' })
+		}
+	})
 }
 
 export default {
-  info: {
-    // Basic info, can be expanded with localized names later if needed by shell manager
-    name: 'user-settings',
-    version: '1.0.0',
-    author: 'Fount AI Assistant', // Or your name/handle
-    description: 'Provides API endpoints for user settings management.'
-  },
-  Load: async (router) => {
-    // The router passed here is specific to this shell, typically prefixed like /api/shells/user_settings
-    configureUserSettingsRoutes(router);
-  },
-  Unload: async () => {
-    // Cleanup if necessary, usually not needed for simple route additions
-  }
-  // 'interfaces' can be added if this shell provides specific programmatic interfaces
-  // for other shells or parts of the system, like the discordbot example. Not needed for now.
-};
+	info: {
+		// Basic info, can be expanded with localized names later if needed by shell manager
+		name: 'user-settings',
+		version: '1.0.0',
+		author: 'Fount AI Assistant', // Or your name/handle
+		description: 'Provides API endpoints for user settings management.'
+	},
+	Load: async (router) => {
+		// The router passed here is specific to this shell, typically prefixed like /api/shells/user_settings
+		configureUserSettingsRoutes(router)
+	},
+	Unload: async () => {
+		// Cleanup if necessary, usually not needed for simple route additions
+	}
+	// 'interfaces' can be added if this shell provides specific programmatic interfaces
+	// for other shells or parts of the system, like the discordbot example. Not needed for now.
+}

--- a/src/public/shells/user_settings/main.mjs
+++ b/src/public/shells/user_settings/main.mjs
@@ -1,136 +1,16 @@
-import {
-	getUserByUsername, // Still needed for /view-devices directly
-	changeUserPassword,
-	revokeUserDevice,
-	deleteUserAccount,
-	renameUser
-} from '../../../../server/auth.mjs'
-// events, config, save_config are no longer directly needed here as auth.mjs handles them.
-
-// Placeholder isAdmin middleware (remains unchanged for this task)
-const isAdmin = (req, res, next) => {
-	// In a real scenario, proper admin/permission checks would be here,
-	// likely based on req.user set by the main authentication middleware.
-	// For now, assuming permissions are handled by the shell manager via home_registry.json
-	// or that any authenticated user can access for now.
-	if (req.user)  // Basic check: user must be authenticated
-		next()
-	else 
-	// If no req.user, means the main authenticate middleware didn't pass them.
-	// This could be due to /api/shells/* not being under main authentication chain,
-	// or if it is, then user isn't logged in.
-	// Shell manager is responsible for ensuring only authorized users can access shell APIs.
-	// This middleware can be a secondary check if needed.
-	// For now, let's assume the shell manager has done its job based on home_registry.json permissions.
-		next() 
-  
-}
-
-function configureUserSettingsRoutes(router) {
-	router.use(isAdmin) // Apply to all routes in this shell
-
-	// Change Password
-	router.post('/change-password', async (req, res) => {
-		const { username, currentPassword, newPassword } = req.body
-		if (!username || !currentPassword || !newPassword) 
-			return res.status(400).json({ success: false, message: 'Missing required fields.' })
-    
-		try {
-			const result = await changeUserPassword(username, currentPassword, newPassword)
-			return res.status(result.success ? 200 : 401).json(result)
-		} catch (error) {
-			console.error('User Settings Shell: Change password error:', error)
-			return res.status(500).json({ success: false, message: 'Internal server error changing password.' })
-		}
-	})
-
-	// View Devices
-	router.post('/view-devices', async (req, res) => {
-		const { username } = req.body
-		if (!username) 
-			return res.status(400).json({ success: false, message: 'Username is required.' })
-    
-		try {
-			const user = getUserByUsername(username) // Direct call to get user data for device list
-			if (!user || !user.auth || !user.auth.refreshTokens) 
-				return res.status(404).json({ success: false, message: 'User not found or no device information available.' })
-      
-			const devices = user.auth.refreshTokens.map(token => ({
-				deviceId: token.deviceId,
-				jti: token.jti,
-				expiry: token.expiry,
-			}))
-			return res.json({ success: true, devices })
-		} catch (error) {
-			console.error('User Settings Shell: View devices error:', error)
-			return res.status(500).json({ success: false, message: 'Error fetching devices.' })
-		}
-	})
-
-	// Revoke Device
-	router.post('/revoke-device', async (req, res) => {
-		const { username, deviceId } = req.body
-		if (!username || !deviceId) 
-			return res.status(400).json({ success: false, message: 'Username and deviceId are required.' })
-    
-		try {
-			const result = await revokeUserDevice(username, deviceId)
-			return res.status(result.success ? 200 : 404).json(result)
-		} catch (error) {
-			console.error('User Settings Shell: Revoke device error:', error)
-			return res.status(500).json({ success: false, message: 'Error revoking device access.' })
-		}
-	})
-
-	// Rename User
-	router.post('/rename-user', async (req, res) => {
-		const { currentUsername, newUsername } = req.body
-		if (!currentUsername || !newUsername) 
-			return res.status(400).json({ success: false, message: 'Current and new usernames are required.' })
-    
-		if (currentUsername === newUsername) 
-			return res.status(400).json({ success: false, message: 'New username cannot be the same as the current username.' })
-    
-		try {
-			const result = await renameUser(currentUsername, newUsername)
-			return res.status(result.success ? 200 : 400).json(result) // 400 for validation errors like "already exists"
-		} catch (error) {
-			console.error('User Settings Shell: Rename user error:', error)
-			return res.status(500).json({ success: false, message: 'Error renaming user.' })
-		}
-	})
-
-	// Delete Account
-	router.post('/delete-account', async (req, res) => {
-		const { username, password } = req.body
-		if (!username || !password) 
-			return res.status(400).json({ success: false, message: 'Username and password are required.' })
-    
-		try {
-			const result = await deleteUserAccount(username, password)
-			return res.status(result.success ? 200 : 401).json(result) // 401 for auth failure
-		} catch (error) {
-			console.error('User Settings Shell: Delete account error:', error)
-			return res.status(500).json({ success: false, message: 'Error deleting account.' })
-		}
-	})
-}
+import { setEndpoints } from './src/server/endpoints.mjs'
 
 export default {
 	info: {
-		// Basic info, can be expanded with localized names later if needed by shell manager
-		name: 'user-settings',
-		version: '1.0.0',
-		author: 'Fount AI Assistant', // Or your name/handle
-		description: 'Provides API endpoints for user settings management.'
+		'': {
+			name: 'user-settings',
+			version: '1.0.0',
+			author: 'steve02081504',
+			description: 'Provides API endpoints for user settings management.'
+		}
 	},
 	Load: async (router) => {
-		// The router passed here is specific to this shell, typically prefixed like /api/shells/user_settings
-		configureUserSettingsRoutes(router)
+		setEndpoints(router)
 	},
-	Unload: async () => {
-		// Cleanup if necessary, usually not needed for simple route additions
-	}
-	// 'interfaces' can be added if this shell provides specific programmatic interfaces
-	// for other shells or parts of the system, like the discordbot example. Not needed for now.
+	Unload: async () => { }
 }

--- a/src/public/shells/user_settings/main.mjs
+++ b/src/public/shells/user_settings/main.mjs
@@ -1,0 +1,137 @@
+import express from 'npm:express@^5.0.1';
+import {
+  getUserByUsername, // Still needed for /view-devices directly
+  changeUserPassword,
+  revokeUserDevice,
+  deleteUserAccount,
+  renameUser
+} from '../../../../server/auth.mjs';
+// events, config, save_config are no longer directly needed here as auth.mjs handles them.
+
+// Placeholder isAdmin middleware (remains unchanged for this task)
+const isAdmin = (req, res, next) => {
+  // In a real scenario, proper admin/permission checks would be here,
+  // likely based on req.user set by the main authentication middleware.
+  // For now, assuming permissions are handled by the shell manager via home_registry.json
+  // or that any authenticated user can access for now.
+  if (req.user) { // Basic check: user must be authenticated
+    next();
+  } else {
+    // If no req.user, means the main authenticate middleware didn't pass them.
+    // This could be due to /api/shells/* not being under main authentication chain,
+    // or if it is, then user isn't logged in.
+    // Shell manager is responsible for ensuring only authorized users can access shell APIs.
+    // This middleware can be a secondary check if needed.
+    // For now, let's assume the shell manager has done its job based on home_registry.json permissions.
+    next(); 
+  }
+};
+
+function configureUserSettingsRoutes(router) {
+  router.use(isAdmin); // Apply to all routes in this shell
+
+  // Change Password
+  router.post('/change-password', async (req, res) => {
+    const { username, currentPassword, newPassword } = req.body;
+    if (!username || !currentPassword || !newPassword) {
+      return res.status(400).json({ success: false, message: 'Missing required fields.' });
+    }
+    try {
+      const result = await changeUserPassword(username, currentPassword, newPassword);
+      return res.status(result.success ? 200 : 401).json(result);
+    } catch (error) {
+      console.error('User Settings Shell: Change password error:', error);
+      return res.status(500).json({ success: false, message: 'Internal server error changing password.' });
+    }
+  });
+
+  // View Devices
+  router.post('/view-devices', async (req, res) => {
+    const { username } = req.body;
+    if (!username) {
+      return res.status(400).json({ success: false, message: 'Username is required.' });
+    }
+    try {
+      const user = getUserByUsername(username); // Direct call to get user data for device list
+      if (!user || !user.auth || !user.auth.refreshTokens) {
+        return res.status(404).json({ success: false, message: 'User not found or no device information available.' });
+      }
+      const devices = user.auth.refreshTokens.map(token => ({
+        deviceId: token.deviceId,
+        jti: token.jti,
+        expiry: token.expiry,
+      }));
+      return res.json({ success: true, devices });
+    } catch (error) {
+      console.error('User Settings Shell: View devices error:', error);
+      return res.status(500).json({ success: false, message: 'Error fetching devices.' });
+    }
+  });
+
+  // Revoke Device
+  router.post('/revoke-device', async (req, res) => {
+    const { username, deviceId } = req.body;
+    if (!username || !deviceId) {
+      return res.status(400).json({ success: false, message: 'Username and deviceId are required.' });
+    }
+    try {
+      const result = await revokeUserDevice(username, deviceId);
+      return res.status(result.success ? 200 : 404).json(result);
+    } catch (error) {
+      console.error('User Settings Shell: Revoke device error:', error);
+      return res.status(500).json({ success: false, message: 'Error revoking device access.' });
+    }
+  });
+
+  // Rename User
+  router.post('/rename-user', async (req, res) => {
+    const { currentUsername, newUsername } = req.body;
+    if (!currentUsername || !newUsername) {
+      return res.status(400).json({ success: false, message: 'Current and new usernames are required.' });
+    }
+    if (currentUsername === newUsername) {
+      return res.status(400).json({ success: false, message: 'New username cannot be the same as the current username.' });
+    }
+    try {
+      const result = await renameUser(currentUsername, newUsername);
+      return res.status(result.success ? 200 : 400).json(result); // 400 for validation errors like "already exists"
+    } catch (error) {
+      console.error('User Settings Shell: Rename user error:', error);
+      return res.status(500).json({ success: false, message: 'Error renaming user.' });
+    }
+  });
+
+  // Delete Account
+  router.post('/delete-account', async (req, res) => {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ success: false, message: 'Username and password are required.' });
+    }
+    try {
+      const result = await deleteUserAccount(username, password);
+      return res.status(result.success ? 200 : 401).json(result); // 401 for auth failure
+    } catch (error) {
+      console.error('User Settings Shell: Delete account error:', error);
+      return res.status(500).json({ success: false, message: 'Error deleting account.' });
+    }
+  });
+}
+
+export default {
+  info: {
+    // Basic info, can be expanded with localized names later if needed by shell manager
+    name: 'user-settings',
+    version: '1.0.0',
+    author: 'Fount AI Assistant', // Or your name/handle
+    description: 'Provides API endpoints for user settings management.'
+  },
+  Load: async (router) => {
+    // The router passed here is specific to this shell, typically prefixed like /api/shells/user_settings
+    configureUserSettingsRoutes(router);
+  },
+  Unload: async () => {
+    // Cleanup if necessary, usually not needed for simple route additions
+  }
+  // 'interfaces' can be added if this shell provides specific programmatic interfaces
+  // for other shells or parts of the system, like the discordbot example. Not needed for now.
+};

--- a/src/public/shells/user_settings/src/public/endpoints.mjs
+++ b/src/public/shells/user_settings/src/public/endpoints.mjs
@@ -1,31 +1,31 @@
 // Helper function to make API calls (internal to this module)
 async function callApi(endpoint, method, body) {
-  const response = await fetch(`/api/shells/user_settings/${endpoint}`, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return response.json();
+	const response = await fetch(`/api/shells/user_settings/${endpoint}`, {
+		method,
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: body ? JSON.stringify(body) : undefined,
+	})
+	return response.json()
 }
 
 export async function changePassword(username, currentPassword, newPassword) {
-  return callApi('change-password', 'POST', { username, currentPassword, newPassword });
+	return callApi('change-password', 'POST', { username, currentPassword, newPassword })
 }
 
 export async function viewDevices(username) {
-  return callApi('view-devices', 'POST', { username });
+	return callApi('view-devices', 'POST', { username })
 }
 
 export async function revokeDevice(username, deviceId) {
-  return callApi('revoke-device', 'POST', { username, deviceId });
+	return callApi('revoke-device', 'POST', { username, deviceId })
 }
 
 export async function renameUser(currentUsername, newUsername) {
-  return callApi('rename-user', 'POST', { currentUsername, newUsername });
+	return callApi('rename-user', 'POST', { currentUsername, newUsername })
 }
 
 export async function deleteAccount(username, password) {
-  return callApi('delete-account', 'POST', { username, password });
+	return callApi('delete-account', 'POST', { username, password })
 }

--- a/src/public/shells/user_settings/src/public/endpoints.mjs
+++ b/src/public/shells/user_settings/src/public/endpoints.mjs
@@ -1,0 +1,31 @@
+// Helper function to make API calls (internal to this module)
+async function callApi(endpoint, method, body) {
+  const response = await fetch(`/api/shells/user_settings/${endpoint}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return response.json();
+}
+
+export async function changePassword(username, currentPassword, newPassword) {
+  return callApi('change-password', 'POST', { username, currentPassword, newPassword });
+}
+
+export async function viewDevices(username) {
+  return callApi('view-devices', 'POST', { username });
+}
+
+export async function revokeDevice(username, deviceId) {
+  return callApi('revoke-device', 'POST', { username, deviceId });
+}
+
+export async function renameUser(currentUsername, newUsername) {
+  return callApi('rename-user', 'POST', { currentUsername, newUsername });
+}
+
+export async function deleteAccount(username, password) {
+  return callApi('delete-account', 'POST', { username, password });
+}

--- a/src/public/shells/user_settings/src/public/endpoints.mjs
+++ b/src/public/shells/user_settings/src/public/endpoints.mjs
@@ -1,31 +1,47 @@
-// Helper function to make API calls (internal to this module)
-async function callApi(endpoint, method, body) {
+// Helper function to make API calls
+async function callApi(endpoint, method = 'POST', body) {
 	const response = await fetch(`/api/shells/user_settings/${endpoint}`, {
 		method,
-		headers: {
-			'Content-Type': 'application/json',
-		},
+		headers: { 'Content-Type': 'application/json' },
 		body: body ? JSON.stringify(body) : undefined,
 	})
-	return response.json()
+	const contentType = response.headers.get('content-type')
+	if (contentType && contentType.indexOf('application/json') !== -1)
+		return response.json()
+	else {
+		const text = await response.text()
+		if (!response.ok)
+			return { success: false, message: text || response.statusText }
+
+		return { success: true, data: text }
+	}
 }
 
-export async function changePassword(username, currentPassword, newPassword) {
-	return callApi('change-password', 'POST', { username, currentPassword, newPassword })
+export async function getUserStats() {
+	return callApi('stats', 'GET')
 }
 
-export async function viewDevices(username) {
-	return callApi('view-devices', 'POST', { username })
+export async function changePassword(currentPassword, newPassword) {
+	return callApi('change_password', 'POST', { currentPassword, newPassword })
 }
 
-export async function revokeDevice(username, deviceId) {
-	return callApi('revoke-device', 'POST', { username, deviceId })
+export async function getDevices() {
+	return callApi('devices', 'GET')
 }
 
-export async function renameUser(currentUsername, newUsername) {
-	return callApi('rename-user', 'POST', { currentUsername, newUsername })
+export async function revokeDevice(tokenJti, password) {
+	return callApi('revoke_device', 'POST', { tokenJti, password })
 }
 
-export async function deleteAccount(username, password) {
-	return callApi('delete-account', 'POST', { username, password })
+export async function renameUser(newUsername, password) {
+	return callApi('rename_user', 'POST', { newUsername, password })
+}
+
+export async function deleteAccount(password) {
+	return callApi('delete_account', 'POST', { password })
+}
+
+// 新增：登出用户的API调用
+export async function logoutUser() {
+	return callApi('logout', 'POST') // 不需要 body
 }

--- a/src/public/shells/user_settings/src/server/endpoints.mjs
+++ b/src/public/shells/user_settings/src/server/endpoints.mjs
@@ -1,0 +1,160 @@
+import {
+	authenticate, getUserByReq,
+	changeUserPassword, revokeUserDeviceByJti,
+	renameUser, deleteUserAccount,
+	getUserDictionary, getUserByUsername as getUserConfig,
+	logout as authLogout // 导入 auth.mjs 中的 logout 函数
+} from '../../../../../server/auth.mjs'
+import { REFRESH_TOKEN_EXPIRY_DURATION } from '../../../../../server/auth.mjs'
+import fs_promises from 'node:fs/promises'
+import path from 'node:path'
+import { ms } from '../../../../../scripts/ms.mjs'
+
+// Helper to calculate directory size
+async function getDirectorySize(directoryPath) {
+	let totalSize = 0
+	try {
+		const dirents = await fs_promises.readdir(directoryPath, { withFileTypes: true })
+		for (const dirent of dirents) {
+			const fullPath = path.join(directoryPath, dirent.name)
+			if (dirent.isDirectory())
+				totalSize += await getDirectorySize(fullPath)
+			else if (dirent.isFile())
+				try {
+					const stats = await fs_promises.stat(fullPath)
+					totalSize += stats.size
+				} catch (statError) {
+					// console.warn(`Could not stat file ${fullPath}: ${statError.message}`);
+				}
+
+		}
+	} catch (error) {
+		if (error.code !== 'ENOENT') console.warn(`Error calculating size for ${directoryPath}: ${error.message}`)
+		return 0
+	}
+	return totalSize
+}
+
+function formatBytes(bytes, decimals = 2) {
+	if (bytes === 0) return '0 Bytes'
+	const k = 1024
+	const dm = decimals < 0 ? 0 : decimals
+	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']
+	const i = Math.floor(Math.log(bytes) / Math.log(k))
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+}
+
+
+export function setEndpoints(router) {
+	router.get('/api/shells/user_settings/stats', authenticate, async (req, res) => {
+		const userReqData = await getUserByReq(req)
+		if (!userReqData) return res.status(401).json({ success: false, message: 'Unauthorized' })
+
+		const userFullConfig = getUserConfig(userReqData.username)
+		const userDirectory = getUserDictionary(userReqData.username)
+
+		try {
+			let creationDate = userFullConfig?.createdAt || Date.now()
+			try {
+				const dirStats = await fs_promises.stat(userDirectory)
+				if (!userFullConfig?.createdAt && dirStats?.birthtimeMs) creationDate = dirStats.birthtimeMs
+			} catch (dirError) { /* Dir might not exist yet, use now or config */ }
+
+			const folderSizeNum = await getDirectorySize(userDirectory)
+			const folderSize = formatBytes(folderSizeNum)
+
+			res.json({
+				success: true,
+				username: userReqData.username,
+				creationDate,
+				folderSize,
+				folderPath: userDirectory
+			})
+		} catch (error) {
+			console.error('User Settings Shell: Error fetching user stats:', error)
+			res.status(500).json({ success: false, message: 'Error fetching user statistics.' })
+		}
+	})
+
+	router.post('/api/shells/user_settings/change_password', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		if (!user) return res.status(401).json({ success: false, message: 'Unauthorized' })
+		const { currentPassword, newPassword } = req.body
+		if (!currentPassword || !newPassword) return res.status(400).json({ success: false, message: 'Missing fields.' })
+
+		const result = await changeUserPassword(user.username, currentPassword, newPassword)
+		res.status(result.success ? 200 : (result.message.includes('Invalid current password') ? 401 : 400) ).json(result)
+	})
+
+	router.get('/api/shells/user_settings/devices', authenticate, async (req, res) => {
+		const userReqData = await getUserByReq(req)
+		if (!userReqData) return res.status(401).json({ success: false, message: 'Unauthorized' })
+
+		const userFullConfig = getUserConfig(userReqData.username)
+		// let currentRefreshTokenJti = null // 这个信息现在由客户端自行判断或从服务端获取后比较
+		// try {
+		// 	const refreshTokenCookie = req.cookies.refreshToken
+		// 	if (refreshTokenCookie) currentRefreshTokenJti = jose.decodeJwt(refreshTokenCookie)?.jti
+		// } catch(e) { /* ignore */ }
+
+		if (!userFullConfig?.auth?.refreshTokens)
+			return res.json({ success: true, devices: [] })
+
+		const devices = userFullConfig.auth.refreshTokens.map(token => ({
+			deviceId: token.deviceId,
+			jti: token.jti,
+			expiry: token.expiry,
+			lastSeen: token.lastSeen || (token.expiry - ms(REFRESH_TOKEN_EXPIRY_DURATION)),
+			ipAddress: token.ipAddress,
+			userAgent: token.userAgent,
+		})).sort((a,b) => (b.lastSeen || 0) - (a.lastSeen || 0) )
+
+		res.json({ success: true, devices })
+	})
+
+	router.post('/api/shells/user_settings/revoke_device', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		if (!user) return res.status(401).json({ success: false, message: 'Unauthorized' })
+		const { tokenJti, password } = req.body
+		if (!tokenJti || !password) return res.status(400).json({ success: false, message: 'Token JTI and password required.' })
+
+		const result = await revokeUserDeviceByJti(user.username, tokenJti, password)
+		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+	})
+
+	router.post('/api/shells/user_settings/rename_user', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		if (!user) return res.status(401).json({ success: false, message: 'Unauthorized' })
+		const { newUsername, password } = req.body
+		if (!newUsername || !password) return res.status(400).json({ success: false, message: 'New username and password required.' })
+
+		const result = await renameUser(user.username, newUsername, password)
+		if (result.success) {
+			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+		}
+		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+	})
+
+	router.post('/api/shells/user_settings/delete_account', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		if (!user) return res.status(401).json({ success: false, message: 'Unauthorized' })
+		const { password } = req.body
+		if (!password) return res.status(400).json({ success: false, message: 'Password required.' })
+
+		const result = await deleteUserAccount(user.username, password)
+		if (result.success) {
+			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+		}
+		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+	})
+
+	// 新增：登出API端点
+	// authenticate 中间件会确保 req.user 和 cookie 信息是有效的
+	router.post('/api/shells/user_settings/logout', authenticate, async (req, res) => {
+		// authLogout 函数期望 req 和 res 对象，它会处理 token 撤销和 cookie 清理
+		await authLogout(req, res)
+		// authLogout 内部会发送响应，所以这里不需要再发送
+	})
+}

--- a/src/public/shells/user_settings/src/server/endpoints.mjs
+++ b/src/public/shells/user_settings/src/server/endpoints.mjs
@@ -83,7 +83,7 @@ export function setEndpoints(router) {
 		if (!currentPassword || !newPassword) return res.status(400).json({ success: false, message: 'Missing fields.' })
 
 		const result = await changeUserPassword(user.username, currentPassword, newPassword)
-		res.status(result.success ? 200 : result.message.includes('Invalid current password') ? 401 : 400 ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid current password') ? 401 : 400).json(result)
 	})
 
 	router.get('/api/shells/user_settings/devices', authenticate, async (req, res) => {
@@ -107,7 +107,7 @@ export function setEndpoints(router) {
 			lastSeen: token.lastSeen || (token.expiry - ms(REFRESH_TOKEN_EXPIRY_DURATION)),
 			ipAddress: token.ipAddress,
 			userAgent: token.userAgent,
-		})).sort((a,b) => (b.lastSeen || 0) - (a.lastSeen || 0) )
+		})).sort((a, b) => (b.lastSeen || 0) - (a.lastSeen || 0))
 
 		res.json({ success: true, devices })
 	})
@@ -119,7 +119,7 @@ export function setEndpoints(router) {
 		if (!tokenJti || !password) return res.status(400).json({ success: false, message: 'Token JTI and password required.' })
 
 		const result = await revokeUserDeviceByJti(user.username, tokenJti, password)
-		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400).json(result)
 	})
 
 	router.post('/api/shells/user_settings/rename_user', authenticate, async (req, res) => {
@@ -133,7 +133,7 @@ export function setEndpoints(router) {
 			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 		}
-		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400).json(result)
 	})
 
 	router.post('/api/shells/user_settings/delete_account', authenticate, async (req, res) => {
@@ -147,7 +147,7 @@ export function setEndpoints(router) {
 			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 		}
-		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400).json(result)
 	})
 
 	// 新增：登出API端点

--- a/src/public/shells/user_settings/src/server/endpoints.mjs
+++ b/src/public/shells/user_settings/src/server/endpoints.mjs
@@ -83,7 +83,7 @@ export function setEndpoints(router) {
 		if (!currentPassword || !newPassword) return res.status(400).json({ success: false, message: 'Missing fields.' })
 
 		const result = await changeUserPassword(user.username, currentPassword, newPassword)
-		res.status(result.success ? 200 : (result.message.includes('Invalid current password') ? 401 : 400) ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid current password') ? 401 : 400 ).json(result)
 	})
 
 	router.get('/api/shells/user_settings/devices', authenticate, async (req, res) => {
@@ -119,7 +119,7 @@ export function setEndpoints(router) {
 		if (!tokenJti || !password) return res.status(400).json({ success: false, message: 'Token JTI and password required.' })
 
 		const result = await revokeUserDeviceByJti(user.username, tokenJti, password)
-		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
 	})
 
 	router.post('/api/shells/user_settings/rename_user', authenticate, async (req, res) => {
@@ -133,7 +133,7 @@ export function setEndpoints(router) {
 			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 		}
-		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
 	})
 
 	router.post('/api/shells/user_settings/delete_account', authenticate, async (req, res) => {
@@ -147,7 +147,7 @@ export function setEndpoints(router) {
 			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 		}
-		res.status(result.success ? 200 : (result.message.includes('Invalid password') ? 401 : 400) ).json(result)
+		res.status(result.success ? 200 : result.message.includes('Invalid password') ? 401 : 400 ).json(result)
 	})
 
 	// 新增：登出API端点

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -449,7 +449,7 @@ export async function deleteUserAccount(username, password) {
 
 	const { userId } = user.auth // 在删除用户前获取 userId
 	const userDirectoryPath = getUserDictionary(username) // 在从配置中删除用户前获取路径
-	events.emit('BeforeUserDeleted', { username, userId: user.auth.userId, userDirectoryPath })
+	await events.emit('BeforeUserDeleted', { username })
 
 	// 撤销用户所有的 refresh tokens
 	if (user.auth.refreshTokens && user.auth.refreshTokens.length > 0)
@@ -466,8 +466,7 @@ export async function deleteUserAccount(username, password) {
 	delete config.data.users[username]
 	save_config()
 
-	// 发出 userDeleted 事件，并附带用户目录路径，供其他模块处理数据清理
-	events.emit('AfterUserDeleted', { username, userId, userDirectoryPath })
+	await events.emit('AfterUserDeleted', { username })
 
 	return { success: true, message: 'User account deleted successfully. Associated data will be cleaned up.' }
 }
@@ -499,7 +498,7 @@ export async function renameUser(currentUsername, newUsername, password) {
 	if (getUserByUsername(newUsername))
 		return { success: false, message: 'New username already exists' }
 
-	events.emit('BeforeUserRenamed', { oldUsername: currentUsername, newUsername, userId: oldUserConfigEntry.auth.userId, newUserData: oldUserConfigEntry })
+	await events.emit('BeforeUserRenamed', { oldUsername: currentUsername, newUsername })
 
 	const oldUserPath = getUserDictionary(currentUsername) // 获取旧路径
 
@@ -537,11 +536,9 @@ export async function renameUser(currentUsername, newUsername, password) {
 	delete config.data.users[currentUsername]
 	save_config()
 
-	events.emit('AfterUserRenamed', {
+	await events.emit('AfterUserRenamed', {
 		oldUsername: currentUsername,
 		newUsername,
-		userId: newUserConfigEntry.auth.userId,
-		newUserData: newUserConfigEntry
 	})
 
 	return { success: true, message: 'Username renamed successfully and user data directory potentially moved.' }

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -2,23 +2,27 @@ import * as jose from 'npm:jose'
 import fs from 'node:fs'
 import fse from 'npm:fs-extra@^11.0.0'
 import crypto from 'node:crypto'
-import { config, save_config, __dirname } from './server.mjs'
+import { config, save_config, __dirname } from './server.mjs' // 假设 server.mjs 在同级目录
 import path from 'node:path'
 import argon2 from 'npm:argon2'
-import { ms } from '../scripts/ms.mjs'
-import { geti18n } from '../scripts/i18n.mjs'
-import { is_local_ip_from_req } from '../scripts/ratelimit.mjs'
-import { loadJsonFile } from '../scripts/json_loader.mjs'
-import { events } from './events.mjs'
+import { ms } from '../scripts/ms.mjs' // 确保路径正确
+import { geti18n } from '../scripts/i18n.mjs' // 确保路径正确
+// 确保路径正确
+import { loadJsonFile } from '../scripts/json_loader.mjs' // 确保路径正确
+import { events } from './events.mjs' // 假设 events.mjs 在同级目录
 
-const ACCESS_TOKEN_EXPIRY = '15m'
-const REFRESH_TOKEN_EXPIRY = '30d'
-const ACCOUNT_LOCK_TIME = '10m'
-const MAX_LOGIN_ATTEMPTS = 3
+const ACCESS_TOKEN_EXPIRY = '15m' // Access Token 有效期
+export const REFRESH_TOKEN_EXPIRY = '30d' // Refresh Token 有效期 (字符串形式)
+export const REFRESH_TOKEN_EXPIRY_DURATION = ms(REFRESH_TOKEN_EXPIRY) // Refresh Token 有效期 (毫秒数)
+const ACCOUNT_LOCK_TIME = '10m' // 账户锁定时间
+const MAX_LOGIN_ATTEMPTS = 3 // 最大登录尝试次数
 
-let privateKey, publicKey
+let privateKey, publicKey // 用于JWT签名的密钥对
 
-export async function initAuth(config) {
+/**
+ * 初始化认证模块，加载或生成密钥对
+ */
+export async function initAuth() { // config 参数已从全局 config 替代
 	if (!config.privateKey || !config.publicKey) {
 		const { privateKey: newPrivateKey, publicKey: newPublicKey } = crypto.generateKeyPairSync('ec', {
 			namedCurve: 'prime256v1',
@@ -49,9 +53,11 @@ export async function initAuth(config) {
 
 /**
  * 生成 JWT (Access Token)
+ * @param {object} payload - 令牌的有效载荷
+ * @returns {Promise<string>} Access Token
  */
 export async function generateAccessToken(payload) {
-	const jti = crypto.randomUUID() // Generate a unique identifier for the access token
+	const jti = crypto.randomUUID() // 为 Access Token 生成唯一标识符
 	return await new jose.SignJWT({ ...payload, jti })
 		.setProtectedHeader({ alg: 'ES256' })
 		.setIssuedAt()
@@ -63,10 +69,18 @@ export async function generateAccessToken(payload) {
  * 生成刷新令牌 (Refresh Token)
  * @param {object} payload - 令牌的有效载荷
  * @param {string} deviceId - 设备的唯一标识符
+ * @param {object} req - Express请求对象，用于获取IP和User-Agent
+ * @returns {Promise<string>} Refresh Token
  */
-async function generateRefreshToken(payload, deviceId = 'unknown') {
-	const refreshTokenId = crypto.randomUUID()
-	return await new jose.SignJWT({ ...payload, jti: refreshTokenId, deviceId })
+async function generateRefreshToken(payload, deviceId = 'unknown', req) {
+	const refreshTokenId = crypto.randomUUID() // JTI for refresh token
+	const tokenPayload = {
+		...payload,
+		jti: refreshTokenId,
+		deviceId,
+	}
+	// 不直接在 JWT payload 中存储 IP 和 UserAgent，这些信息存储在服务器端的 refreshTokens 数组中
+	return await new jose.SignJWT(tokenPayload)
 		.setProtectedHeader({ alg: 'ES256' })
 		.setIssuedAt()
 		.setExpirationTime(REFRESH_TOKEN_EXPIRY)
@@ -75,12 +89,19 @@ async function generateRefreshToken(payload, deviceId = 'unknown') {
 
 /**
  * 验证 JWT (包括 Access Token 和 Refresh Token)
+ * @param {string} token - 要验证的 JWT
+ * @returns {Promise<object|null>} 解码后的 payload 或 null
  */
 async function verifyToken(token) {
 	try {
 		const { payload } = await jose.jwtVerify(token, publicKey, {
 			algorithms: ['ES256'],
 		})
+		// 检查令牌是否已被撤销 (针对 access token 和 refresh token 统一检查)
+		if (config.data.revokedTokens[payload.jti]) {
+			console.warn(await geti18n('fountConsole.auth.tokenRevoked', { jti: payload.jti }))
+			return null
+		}
 		return payload
 	} catch (error) {
 		console.error(await geti18n('fountConsole.auth.tokenVerifyError', { error }))
@@ -90,178 +111,252 @@ async function verifyToken(token) {
 
 /**
  * 刷新 Access Token
+ * @param {string} refreshTokenValue - 客户端传入的 Refresh Token
+ * @param {object} req - Express 请求对象, 用于获取 IP 和 User-Agent
+ * @returns {Promise<object>} 包含状态码、新令牌或错误消息的对象
  */
-async function refresh(refreshToken) {
+async function refresh(refreshTokenValue, req) {
 	try {
-		const decoded = await verifyToken(refreshToken)
-		if (!decoded) return { status: 401, message: 'Invalid refresh token' }
+		const decoded = await verifyToken(refreshTokenValue) // verifyToken 内部已检查全局 revokedTokens
+		if (!decoded) return { status: 401, success: false, message: 'Invalid or revoked refresh token' }
 
 		const user = getUserByUsername(decoded.username)
-		const userRefreshToken = user?.auth.refreshTokens.find((token) => token.jti === decoded.jti)
+		if (!user || !user.auth || !user.auth.refreshTokens)
+			return { status: 401, success: false, message: 'User not found or refresh tokens unavailable' }
 
-		// 验证 refreshToken 是否存在、是否被撤销以及 deviceId 是否匹配（过期问题已被verifyToken验证）
-		if (!user || !userRefreshToken || config.data.revokedTokens[decoded.jti] || userRefreshToken.deviceId !== decoded.deviceId)
-			return { status: 401, message: 'Invalid refresh token' }
+		const userRefreshTokenEntry = user.auth.refreshTokens.find((token) => token.jti === decoded.jti)
 
-		// 生成新的 access token 和 refresh token
+		// 再次验证 refreshToken 是否存在于用户记录中，以及 deviceId 是否匹配
+		if (!userRefreshTokenEntry || userRefreshTokenEntry.deviceId !== decoded.deviceId) {
+			// 如果 JTI 存在于用户记录中但 deviceId 不匹配，这可能是一个安全问题，撤销该 JTI
+			if (userRefreshTokenEntry)
+				await revokeToken(refreshTokenValue, 'refresh-device-mismatch')
+
+			return { status: 401, success: false, message: 'Refresh token not found for user or device mismatch' }
+		}
+
+		// 更新 lastSeen, ipAddress, userAgent for the current token entry
+		userRefreshTokenEntry.lastSeen = Date.now()
+		if (req?.ip) userRefreshTokenEntry.ipAddress = req.ip
+		if (req?.headers?.['user-agent']) userRefreshTokenEntry.userAgent = req.headers['user-agent']
+
+		// 生成新的 access token
 		const accessToken = await generateAccessToken({ username: decoded.username, userId: decoded.userId })
-		const newRefreshToken = await generateRefreshToken({ username: decoded.username, userId: decoded.userId }, userRefreshToken.deviceId)
-		const decodedNewRefreshToken = jose.decodeJwt(newRefreshToken) // 解码 newRefreshToken
 
+		// (可选) 滚动刷新 Refresh Token：生成新的 Refresh Token，并使旧的失效
+		// 为了简化，并减少客户端状态管理，这里可以不滚动刷新 Refresh Token，而是沿用旧的，直到它过期
+		// 如果决定滚动：
+		const newRefreshToken = await generateRefreshToken({ username: decoded.username, userId: decoded.userId }, userRefreshTokenEntry.deviceId, req);
+		const decodedNewRefreshToken = jose.decodeJwt(newRefreshToken);
 		// 移除旧的 refreshToken，添加新的 refreshToken
-		user.auth.refreshTokens = user.auth.refreshTokens.filter((token) => token.jti !== decoded.jti)
+		user.auth.refreshTokens = user.auth.refreshTokens.filter((token) => token.jti !== decoded.jti);
 		user.auth.refreshTokens.push({
 			jti: decodedNewRefreshToken.jti,
-			deviceId: userRefreshToken.deviceId,
-			expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY),
-		})
-		save_config()
-
-		return { status: 200, accessToken, refreshToken: newRefreshToken }
+			deviceId: userRefreshTokenEntry.deviceId,
+			expiry: decodedNewRefreshToken.exp * 1000, // 从JWT payload获取过期时间
+			ipAddress: req?.ip,
+			userAgent: req?.headers?.['user-agent'],
+			lastSeen: Date.now()
+		});
+		save_config();
+		return { status: 200, success: true, accessToken, refreshToken: newRefreshToken };
 	} catch (error) {
-		console.error(await geti18n('fountConsole.auth.refreshTokenError', { error }))
-		return { status: 401, message: 'Invalid refresh token' }
+		console.error(await geti18n('fountConsole.auth.refreshTokenError', { error: error.message }))
+		return { status: 401, success: false, message: 'Error refreshing token' }
 	}
 }
 
 /**
  * 用户登出
+ * @param {object} req - Express 请求对象
+ * @param {object} res - Express 响应对象
  */
 export async function logout(req, res) {
-	const { user, cookies: { accessToken, refreshToken } } = req
+	const { cookies: { accessToken, refreshToken } } = req
+	const user = await getUserByReq(req) // 使用 getUserByReq 获取用户信息
 
-	if (accessToken) {
-		// 将 accessToken 添加到 revokedTokens 中
-		const decodedAccessToken = await jose.decodeJwt(accessToken)
-		if (decodedAccessToken && decodedAccessToken.exp)
-			config.data.revokedTokens[decodedAccessToken.jti] = { expiry: decodedAccessToken.exp * 1000, type: 'access' }
+	if (accessToken)
+		await revokeToken(accessToken, 'access-logout')
+
+
+	if (refreshToken && user) {
+		const userConfig = getUserByUsername(user.username) // 获取完整的用户配置
+		if (userConfig?.auth?.refreshTokens)
+			try {
+				const decodedRefreshToken = await jose.decodeJwt(refreshToken) // 仅解码，不验证，因为可能已过期但仍需从用户列表中移除
+				if (decodedRefreshToken?.jti) {
+					// 从用户的 refreshToken 列表中移除当前的 refreshToken
+					const tokenIndex = userConfig.auth.refreshTokens.findIndex((token) => token.jti === decodedRefreshToken.jti)
+					if (tokenIndex !== -1)
+						userConfig.auth.refreshTokens.splice(tokenIndex, 1)
+
+					// 将其添加到全局 revokedTokens
+					await revokeToken(refreshToken, 'refresh-logout')
+				}
+			} catch (error) {
+				console.error(await geti18n('fountConsole.auth.logoutRefreshTokenProcessError', { error: error.message }))
+			}
+
 	}
 
-	if (refreshToken && user)
-		try {
-			const decodedRefreshToken = await verifyToken(refreshToken)
-			if (decodedRefreshToken) {
-				// 从用户的 refreshToken 列表中移除当前的 refreshToken，并将其添加到 revokedTokens
-				const userRefreshTokenIndex = user.auth.refreshTokens.findIndex((token) => token.jti === decodedRefreshToken.jti)
-				if (userRefreshTokenIndex !== -1) {
-					user.auth.refreshTokens.splice(userRefreshTokenIndex, 1)
-					config.data.revokedTokens[decodedRefreshToken.jti] = { expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY), type: 'refresh' }
-				}
-			}
-		} catch (error) {
-			console.error(await geti18n('fountConsole.auth.logoutRefreshTokenProcessError', { error }))
-		}
-
-	res.clearCookie('accessToken')
-	res.clearCookie('refreshToken')
+	res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+	res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
 	save_config()
-	res.status(200).json({ message: 'Logout successful' })
+	res.status(200).json({ success: true, message: 'Logout successful' })
 }
 
 /**
  * 身份验证中间件
+ * @param {object} req - Express 请求对象
+ * @param {object} res - Express 响应对象
+ * @param {function} next - Express next middleware 函数
  */
 export async function authenticate(req, res, next) {
 	const { accessToken, refreshToken } = req.cookies
 
-	const Unauthorized = () => {
+	const Unauthorized = (message = 'Unauthorized') => {
 		const path = encodeURIComponent(req.originalUrl)
-		if (req.accepts('html')) return res.redirect('/login?redirect=' + path)
-		return res.status(401).json({ message: 'Unauthorized' })
+		if (req.accepts('html') && req.method === 'GET') return res.redirect(`/login?redirect=${path}`) // 只对GET HTML请求重定向
+		return res.status(401).json({ success: false, message })
 	}
+
 	if (!accessToken) return Unauthorized()
 
-	// 本地 IP
-	if (is_local_ip_from_req(req)) {
-		// 解密 accessToken而无需验证
-		const decoded = await jose.decodeJwt(accessToken)
-		if (config.data.users[decoded.username])
-			return next()
-		return Unauthorized()
-	}
+	// 本地 IP 特权（如果需要，但通常不推荐完全跳过验证）
+	// if (is_local_ip_from_req(req)) {
+	//     const decoded = await jose.decodeJwt(accessToken); // 仅解码
+	//     if (decoded && config.data.users[decoded.username]) {
+	//         req.user = { username: decoded.username, userId: decoded.userId || config.data.users[decoded.username].auth.userId };
+	//         return next();
+	//     }
+	// }
 
-	let decoded = await verifyToken(accessToken)
+	let decodedAccessToken = await verifyToken(accessToken)
 
-	if (!decoded) {
-		// accessToken 无效，尝试使用 refreshToken 刷新
-		if (!refreshToken) return Unauthorized()
+	if (!decodedAccessToken) {
+		// accessToken 无效或已过期，尝试使用 refreshToken 刷新
+		if (!refreshToken) return Unauthorized('Access token invalid, no refresh token provided.')
 
-		const refreshResult = await refresh(refreshToken)
-		if (refreshResult.status !== 200) {
+		const refreshResult = await refresh(refreshToken, req) // 传入 req
+		if (refreshResult.status !== 200 || !refreshResult.success) {
 			// refreshToken 也无效，需要重新登录
-			res.clearCookie('accessToken')
-			res.clearCookie('refreshToken')
-			return Unauthorized()
+			res.clearCookie('accessToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+			res.clearCookie('refreshToken', { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+			return Unauthorized(refreshResult.message || 'Session expired, please login again.')
 		}
 
 		// 刷新成功，设置新的 accessToken 和 refreshToken 到 Cookie
-		const newAccessToken = refreshResult.accessToken
-		const newRefreshToken = refreshResult.refreshToken
-		res.cookie('accessToken', newAccessToken, { httpOnly: true, secure: false })
-		res.cookie('refreshToken', newRefreshToken, { httpOnly: true, secure: false })
-		req.cookies.accessToken = newAccessToken
-		req.cookies.refreshToken = newRefreshToken
+		res.cookie('accessToken', refreshResult.accessToken, { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+		// 如果 refresh token 被滚动了，也需要更新 cookie
+		if (refreshResult.refreshToken !== refreshToken)
+			res.cookie('refreshToken', refreshResult.refreshToken, { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https', sameSite: 'Lax' })
+
+
+		req.cookies.accessToken = refreshResult.accessToken // 更新当前请求的cookies对象，供后续逻辑使用
+		// req.cookies.refreshToken = refreshResult.refreshToken; // 如果滚动了，也更新
 
 		// 使用新的 accessToken 重新验证
-		decoded = await verifyToken(newAccessToken)
+		decodedAccessToken = await verifyToken(refreshResult.accessToken)
+		if (!decodedAccessToken) return Unauthorized('Failed to verify newly refreshed token.') // 安全检查
 	}
 
-	req.user = decoded
+	req.user = { username: decodedAccessToken.username, userId: decodedAccessToken.userId }
 	next()
 }
 
 /**
  * 撤销令牌 (将 Access Token 或 Refresh Token 添加到撤销列表)
+ * @param {string} token - 要撤销的令牌
+ * @param {string} typeSuffix - 撤销原因的后缀 (e.g., 'logout', 'manual')
  */
-async function revokeToken(token) {
-	const decoded = await jose.decodeJwt(token)
-	if (!decoded || !decoded.jti) return console.error(await geti18n('fountConsole.auth.revokeTokenNoJTI'))
-	const tokenType = decoded.exp ? decoded.exp * 1000 - Date.now() > ms(ACCESS_TOKEN_EXPIRY) ? 'refresh' : 'access' : 'unknown'
+async function revokeToken(token, typeSuffix = 'unknown') {
+	try {
+		const decoded = await jose.decodeJwt(token) // 仅解码以获取 jti 和 exp
+		if (!decoded || !decoded.jti) {
+			console.error(await geti18n('fountConsole.auth.revokeTokenNoJTI'))
+			return
+		}
 
-	if (decoded && decoded.exp) {
-		config.data.revokedTokens[decoded.jti] = { expiry: decoded.exp * 1000, type: tokenType }
+		const tokenType = decoded.exp ?
+			decoded.exp * 1000 - (decoded.iat ? decoded.iat * 1000 : Date.now() - ms('1m')) > ms(ACCESS_TOKEN_EXPIRY) + ms('1m') ? 'refresh' : 'access'
+			: 'unknown' // 尝试根据典型有效期猜测类型
+
+		const expiry = decoded.exp ? decoded.exp * 1000 : Date.now() + ms(REFRESH_TOKEN_EXPIRY) // 如果没有exp，假设是长期有效的需要被记录
+
+		config.data.revokedTokens[decoded.jti] = {
+			expiry,
+			type: `${tokenType}-${typeSuffix}`,
+			revokedAt: Date.now()
+		}
 		save_config()
+	} catch (e) {
+		console.error(`Error decoding token for revocation: ${e.message}`)
 	}
 }
 
 /**
- * 通过用户名获取用户信息
+ * 通过用户名获取完整的用户信息对象
+ * @param {string} username - 用户名
+ * @returns {object|undefined} 用户对象或 undefined
  */
 export function getUserByUsername(username) {
 	return config.data.users[username]
 }
 
+/**
+ * 获取所有用户名列表
+ * @returns {string[]}
+ */
 export function getAllUserNames() {
 	return Object.keys(config.data.users)
 }
 
+/**
+ * 获取所有用户对象的字典
+ * @returns {object}
+ */
 export function getAllUsers() {
 	return config.data.users
 }
 
 /**
  * 创建新用户
+ * @param {string} username - 用户名
+ * @param {string} password - 密码
+ * @returns {Promise<object>} 创建的用户对象 (包含 userId)
  */
 async function createUser(username, password) {
 	const hashedPassword = await hashPassword(password)
 	const userId = crypto.randomUUID()
+	const now = Date.now()
 	config.data.users[username] = {
 		username,
+		createdAt: now, // 添加 createdAt 字段
 		auth: {
 			userId,
 			password: hashedPassword,
 			loginAttempts: 0,
 			lockedUntil: null,
-			refreshTokens: [],
+			refreshTokens: [], // 初始化 refreshTokens 数组
 		},
-		...loadJsonFile(__dirname + '/default/templates/user.json'),
+		// 合并默认用户模板，确保 createdAt 和 auth 中的核心字段不被覆盖
+		...loadJsonFile(path.join(__dirname, 'default', 'templates', 'user.json'))
 	}
+	// 再次确保核心字段
+	config.data.users[username].username = username
+	config.data.users[username].createdAt = now
+	config.data.users[username].auth.userId = userId
+	config.data.users[username].auth.password = hashedPassword
+
+
 	save_config()
-	return { ...config.data.users[username], userId }
+	return { ...config.data.users[username], userId } // 返回包含userId的完整用户对象
 }
 
 /**
  * 使用 Argon2id 哈希密码
+ * @param {string} password - 明文密码
+ * @returns {Promise<string>} 哈希后的密码
  */
 export async function hashPassword(password) {
 	return await argon2.hash(password, { type: argon2.argon2id })
@@ -269,14 +364,25 @@ export async function hashPassword(password) {
 
 /**
  * 验证密码
+ * @param {string} password - 用户输入的明文密码
+ * @param {string} hashedPassword - 存储的哈希密码
+ * @returns {Promise<boolean>} 密码是否匹配
  */
 export async function verifyPassword(password, hashedPassword) {
+	if (!password || !hashedPassword) return false
 	return await argon2.verify(hashedPassword, password)
 }
 
+/**
+ * 修改用户密码
+ * @param {string} username - 用户名
+ * @param {string} currentPassword - 当前密码
+ * @param {string} newPassword - 新密码
+ * @returns {Promise<object>} 操作结果 { success: boolean, message: string }
+ */
 export async function changeUserPassword(username, currentPassword, newPassword) {
 	const user = getUserByUsername(username)
-	if (!user) return { success: false, message: 'User not found' }
+	if (!user || !user.auth) return { success: false, message: 'User not found' }
 
 	const isValidPassword = await verifyPassword(currentPassword, user.auth.password)
 	if (!isValidPassword) return { success: false, message: 'Invalid current password' }
@@ -286,93 +392,136 @@ export async function changeUserPassword(username, currentPassword, newPassword)
 	return { success: true, message: 'Password changed successfully' }
 }
 
-export async function revokeUserDevice(username, deviceId) {
-	const user = getUserByUsername(username)
-	if (!user || !user.auth || !user.auth.refreshTokens) 
-		return { success: false, message: 'User or device list not found' }
-	
 
-	const tokenIndex = user.auth.refreshTokens.findIndex(token => token.deviceId === deviceId || token.jti === deviceId)
-	if (tokenIndex === -1) 
-		return { success: false, message: 'Device not found for this user' }
-	
+/**
+ * 根据 JTI 撤销用户的某个设备（Refresh Token）
+ * 需要用户密码进行验证
+ * @param {string} username - 用户名
+ * @param {string} tokenJti - 要撤销的 Refresh Token 的 JTI
+ * @param {string} password - 用户密码，用于验证操作权限
+ * @returns {Promise<object>} 操作结果 { success: boolean, message: string }
+ */
+export async function revokeUserDeviceByJti(username, tokenJti, password) {
+	const user = getUserByUsername(username)
+	if (!user || !user.auth || !user.auth.refreshTokens)
+		return { success: false, message: 'User or device list not found' }
+
+
+	// 验证用户密码
+	const isValidPassword = await verifyPassword(password, user.auth.password)
+	if (!isValidPassword)
+		return { success: false, message: 'Invalid password for user action' }
+
+
+	const tokenIndex = user.auth.refreshTokens.findIndex(token => token.jti === tokenJti)
+	if (tokenIndex === -1)
+		return { success: false, message: 'Device (JTI) not found for this user' }
+
 
 	const revokedToken = user.auth.refreshTokens.splice(tokenIndex, 1)[0]
-	// Add to global revoked list if your system requires it by jti
-	if (revokedToken && revokedToken.jti) 
-		config.data.revokedTokens[revokedToken.jti] = { expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY), type: 'refresh-revoked-manual' } // Or use actual expiry if preferred
-	
+	if (revokedToken && revokedToken.jti)
+		// 全局撤销这个JTI
+		config.data.revokedTokens[revokedToken.jti] = {
+			expiry: Date.now() + REFRESH_TOKEN_EXPIRY_DURATION, // 或使用 token.expiry
+			type: 'refresh-revoked-by-user-jti',
+			revokedAt: Date.now()
+		}
+
+
 	save_config()
-	return { success: true, message: 'Device access revoked successfully' }
+	return { success: true, message: 'Device access (JTI) revoked successfully' }
 }
 
+/**
+ * 删除用户账户及数据，需要密码验证
+ * @param {string} username - 要删除的用户名
+ * @param {string} password - 用户密码
+ * @returns {Promise<object>} 操作结果 { success: boolean, message: string }
+ */
 export async function deleteUserAccount(username, password) {
 	const user = getUserByUsername(username)
-	if (!user) return { success: false, message: 'User not found' }
+	if (!user || !user.auth)
+		return { success: false, message: 'User not found.' }
+
 
 	const isValidPassword = await verifyPassword(password, user.auth.password)
-	if (!isValidPassword) return { success: false, message: 'Invalid password' }
+	if (!isValidPassword)
+		return { success: false, message: 'Invalid password for deleting account.' }
 
-	const {userId} = user.auth // Get userId before deleting user
-	const userDirectoryPath = getUserDictionary(username) // Get path BEFORE deleting user from config
+	const { userId } = user.auth // 在删除用户前获取 userId
+	const userDirectoryPath = getUserDictionary(username) // 在从配置中删除用户前获取路径
+	events.emit('BeforeUserDeleted', { username, userId: user.auth.userId, userDirectoryPath })
 
-	// Revoke all refresh tokens for the user
-	if (user.auth.refreshTokens && user.auth.refreshTokens.length > 0) 
+	// 撤销用户所有的 refresh tokens
+	if (user.auth.refreshTokens && user.auth.refreshTokens.length > 0)
 		user.auth.refreshTokens.forEach(token => {
-			if (token.jti) 
-				config.data.revokedTokens[token.jti] = { expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY), type: 'refresh-revoked-delete' }
-			
+			if (token.jti)
+				config.data.revokedTokens[token.jti] = {
+					expiry: Date.now() + REFRESH_TOKEN_EXPIRY_DURATION,
+					type: 'refresh-revoked-account-delete',
+					revokedAt: Date.now()
+				}
 		})
-	
 
-	// Delete user data from config
+	// 从配置中删除用户数据
 	delete config.data.users[username]
 	save_config()
 
-	// Emit userDeleted event WITH userDirectoryPath
-	events.emit('userDeleted', { username, userId, userDirectoryPath })
+	// 发出 userDeleted 事件，并附带用户目录路径，供其他模块处理数据清理
+	events.emit('AfterUserDeleted', { username, userId, userDirectoryPath })
 
-	return { success: true, message: 'User account deleted successfully' }
+	return { success: true, message: 'User account deleted successfully. Associated data will be cleaned up.' }
 }
 
-export async function renameUser(currentUsername, newUsername) {
-	if (currentUsername === newUsername) 
+/**
+ * 重命名用户账户，需要密码验证
+ * @param {string} currentUsername - 当前用户名
+ * @param {string} newUsername - 新用户名
+ * @param {string} password - 用户密码
+ * @returns {Promise<object>} 操作结果 { success: boolean, message: string }
+ */
+export async function renameUser(currentUsername, newUsername, password) {
+	const user = getUserByUsername(currentUsername)
+	if (!user || !user.auth)
+		return { success: false, message: 'Current user not found.' }
+
+
+	const isValidPassword = await verifyPassword(password, user.auth.password)
+	if (!isValidPassword)
+		return { success: false, message: 'Invalid password for renaming user.' }
+
+	if (currentUsername === newUsername)
 		return { success: false, message: 'New username must be different from the current one.' }
-	
 
 	const oldUserConfigEntry = getUserByUsername(currentUsername)
-	if (!oldUserConfigEntry) 
+	if (!oldUserConfigEntry)
 		return { success: false, message: 'Current user not found' }
-	
 
-	if (getUserByUsername(newUsername)) 
+	if (getUserByUsername(newUsername))
 		return { success: false, message: 'New username already exists' }
-	
 
-	const oldUserPath = getUserDictionary(currentUsername)
+	events.emit('BeforeUserRenamed', { oldUsername: currentUsername, newUsername, userId: oldUserConfigEntry.auth.userId, newUserData: oldUserConfigEntry })
 
+	const oldUserPath = getUserDictionary(currentUsername) // 获取旧路径
+
+	// 深拷贝用户配置
 	const newUserConfigEntry = JSON.parse(JSON.stringify(oldUserConfigEntry))
-	newUserConfigEntry.username = newUsername
-
-	if (newUserConfigEntry.UserDictionary &&
-		typeof newUserConfigEntry.UserDictionary === 'string' &&
-		newUserConfigEntry.UserDictionary.includes(currentUsername)) 
-		newUserConfigEntry.UserDictionary = newUserConfigEntry.UserDictionary.replace(currentUsername, newUsername)
-	
+	newUserConfigEntry.username = newUsername // 更新用户名
 
 	const newUserPath = path.resolve(newUserConfigEntry.UserDictionary || path.join(__dirname, 'data', 'users', newUsername))
 
 	try {
-		if (fse.existsSync(oldUserPath)) 
-			if (oldUserPath.toLowerCase() !== newUserPath.toLowerCase()) {
-				fse.ensureDirSync(path.dirname(newUserPath))
+		if (fse.existsSync(oldUserPath))
+			if (oldUserPath.toLowerCase() !== newUserPath.toLowerCase()) { // 路径不同才移动
+				fse.ensureDirSync(path.dirname(newUserPath)) // 确保目标目录的父目录存在
 				fse.moveSync(oldUserPath, newUserPath, { overwrite: true })
 				console.log(`User data directory moved from ${oldUserPath} to ${newUserPath}`)
-			} else 
-				console.log(`User data directory path is effectively the same, no move needed: ${oldUserPath}`)
-			
-		 else {
+			} else
+				console.log(`User data directory path is effectively the same (case-insensitive), no move needed: ${oldUserPath}`)
+
+		else {
 			console.warn(`Old user data directory not found: ${oldUserPath}. Nothing to move.`)
+			// 即使旧目录不存在，也应确保新目录存在
 			if (!fse.existsSync(newUserPath)) {
 				fse.ensureDirSync(newUserPath)
 				console.log(`Ensured new user data directory exists at: ${newUserPath}`)
@@ -380,116 +529,158 @@ export async function renameUser(currentUsername, newUsername) {
 		}
 	} catch (error) {
 		console.error(`Error moving user data directory from ${oldUserPath} to ${newUserPath}:`, error)
+		// 如果移动失败，不应该保存配置更改，以避免数据和配置不一致
 		return { success: false, message: `Error moving user data directory: ${error.message}. Username change not saved.` }
 	}
 
+	// 更新配置
 	config.data.users[newUsername] = newUserConfigEntry
 	delete config.data.users[currentUsername]
 	save_config()
 
-	events.emit('userRenamed', {
+	events.emit('AfterUserRenamed', {
 		oldUsername: currentUsername,
 		newUsername,
 		userId: newUserConfigEntry.auth.userId,
 		newUserData: newUserConfigEntry
 	})
 
-	return { success: true, message: 'Username renamed successfully and user data directory moved.' }
+	return { success: true, message: 'Username renamed successfully and user data directory potentially moved.' }
 }
 
-async function getUserByToken(token) {
+
+/**
+ * 从请求中获取用户信息（username, userId）
+ * 依赖 authenticate 中间件已填充 req.user
+ * @param {object} req - Express 请求对象
+ * @returns {Promise<object|null>} { username, userId } 或 null
+ */
+export async function getUserByReq(req) {
+	if (req.user && req.user.username && req.user.userId)
+		// 如果 authenticate 中间件已经填充了 req.user
+		return { username: req.user.username, userId: req.user.userId }
+
+	// Fallback: 尝试从 access token 解码 (不推荐，应依赖 authenticate)
+	const token = req.cookies?.accessToken
 	if (!token) return null
 
-	const decoded = jose.decodeJwt(token)
+	const decoded = await verifyToken(token) // verifyToken 会检查过期和撤销
 	if (!decoded) return null
 
-	return config.data.users[decoded.username]
+	return { username: decoded.username, userId: decoded.userId }
 }
 
+/**
+ * 获取用户的数据目录路径
+ * @param {string} username - 用户名
+ * @returns {string} 用户数据目录的绝对路径
+ */
 export function getUserDictionary(username) {
-	return path.resolve(config.data.users[username]?.UserDictionary || __dirname + '/data/users/' + username)
-}
-
-export function getUserByReq(req) {
-	return getUserByToken(req.cookies.accessToken)
+	const user = config.data.users[username]
+	return path.resolve(user?.UserDictionary || path.join(__dirname, 'data', 'users', username))
 }
 
 /**
  * 用户登录
+ * @param {string} username - 用户名
+ * @param {string} password - 密码
+ * @param {string} deviceId - 设备标识符，用于区分不同设备的会话
+ * @param {object} req - Express 请求对象, 用于获取 IP 和 User-Agent
+ * @returns {Promise<object>} 包含状态码、消息、令牌的对象
  */
-export async function login(username, password, deviceId = 'unknown') {
+export async function login(username, password, deviceId = 'unknown', req) {
 	const user = getUserByUsername(username)
-	if (!user) return { status: 404, message: 'User not found' }
+	if (!user || !user.auth) return { status: 404, success: false, message: 'User not found' }
 
 	const authData = user.auth
 
-	// 检查账户是否被锁定
-	if (authData.lockedUntil && authData.lockedUntil > Date.now())
-		return { status: 403, message: 'Account locked' }
+	if (authData.lockedUntil && authData.lockedUntil > Date.now()) {
+		const timeLeft = ms(authData.lockedUntil - Date.now(), { long: true })
+		return { status: 403, success: false, message: `Account locked. Try again in ${timeLeft}.` }
+	}
 
 	const isValidPassword = await verifyPassword(password, authData.password)
 	if (!isValidPassword) {
-		authData.loginAttempts++
+		authData.loginAttempts = (authData.loginAttempts || 0) + 1
 		if (authData.loginAttempts >= MAX_LOGIN_ATTEMPTS) {
 			authData.lockedUntil = Date.now() + ms(ACCOUNT_LOCK_TIME)
-			authData.loginAttempts = 0 // 达到最大尝试次数后重置尝试次数
-			// 账户锁定逻辑：如果登录尝试次数超过限制，锁定账户一段时间
-			// 此处记录日志或发送通知
+			authData.loginAttempts = 0 // 达到最大尝试次数后重置
+			save_config()
 			console.log(await geti18n('fountConsole.auth.accountLockedLog', { username }))
+			return { status: 403, success: false, message: `Account locked due to too many failed attempts. Try again in ${ms(ms(ACCOUNT_LOCK_TIME), { long: true })}.` }
 		}
 		save_config()
-		return { status: 401, message: 'Invalid password' }
+		return { status: 401, success: false, message: 'Invalid username or password' }
 	}
 
-	// 重置登录尝试次数
-	if (authData.loginAttempts !== 0 || authData.lockedUntil !== null) {
-		authData.loginAttempts = 0
-		authData.lockedUntil = null
-	}
+	authData.loginAttempts = 0
+	authData.lockedUntil = null
 
+	// 创建用户目录 (如果尚不存在)
 	const userdir = getUserDictionary(username)
-	if (!fs.existsSync(userdir)) try {
-		fs.mkdirSync(path.dirname(userdir), { recursive: true })
-		// 自`/default/user`复制到用户目录
-		fse.copySync(path.join(__dirname, '/default/templates/user'), userdir)
-	} catch { }
-	for (const subdir of ['AIsources', 'chars', 'personas', 'settings', 'shells', 'worlds', 'ImportHandlers', 'AIsourceGenerators'])
-		try { fs.mkdirSync(userdir + '/' + subdir, { recursive: true }) } catch {
-			console.error('Failed to create directory:', userdir + '/' + subdir, error)
+	if (!fs.existsSync(userdir))
+		try {
+			fs.mkdirSync(userdir, { recursive: true }) // 确保父目录也创建
+			// 从 `/default/templates/user` 复制基础结构到用户目录
+			const templateUserDir = path.join(__dirname, 'default', 'templates', 'user')
+			if (fs.existsSync(templateUserDir))
+				fse.copySync(templateUserDir, userdir, { overwrite: false }) // 不覆盖已存在的文件
+
+		} catch (error) {
+			console.error(`Failed to create or initialize user directory ${userdir}:`, error)
+			// 可以选择是否因为目录创建失败而阻止登录
 		}
+
+	// 确保标准子目录存在
+	const subdirs = ['AIsources', 'chars', 'personas', 'settings', 'shells', 'worlds', 'ImportHandlers', 'AIsourceGenerators']
+	for (const subdir of subdirs)
+		try {
+			fs.mkdirSync(path.join(userdir, subdir), { recursive: true })
+		} catch (error) {
+			console.error(`Failed to create subdirectory ${path.join(userdir, subdir)}:`, error)
+		}
+
+
 
 	// 生成 access token 和 refresh token
 	const accessToken = await generateAccessToken({ username: user.username, userId: authData.userId })
-	const refreshToken = await generateRefreshToken({ username: user.username, userId: authData.userId }, deviceId)
-	const decodedRefreshToken = jose.decodeJwt(refreshToken) // 解码 refreshToken 以获取 jti
+	const refreshTokenString = await generateRefreshToken({ username: user.username, userId: authData.userId }, deviceId, req)
+	const decodedRefreshToken = jose.decodeJwt(refreshTokenString) // 解码 refreshToken 以获取 jti 和 exp
 
-	// 移除同一个设备上的旧的 refresh token
+	// 移除同一个设备上的旧的 refresh token (如果策略是每个设备只保留一个会话)
 	authData.refreshTokens = authData.refreshTokens.filter((token) => token.deviceId !== deviceId)
-	// 存储 refresh token
+
+	// 存储新的 refresh token 信息
 	authData.refreshTokens.push({
 		jti: decodedRefreshToken.jti,
 		deviceId,
-		expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY),
+		expiry: decodedRefreshToken.exp * 1000, // 从JWT payload获取过期时间 (秒转毫秒)
+		ipAddress: req?.ip,
+		userAgent: req?.headers?.['user-agent'],
+		lastSeen: Date.now()
 	})
 	save_config()
 
-	return { status: 200, message: 'Login successful', accessToken, refreshToken }
+	return { status: 200, success: true, message: 'Login successful', accessToken, refreshToken: refreshTokenString }
 }
 
 /**
  * 用户注册
+ * @param {string} username - 用户名
+ * @param {string} password - 密码
+ * @returns {Promise<object>} 包含状态码和用户信息的对象
  */
 export async function register(username, password) {
 	const existingUser = getUserByUsername(username)
-	if (existingUser?.auth)
-		return { status: 409, message: 'Username already exists' }
+	if (existingUser?.auth)  // 检查 .auth 是为了确保这是一个完整的用户记录，而不仅仅是配置中的某个键
+		return { status: 409, success: false, message: 'Username already exists' }
 
-	const newUser = await createUser(username, password)
-	return { status: 201, user: newUser }
+	const newUser = await createUser(username, password) // createUser 内部处理保存
+	return { status: 201, success: true, user: { username: newUser.username, userId: newUser.auth.userId, createdAt: newUser.createdAt } }
 }
 
 /**
- * 清理过期的已撤销 token (每小时调用一次)
+ * 清理过期的已撤销 token (例如，每小时调用一次)
  */
 function cleanupRevokedTokens() {
 	const now = Date.now()
@@ -500,28 +691,48 @@ function cleanupRevokedTokens() {
 			cleaned = true
 		}
 
-	if (cleaned) save_config()
+	if (cleaned) {
+		save_config()
+		console.log('Cleaned up expired revoked tokens.')
+	}
 }
 
 /**
- * 清理过期的 refresh token (每小时调用一次)
+ * 清理用户配置中过期的 refresh token (例如，每小时调用一次)
  */
 function cleanupRefreshTokens() {
 	const now = Date.now()
-	let cleaned = false
+	let cleanedAnyUser = false
 	for (const username in config.data.users) {
 		const user = config.data.users[username]
-		const initialLength = user.auth.refreshTokens.length
-		user.auth.refreshTokens = user.auth.refreshTokens.filter((token) =>
-			token.expiry > now && !config.data.revokedTokens[token.jti]
-		)
-		if (user.auth.refreshTokens.length !== initialLength) cleaned = true
+		if (user?.auth?.refreshTokens) {
+			const initialLength = user.auth.refreshTokens.length
+			user.auth.refreshTokens = user.auth.refreshTokens.filter((token) => {
+				const stillValid = token.expiry > now
+				const notGloballyRevoked = !config.data.revokedTokens[token.jti]
+				return stillValid && notGloballyRevoked
+			})
+			if (user.auth.refreshTokens.length !== initialLength)
+				cleanedAnyUser = true
+
+		}
 	}
 
-	if (cleaned) save_config()
+	if (cleanedAnyUser) {
+		save_config()
+		console.log('Cleaned up expired refresh tokens from user configs.')
+	}
 }
 
+// 定时清理任务
 setInterval(() => {
 	cleanupRevokedTokens()
 	cleanupRefreshTokens()
 }, ms('1h'))
+
+// 确保在应用启动时至少运行一次清理（尤其是在长时间停机后）
+// initAuth 调用后执行，或者单独导出并由主应用调用
+export function runInitialCleanup() {
+	cleanupRevokedTokens()
+	cleanupRefreshTokens()
+}

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -9,6 +9,7 @@ import { ms } from '../scripts/ms.mjs'
 import { geti18n } from '../scripts/i18n.mjs'
 import { is_local_ip_from_req } from '../scripts/ratelimit.mjs'
 import { loadJsonFile } from '../scripts/json_loader.mjs'
+import { events } from './events.mjs';
 
 const ACCESS_TOKEN_EXPIRY = '15m'
 const REFRESH_TOKEN_EXPIRY = '30d'
@@ -262,15 +263,139 @@ async function createUser(username, password) {
 /**
  * 使用 Argon2id 哈希密码
  */
-async function hashPassword(password) {
+export async function hashPassword(password) {
 	return await argon2.hash(password, { type: argon2.argon2id })
 }
 
 /**
  * 验证密码
  */
-async function verifyPassword(password, hashedPassword) {
+export async function verifyPassword(password, hashedPassword) {
 	return await argon2.verify(hashedPassword, password)
+}
+
+export async function changeUserPassword(username, currentPassword, newPassword) {
+  const user = getUserByUsername(username);
+  if (!user) return { success: false, message: 'User not found' };
+
+  const isValidPassword = await verifyPassword(currentPassword, user.auth.password);
+  if (!isValidPassword) return { success: false, message: 'Invalid current password' };
+
+  user.auth.password = await hashPassword(newPassword);
+  save_config();
+  return { success: true, message: 'Password changed successfully' };
+}
+
+export async function revokeUserDevice(username, deviceId) {
+  const user = getUserByUsername(username);
+  if (!user || !user.auth || !user.auth.refreshTokens) {
+    return { success: false, message: 'User or device list not found' };
+  }
+
+  const tokenIndex = user.auth.refreshTokens.findIndex(token => token.deviceId === deviceId || token.jti === deviceId);
+  if (tokenIndex === -1) {
+    return { success: false, message: 'Device not found for this user' };
+  }
+
+  const revokedToken = user.auth.refreshTokens.splice(tokenIndex, 1)[0];
+  // Add to global revoked list if your system requires it by jti
+  if (revokedToken && revokedToken.jti) {
+    config.data.revokedTokens[revokedToken.jti] = { expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY), type: 'refresh-revoked-manual' }; // Or use actual expiry if preferred
+  }
+  save_config();
+  return { success: true, message: 'Device access revoked successfully' };
+}
+
+export async function deleteUserAccount(username, password) {
+  const user = getUserByUsername(username);
+  if (!user) return { success: false, message: 'User not found' };
+
+  const isValidPassword = await verifyPassword(password, user.auth.password);
+  if (!isValidPassword) return { success: false, message: 'Invalid password' };
+
+  const userId = user.auth.userId; // Get userId before deleting user
+  const userDirectoryPath = getUserDictionary(username); // Get path BEFORE deleting user from config
+
+  // Revoke all refresh tokens for the user
+  if (user.auth.refreshTokens && user.auth.refreshTokens.length > 0) {
+    user.auth.refreshTokens.forEach(token => {
+      if (token.jti) {
+        config.data.revokedTokens[token.jti] = { expiry: Date.now() + ms(REFRESH_TOKEN_EXPIRY), type: 'refresh-revoked-delete' };
+      }
+    });
+  }
+  
+  // Delete user data from config
+  delete config.data.users[username];
+  save_config();
+
+  // Emit userDeleted event WITH userDirectoryPath
+  events.emit('userDeleted', { username, userId, userDirectoryPath });
+
+  return { success: true, message: 'User account deleted successfully' };
+}
+
+export async function renameUser(currentUsername, newUsername) {
+  if (currentUsername === newUsername) {
+    return { success: false, message: 'New username must be different from the current one.' };
+  }
+
+  const oldUserConfigEntry = getUserByUsername(currentUsername);
+  if (!oldUserConfigEntry) {
+    return { success: false, message: 'Current user not found' };
+  }
+
+  if (getUserByUsername(newUsername)) {
+    return { success: false, message: 'New username already exists' };
+  }
+
+  const oldUserPath = getUserDictionary(currentUsername); 
+
+  const newUserConfigEntry = JSON.parse(JSON.stringify(oldUserConfigEntry));
+  newUserConfigEntry.username = newUsername; 
+
+  if (newUserConfigEntry.UserDictionary && 
+      typeof newUserConfigEntry.UserDictionary === 'string' && 
+      newUserConfigEntry.UserDictionary.includes(currentUsername)) {
+    const escapedOldUsername = currentUsername.replace(/[.*+?^${}()|[\]\]/g, '\\$&');
+    newUserConfigEntry.UserDictionary = newUserConfigEntry.UserDictionary.replace(new RegExp(escapedOldUsername, 'g'), newUsername);
+  }
+
+  const newUserPath = path.resolve(newUserConfigEntry.UserDictionary || path.join(__dirname, 'data', 'users', newUsername));
+
+  try {
+    if (fse.existsSync(oldUserPath)) {
+      if (oldUserPath.toLowerCase() !== newUserPath.toLowerCase()) {
+        fse.ensureDirSync(path.dirname(newUserPath)); 
+        fse.moveSync(oldUserPath, newUserPath, { overwrite: true });
+        console.log(`User data directory moved from ${oldUserPath} to ${newUserPath}`);
+      } else {
+        console.log(`User data directory path is effectively the same, no move needed: ${oldUserPath}`);
+      }
+    } else {
+      console.warn(`Old user data directory not found: ${oldUserPath}. Nothing to move.`);
+      if (!fse.existsSync(newUserPath)) {
+         fse.ensureDirSync(newUserPath);
+         console.log(`Ensured new user data directory exists at: ${newUserPath}`);
+      }
+    }
+  } catch (error) {
+    console.error(`Error moving user data directory from ${oldUserPath} to ${newUserPath}:`, error);
+    return { success: false, message: `Error moving user data directory: ${error.message}. Username change not saved.` };
+  }
+
+  config.data.users[newUsername] = newUserConfigEntry;
+  delete config.data.users[currentUsername];
+  save_config();
+
+  events.emit('userRenamed', {
+    oldUsername: currentUsername,
+    newUsername: newUsername,
+    userId: newUserConfigEntry.auth.userId,
+    newUserData: newUserConfigEntry
+  });
+
+  return { success: true, message: 'Username renamed successfully and user data directory moved.' };
 }
 
 async function getUserByToken(token) {

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -730,10 +730,3 @@ setInterval(() => {
 	cleanupRevokedTokens()
 	cleanupRefreshTokens()
 }, ms('1h'))
-
-// 确保在应用启动时至少运行一次清理（尤其是在长时间停机后）
-// initAuth 调用后执行，或者单独导出并由主应用调用
-export function runInitialCleanup() {
-	cleanupRevokedTokens()
-	cleanupRefreshTokens()
-}

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -146,10 +146,10 @@ async function refresh(refreshTokenValue, req) {
 		// (可选) 滚动刷新 Refresh Token：生成新的 Refresh Token，并使旧的失效
 		// 为了简化，并减少客户端状态管理，这里可以不滚动刷新 Refresh Token，而是沿用旧的，直到它过期
 		// 如果决定滚动：
-		const newRefreshToken = await generateRefreshToken({ username: decoded.username, userId: decoded.userId }, userRefreshTokenEntry.deviceId, req);
-		const decodedNewRefreshToken = jose.decodeJwt(newRefreshToken);
+		const newRefreshToken = await generateRefreshToken({ username: decoded.username, userId: decoded.userId }, userRefreshTokenEntry.deviceId, req)
+		const decodedNewRefreshToken = jose.decodeJwt(newRefreshToken)
 		// 移除旧的 refreshToken，添加新的 refreshToken
-		user.auth.refreshTokens = user.auth.refreshTokens.filter((token) => token.jti !== decoded.jti);
+		user.auth.refreshTokens = user.auth.refreshTokens.filter((token) => token.jti !== decoded.jti)
 		user.auth.refreshTokens.push({
 			jti: decodedNewRefreshToken.jti,
 			deviceId: userRefreshTokenEntry.deviceId,
@@ -157,9 +157,9 @@ async function refresh(refreshTokenValue, req) {
 			ipAddress: req?.ip,
 			userAgent: req?.headers?.['user-agent'],
 			lastSeen: Date.now()
-		});
-		save_config();
-		return { status: 200, success: true, accessToken, refreshToken: newRefreshToken };
+		})
+		save_config()
+		return { status: 200, success: true, accessToken, refreshToken: newRefreshToken }
 	} catch (error) {
 		console.error(await geti18n('fountConsole.auth.refreshTokenError', { error: error.message }))
 		return { status: 401, success: false, message: 'Error refreshing token' }
@@ -222,14 +222,13 @@ export async function authenticate(req, res, next) {
 
 	if (!accessToken) return Unauthorized()
 
-	// 本地 IP 特权（如果需要，但通常不推荐完全跳过验证）
-	// if (is_local_ip_from_req(req)) {
-	//     const decoded = await jose.decodeJwt(accessToken); // 仅解码
-	//     if (decoded && config.data.users[decoded.username]) {
-	//         req.user = { username: decoded.username, userId: decoded.userId || config.data.users[decoded.username].auth.userId };
-	//         return next();
-	//     }
-	// }
+	if (is_local_ip_from_req(req)) {
+		const decoded = await jose.decodeJwt(accessToken)
+		if (decoded && config.data.users[decoded.username]) {
+			req.user = { username: decoded.username, userId: decoded.userId || config.data.users[decoded.username].auth.userId }
+			return next()
+		}
+	}
 
 	let decodedAccessToken = await verifyToken(accessToken)
 

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -1,28 +1,14 @@
-class EventEmitter {
-  constructor() {
-    this.events = {};
-  }
-
-  on(eventName, listener) {
-    if (!this.events[eventName]) {
-      this.events[eventName] = [];
-    }
-    this.events[eventName].push(listener);
-  }
-
-  emit(eventName, ...args) {
-    if (this.events[eventName]) {
-      this.events[eventName].forEach(listener => listener(...args));
-    }
-  }
-
-  off(eventName, listenerToRemove) {
-    if (!this.events[eventName]) {
-      return;
-    }
-    this.events[eventName] = this.events[eventName].filter(listener => listener !== listenerToRemove);
-  }
+const data = {}
+export const events = {
+	on(eventName, listener) {
+		data[eventName] ??= []
+		this.events[eventName].push(listener)
+	},
+	emit(eventName, ...args) {
+		data[eventName]?.forEach?.(listener => listener(...args))
+	},
+	off(eventName, listenerToRemove) {
+		if (!this.events[eventName]) return
+		this.events[eventName] = this.events[eventName].filter(listener => listener !== listenerToRemove)
+	}
 }
-
-export { EventEmitter }; // Export the class
-export const events = new EventEmitter();

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -4,8 +4,10 @@ export const events = {
 		data[eventName] ??= []
 		data[eventName].push(listener)
 	},
-	emit(eventName, ...args) {
-		data[eventName]?.forEach?.(listener => listener(...args))
+	async emit(eventName, ...args) {
+		if (!data[eventName]) return
+		for (const listener of data[eventName])
+			await listener(...args)
 	},
 	off(eventName, listenerToRemove) {
 		if (!data[eventName]) return

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -1,0 +1,28 @@
+class EventEmitter {
+  constructor() {
+    this.events = {};
+  }
+
+  on(eventName, listener) {
+    if (!this.events[eventName]) {
+      this.events[eventName] = [];
+    }
+    this.events[eventName].push(listener);
+  }
+
+  emit(eventName, ...args) {
+    if (this.events[eventName]) {
+      this.events[eventName].forEach(listener => listener(...args));
+    }
+  }
+
+  off(eventName, listenerToRemove) {
+    if (!this.events[eventName]) {
+      return;
+    }
+    this.events[eventName] = this.events[eventName].filter(listener => listener !== listenerToRemove);
+  }
+}
+
+export { EventEmitter }; // Export the class
+export const events = new EventEmitter();

--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -2,13 +2,13 @@ const data = {}
 export const events = {
 	on(eventName, listener) {
 		data[eventName] ??= []
-		this.events[eventName].push(listener)
+		data[eventName].push(listener)
 	},
 	emit(eventName, ...args) {
 		data[eventName]?.forEach?.(listener => listener(...args))
 	},
 	off(eventName, listenerToRemove) {
-		if (!this.events[eventName]) return
-		this.events[eventName] = this.events[eventName].filter(listener => listener !== listenerToRemove)
+		if (!data[eventName]) return
+		data[eventName] = data[eventName].filter(listener => listener !== listenerToRemove)
 	}
 }

--- a/src/server/jobs.mjs
+++ b/src/server/jobs.mjs
@@ -3,6 +3,7 @@ import { getAllUserNames } from './auth.mjs'
 import { save_config } from './server.mjs'
 import { loadPart } from './managers/index.mjs'
 import { events } from './events.mjs'
+import { geti18n } from '../scripts/i18n.mjs'
 
 export function StartJob(username, parttype, partname, uid, data = null) {
 	const jobs = getUserByUsername(username).jobs ??= {}

--- a/src/server/jobs.mjs
+++ b/src/server/jobs.mjs
@@ -19,14 +19,14 @@ async function startJobsOfUser(username) {
 	const jobs = getUserByUsername(username).jobs ?? {}
 	for (const parttype in jobs)
 		for (const partname in jobs[parttype])
-			for (const uid in jobs[parttype][partname]) 
+			for (const uid in jobs[parttype][partname])
 				try {
+					console.log(await geti18n('fountConsole.jobs.restartingJob', { username, parttype, partname, uid }))
 					const part = await loadPart(username, parttype, partname)
-					await part.interfaces.jobs.StartJob(username, jobs[parttype][partname][uid] ?? uid)
+					await part.interfaces.jobs.ReStartJob(username, jobs[parttype][partname][uid] ?? uid)
 				} catch (err) {
 					console.error(err)
 				}
-			
 }
 export async function ReStartJobs() {
 	await Promise.all(getAllUserNames().map(startJobsOfUser))

--- a/src/server/jobs.mjs
+++ b/src/server/jobs.mjs
@@ -1,8 +1,8 @@
 import { getUserByUsername } from './auth.mjs'
 import { getAllUserNames } from './auth.mjs'
 import { save_config } from './server.mjs'
-import { geti18n } from '../scripts/i18n.mjs'
 import { loadPart } from './managers/index.mjs'
+import { events } from './events.mjs'
 
 export function StartJob(username, parttype, partname, uid, data = null) {
 	const jobs = getUserByUsername(username).jobs ??= {}
@@ -15,20 +15,23 @@ export function EndJob(username, parttype, partname, uid) {
 	delete getUserByUsername(username).jobs?.[parttype]?.[partname]?.[uid]
 	save_config()
 }
-export async function ReStartJobs() {
-	const users = getAllUserNames()
-	for (const user of users) {
-		const jobs = getUserByUsername(user).jobs ?? {}
-		for (const parttype in jobs)
-			for (const partname in jobs[parttype])
-				for (const uid in jobs[parttype][partname]) {
-					console.log(await geti18n('fountConsole.jobs.restartingJob', { username: user, parttype, partname, uid }))
-					try {
-						const part = await loadPart(user, parttype, partname)
-						await part.interfaces.jobs.ReStartJob(user, jobs[parttype][partname][uid] ?? uid)
-					} catch (err) {
-						console.error(err)
-					}
+async function startJobsOfUser(username) {
+	const jobs = getUserByUsername(username).jobs ?? {}
+	for (const parttype in jobs)
+		for (const partname in jobs[parttype])
+			for (const uid in jobs[parttype][partname]) 
+				try {
+					const part = await loadPart(username, parttype, partname)
+					await part.interfaces.jobs.StartJob(username, jobs[parttype][partname][uid] ?? uid)
+				} catch (err) {
+					console.error(err)
 				}
-	}
+			
 }
+export async function ReStartJobs() {
+	await Promise.all(getAllUserNames().map(startJobsOfUser))
+}
+
+events.on('AfterUserRenamed', async ({ oldUsername, newUsername }) => {
+	await startJobsOfUser(newUsername)
+})

--- a/src/server/managers/index.mjs
+++ b/src/server/managers/index.mjs
@@ -58,13 +58,13 @@ on_shutdown(async () => {
 })
 
 // Event Handlers
-events.on('userDeleted', async ({ username }) => {
+events.on('BeforeUserDeleted', async ({ username }) => {
 	for (const parttype in parts_set[username])
 		for (const partname in parts_set[username][parttype])
 			await unloadPart(username, parttype, partname)
 })
 
-events.on('userRenamed', async ({ oldUsername, newUsername }) => {
+events.on('BeforeUserRenamed', async ({ oldUsername, newUsername }) => {
 	for (const parttype in parts_set[oldUsername])
 		for (const partname in parts_set[oldUsername][parttype])
 			await unloadPart(oldUsername, parttype, partname)

--- a/src/server/managers/index.mjs
+++ b/src/server/managers/index.mjs
@@ -6,6 +6,7 @@ import { loadAIsource, loadAIsourceGenerator, unloadAIsource, unloadAIsourceGene
 import { LoadImportHandler, UnloadImportHandler } from '../../public/shells/install/src/server/importHandler_manager.mjs'
 import { loadWorld, unloadWorld } from './world_manager.mjs'
 import { on_shutdown, shutdown } from '../on_shutdown.mjs'
+import { events } from "../events.mjs";
 
 export const partsList = [
 	'shells', 'chars', 'personas', 'worlds', 'AIsources', 'AIsourceGenerators',
@@ -54,6 +55,19 @@ on_shutdown(async () => {
 		for (const parttype in parts_set[username])
 			for (const partname in parts_set[username][parttype])
 				await unloadPart(username, parttype, partname)
+})
+
+// Event Handlers
+events.on('userDeleted', async ({ username, userId }) => {
+	for (const parttype in parts_set[username])
+		for (const partname in parts_set[username][parttype])
+			await unloadPart(username, parttype, partname)
+})
+
+events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+	for (const parttype in parts_set[oldUsername])
+		for (const partname in parts_set[oldUsername][parttype])
+			await unloadPart(oldUsername, parttype, partname)
 })
 
 export async function reloadPart(username, parttype, partname) {

--- a/src/server/managers/index.mjs
+++ b/src/server/managers/index.mjs
@@ -58,13 +58,13 @@ on_shutdown(async () => {
 })
 
 // Event Handlers
-events.on('userDeleted', async ({ username, userId }) => {
+events.on('userDeleted', async ({ username }) => {
 	for (const parttype in parts_set[username])
 		for (const partname in parts_set[username][parttype])
 			await unloadPart(username, parttype, partname)
 })
 
-events.on('userRenamed', async ({ oldUsername, newUsername, userId, newUserData }) => {
+events.on('userRenamed', async ({ oldUsername, newUsername }) => {
 	for (const parttype in parts_set[oldUsername])
 		for (const partname in parts_set[oldUsername][parttype])
 			await unloadPart(oldUsername, parttype, partname)

--- a/src/server/managers/index.mjs
+++ b/src/server/managers/index.mjs
@@ -6,7 +6,7 @@ import { loadAIsource, loadAIsourceGenerator, unloadAIsource, unloadAIsourceGene
 import { LoadImportHandler, UnloadImportHandler } from '../../public/shells/install/src/server/importHandler_manager.mjs'
 import { loadWorld, unloadWorld } from './world_manager.mjs'
 import { on_shutdown, shutdown } from '../on_shutdown.mjs'
-import { events } from "../events.mjs";
+import { events } from '../events.mjs'
 
 export const partsList = [
 	'shells', 'chars', 'personas', 'worlds', 'AIsources', 'AIsourceGenerators',

--- a/src/server/server.mjs
+++ b/src/server/server.mjs
@@ -14,6 +14,7 @@ import { createTray } from '../scripts/tray.mjs'
 import { StartRPC } from '../scripts/discordrpc.mjs'
 import { geti18n } from '../scripts/i18n.mjs'
 import { sentrytunnel } from '../scripts/sentrytunnel.mjs'
+import { events } from './events.mjs';
 
 export { __dirname }
 const app = express()

--- a/src/server/server.mjs
+++ b/src/server/server.mjs
@@ -14,7 +14,6 @@ import { createTray } from '../scripts/tray.mjs'
 import { StartRPC } from '../scripts/discordrpc.mjs'
 import { geti18n } from '../scripts/i18n.mjs'
 import { sentrytunnel } from '../scripts/sentrytunnel.mjs'
-import { events } from './events.mjs';
 
 export { __dirname }
 const app = express()

--- a/src/server/setting_loader.mjs
+++ b/src/server/setting_loader.mjs
@@ -57,9 +57,7 @@ export function loadTempData(username, dataname) {
 // 无需保存 :)
 
 // Event Handlers
-events.on('userDeleted', ({ username, userId }) => {
-	console.log(`SettingLoader: Handling userDeleted event for username: ${username}`)
-
+events.on('AfterUserDeleted', ({ username, userId }) => {
 	if (userDataSet[username]) {
 		delete userDataSet[username]
 		console.log(`SettingLoader: Cleared userDataSet cache for ${username}`)
@@ -72,15 +70,9 @@ events.on('userDeleted', ({ username, userId }) => {
 		delete userTempDataSet[username]
 		console.log(`SettingLoader: Cleared userTempDataSet cache for ${username}`)
 	}
-	// Note: Actual file deletion for data managed by loadData/saveData and loadShellData/saveShellData
-	// is assumed to be handled by the process that deletes the user's main data directory
-	// (e.g., data/users/<username>/settings/ and data/users/<username>/shells/).
-	// This handler only clears the in-memory caches.
 })
 
-events.on('userRenamed', ({ oldUsername, newUsername, userId, newUserData }) => {
-	console.log(`SettingLoader: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
-
+events.on('AfterUserRenamed', ({ oldUsername, newUsername, userId, newUserData }) => {
 	if (userDataSet[oldUsername]) {
 		userDataSet[newUsername] = userDataSet[oldUsername]
 		delete userDataSet[oldUsername]
@@ -96,8 +88,4 @@ events.on('userRenamed', ({ oldUsername, newUsername, userId, newUserData }) => 
 		delete userTempDataSet[oldUsername]
 		console.log(`SettingLoader: Migrated userTempDataSet cache from ${oldUsername} to ${newUsername}`)
 	}
-	// Note: Actual file renaming for data managed by loadData/saveData and loadShellData/saveShellData
-	// (e.g., data/users/<username>/settings/ and data/users/<username>/shells/)
-	// has already been handled by auth.mjs moving the entire user's data directory.
-	// This handler only updates the in-memory cache keys.
 })

--- a/src/server/setting_loader.mjs
+++ b/src/server/setting_loader.mjs
@@ -57,7 +57,7 @@ export function loadTempData(username, dataname) {
 // 无需保存 :)
 
 // Event Handlers
-events.on('AfterUserDeleted', ({ username, userId }) => {
+events.on('AfterUserDeleted', ({ username }) => {
 	if (userDataSet[username]) {
 		delete userDataSet[username]
 		console.log(`SettingLoader: Cleared userDataSet cache for ${username}`)
@@ -72,7 +72,7 @@ events.on('AfterUserDeleted', ({ username, userId }) => {
 	}
 })
 
-events.on('AfterUserRenamed', ({ oldUsername, newUsername, userId, newUserData }) => {
+events.on('AfterUserRenamed', ({ oldUsername, newUsername }) => {
 	if (userDataSet[oldUsername]) {
 		userDataSet[newUsername] = userDataSet[oldUsername]
 		delete userDataSet[oldUsername]

--- a/src/server/setting_loader.mjs
+++ b/src/server/setting_loader.mjs
@@ -1,5 +1,5 @@
 import { getUserDictionary } from './auth.mjs'
-import { events } from './events.mjs';
+import { events } from './events.mjs'
 import { saveJsonFile, loadJsonFileIfExists } from '../scripts/json_loader.mjs'
 import { on_shutdown } from './on_shutdown.mjs'
 import fs from 'node:fs'
@@ -58,46 +58,46 @@ export function loadTempData(username, dataname) {
 
 // Event Handlers
 events.on('userDeleted', ({ username, userId }) => {
-  console.log(`SettingLoader: Handling userDeleted event for username: ${username}`);
+	console.log(`SettingLoader: Handling userDeleted event for username: ${username}`)
 
-  if (userDataSet[username]) {
-    delete userDataSet[username];
-    console.log(`SettingLoader: Cleared userDataSet cache for ${username}`);
-  }
-  if (userShellDataSet[username]) {
-    delete userShellDataSet[username];
-    console.log(`SettingLoader: Cleared userShellDataSet cache for ${username}`);
-  }
-  if (userTempDataSet[username]) {
-    delete userTempDataSet[username];
-    console.log(`SettingLoader: Cleared userTempDataSet cache for ${username}`);
-  }
-  // Note: Actual file deletion for data managed by loadData/saveData and loadShellData/saveShellData
-  // is assumed to be handled by the process that deletes the user's main data directory
-  // (e.g., data/users/<username>/settings/ and data/users/<username>/shells/).
-  // This handler only clears the in-memory caches.
-});
+	if (userDataSet[username]) {
+		delete userDataSet[username]
+		console.log(`SettingLoader: Cleared userDataSet cache for ${username}`)
+	}
+	if (userShellDataSet[username]) {
+		delete userShellDataSet[username]
+		console.log(`SettingLoader: Cleared userShellDataSet cache for ${username}`)
+	}
+	if (userTempDataSet[username]) {
+		delete userTempDataSet[username]
+		console.log(`SettingLoader: Cleared userTempDataSet cache for ${username}`)
+	}
+	// Note: Actual file deletion for data managed by loadData/saveData and loadShellData/saveShellData
+	// is assumed to be handled by the process that deletes the user's main data directory
+	// (e.g., data/users/<username>/settings/ and data/users/<username>/shells/).
+	// This handler only clears the in-memory caches.
+})
 
 events.on('userRenamed', ({ oldUsername, newUsername, userId, newUserData }) => {
-  console.log(`SettingLoader: Handling userRenamed event from ${oldUsername} to ${newUsername}`);
+	console.log(`SettingLoader: Handling userRenamed event from ${oldUsername} to ${newUsername}`)
 
-  if (userDataSet[oldUsername]) {
-    userDataSet[newUsername] = userDataSet[oldUsername];
-    delete userDataSet[oldUsername];
-    console.log(`SettingLoader: Migrated userDataSet cache from ${oldUsername} to ${newUsername}`);
-  }
-  if (userShellDataSet[oldUsername]) {
-    userShellDataSet[newUsername] = userShellDataSet[oldUsername];
-    delete userShellDataSet[oldUsername];
-    console.log(`SettingLoader: Migrated userShellDataSet cache from ${oldUsername} to ${newUsername}`);
-  }
-  if (userTempDataSet[oldUsername]) {
-    userTempDataSet[newUsername] = userTempDataSet[oldUsername];
-    delete userTempDataSet[oldUsername];
-    console.log(`SettingLoader: Migrated userTempDataSet cache from ${oldUsername} to ${newUsername}`);
-  }
-  // Note: Actual file renaming for data managed by loadData/saveData and loadShellData/saveShellData
-  // (e.g., data/users/<username>/settings/ and data/users/<username>/shells/)
-  // has already been handled by auth.mjs moving the entire user's data directory.
-  // This handler only updates the in-memory cache keys.
-});
+	if (userDataSet[oldUsername]) {
+		userDataSet[newUsername] = userDataSet[oldUsername]
+		delete userDataSet[oldUsername]
+		console.log(`SettingLoader: Migrated userDataSet cache from ${oldUsername} to ${newUsername}`)
+	}
+	if (userShellDataSet[oldUsername]) {
+		userShellDataSet[newUsername] = userShellDataSet[oldUsername]
+		delete userShellDataSet[oldUsername]
+		console.log(`SettingLoader: Migrated userShellDataSet cache from ${oldUsername} to ${newUsername}`)
+	}
+	if (userTempDataSet[oldUsername]) {
+		userTempDataSet[newUsername] = userTempDataSet[oldUsername]
+		delete userTempDataSet[oldUsername]
+		console.log(`SettingLoader: Migrated userTempDataSet cache from ${oldUsername} to ${newUsername}`)
+	}
+	// Note: Actual file renaming for data managed by loadData/saveData and loadShellData/saveShellData
+	// (e.g., data/users/<username>/settings/ and data/users/<username>/shells/)
+	// has already been handled by auth.mjs moving the entire user's data directory.
+	// This handler only updates the in-memory cache keys.
+})


### PR DESCRIPTION
This commit addresses feedback on the user_settings shell:
- Corrected `src/public/shells/user_settings/home_registry.json` to use the `home_function_buttons` structure, aligning with other shells like discordbot.
- Refactored `src/public/shells/user_settings/main.mjs` to the standard shell pattern: exports a default object with `info` and `Load` function; `Load` now configures routes on the provided router and uses actual functions from `auth.mjs` for its logic.
- Ensured `src/public/shells/user_settings/index.mjs` correctly initializes i18n by calling `initTranslations('userSettings')`.
- Removed unit test files (`events.test.mjs`, `auth.test.mjs`) as per your request.