### PR TITLE
feat: Implement modal viewer for video attachments

### DIFF
--- a/src/public/shells/chat/index.css
+++ b/src/public/shells/chat/index.css
@@ -105,7 +105,6 @@ body {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	width: 100%;
-	position: absolute;
 	bottom: 0;
 	background-color: rgba(0, 0, 0, 0.5);
 	color: #fff;
@@ -185,90 +184,4 @@ body {
 	max-width: 90%;
 	max-height: 90%;
 	object-fit: contain;
-}
-
-/* Styles for audio attachments */
-.attachment[data-attachment-type="audio"] {
-    /* Add specific styling for audio attachment containers if needed */
-    /* For example, you might want to ensure it has a certain height or layout */
-}
-
-.attachment[data-attachment-type="audio"] .preview-container {
-    display: flex; /* Helps align audio element and controls */
-    flex-direction: column; /* Stack audio element and controls vertically */
-    align-items: stretch; /* Stretch items to fill container width */
-    gap: 8px; /* Space between audio element (if visible) and controls */
-}
-
-/* Hide the default audio player if using custom controls exclusively */
-/* If you want to keep it, you might need to style it or ensure it doesn't clash */
-.attachment[data-attachment-type="audio"] .preview-container audio {
-    /* max-width: 100%; */
-    /* display: none; */ /* Uncomment if you want to fully hide the native player */
-}
-
-.audio-controls {
-    display: flex;
-    align-items: center;
-    gap: 8px; /* Space between button and progress bar */
-    padding: 4px;
-    border: 1px solid var(--fallback-bc, oklch(var(--bc) / 0.2)); /* Use theme border color */
-    border-radius: var(--rounded-btn, 0.5rem); /* Use theme border radius */
-    background-color: var(--fallback-b2, oklch(var(--b2) / 1)); /* Use theme background color */
-}
-
-.play-pause-btn {
-    /* DaisyUI btn styles are quite comprehensive.
-       If the button is a <button class="btn btn-sm btn-ghost"> for example,
-       it might already look good. These are additional/override styles. */
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 0; /* Reset padding if using img/svg directly */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.play-pause-btn img { /* If using <img> for icons */
-    width: 24px; /* Adjust size as needed */
-    height: 24px; /* Adjust size as needed */
-    filter: var(--icon-filter, invert(80%)); /* Adjust if icons are not visible with current theme */
-}
-
-.progress-bar {
-    flex-grow: 1; /* Allow progress bar to take available space */
-    height: 8px; /* Make the track thinner */
-    -webkit-appearance: none; /* Override default Safari/Chrome appearance */
-    appearance: none;
-    background: var(--fallback-b3, oklch(var(--b3) / 1)); /* Theme background for the track */
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-/* Webkit (Chrome, Safari, Edge) */
-.progress-bar::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    background: var(--fallback-p, oklch(var(--p) / 1)); /* Theme primary color for thumb */
-    border-radius: 50%;
-    cursor: pointer;
-}
-
-/* Mozilla Firefox */
-.progress-bar::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    background: var(--fallback-p, oklch(var(--p) / 1)); /* Theme primary color for thumb */
-    border-radius: 50%;
-    border: none; /* Reset Firefox default border */
-    cursor: pointer;
-}
-
-.progress-bar::-moz-range-track {
-    background: var(--fallback-b3, oklch(var(--b3) / 1)); /* Theme background for the track */
-    height: 8px;
-    border-radius: 4px;
 }

--- a/src/public/shells/chat/index.css
+++ b/src/public/shells/chat/index.css
@@ -186,3 +186,89 @@ body {
 	max-height: 90%;
 	object-fit: contain;
 }
+
+/* Styles for audio attachments */
+.attachment[data-attachment-type="audio"] {
+    /* Add specific styling for audio attachment containers if needed */
+    /* For example, you might want to ensure it has a certain height or layout */
+}
+
+.attachment[data-attachment-type="audio"] .preview-container {
+    display: flex; /* Helps align audio element and controls */
+    flex-direction: column; /* Stack audio element and controls vertically */
+    align-items: stretch; /* Stretch items to fill container width */
+    gap: 8px; /* Space between audio element (if visible) and controls */
+}
+
+/* Hide the default audio player if using custom controls exclusively */
+/* If you want to keep it, you might need to style it or ensure it doesn't clash */
+.attachment[data-attachment-type="audio"] .preview-container audio {
+    /* max-width: 100%; */
+    /* display: none; */ /* Uncomment if you want to fully hide the native player */
+}
+
+.audio-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px; /* Space between button and progress bar */
+    padding: 4px;
+    border: 1px solid var(--fallback-bc, oklch(var(--bc) / 0.2)); /* Use theme border color */
+    border-radius: var(--rounded-btn, 0.5rem); /* Use theme border radius */
+    background-color: var(--fallback-b2, oklch(var(--b2) / 1)); /* Use theme background color */
+}
+
+.play-pause-btn {
+    /* DaisyUI btn styles are quite comprehensive.
+       If the button is a <button class="btn btn-sm btn-ghost"> for example,
+       it might already look good. These are additional/override styles. */
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0; /* Reset padding if using img/svg directly */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.play-pause-btn img { /* If using <img> for icons */
+    width: 24px; /* Adjust size as needed */
+    height: 24px; /* Adjust size as needed */
+    filter: var(--icon-filter, invert(80%)); /* Adjust if icons are not visible with current theme */
+}
+
+.progress-bar {
+    flex-grow: 1; /* Allow progress bar to take available space */
+    height: 8px; /* Make the track thinner */
+    -webkit-appearance: none; /* Override default Safari/Chrome appearance */
+    appearance: none;
+    background: var(--fallback-b3, oklch(var(--b3) / 1)); /* Theme background for the track */
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+/* Webkit (Chrome, Safari, Edge) */
+.progress-bar::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    background: var(--fallback-p, oklch(var(--p) / 1)); /* Theme primary color for thumb */
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+/* Mozilla Firefox */
+.progress-bar::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    background: var(--fallback-p, oklch(var(--p) / 1)); /* Theme primary color for thumb */
+    border-radius: 50%;
+    border: none; /* Reset Firefox default border */
+    cursor: pointer;
+}
+
+.progress-bar::-moz-range-track {
+    background: var(--fallback-b3, oklch(var(--b3) / 1)); /* Theme background for the track */
+    height: 8px;
+    border-radius: 4px;
+}

--- a/src/public/shells/chat/src/public/ui/modal.mjs
+++ b/src/public/shells/chat/src/public/ui/modal.mjs
@@ -1,41 +1,38 @@
 export function openModal(contentSrc, contentType) {
-    const modal = document.createElement('div');
-    modal.classList.add('modal', 'modal-open');
+	const modal = document.createElement('div')
+	modal.classList.add('modal', 'modal-open')
 
-    let modalContentElement;
+	let modalContentElement
 
-    if (contentType === 'image') {
-        modalContentElement = document.createElement('img');
-        modalContentElement.src = contentSrc;
-        modalContentElement.classList.add('modal-img'); // Or a generic class
-    } else if (contentType === 'video') {
-        modalContentElement = document.createElement('video');
-        modalContentElement.src = contentSrc;
-        modalContentElement.controls = true;
-        modalContentElement.autoplay = true; // Optional
-        modalContentElement.classList.add('modal-video'); // Or a generic class
-        // Style the video element for the modal to ensure it's not too small or too large
-        modalContentElement.style.maxWidth = '90vw';
-        modalContentElement.style.maxHeight = '90vh';
-        modalContentElement.style.display = 'block'; // Prevents extra space below video
-        modalContentElement.style.margin = 'auto'; // Centers the video
-    } else {
-        console.error('Unsupported content type for modal:', contentType);
-        return; // Don't open modal for unsupported types
-    }
+	if (contentType === 'image') {
+		modalContentElement = document.createElement('img')
+		modalContentElement.src = contentSrc
+		modalContentElement.classList.add('modal-img')
+	} else if (contentType === 'video') {
+		modalContentElement = document.createElement('video')
+		modalContentElement.src = contentSrc
+		modalContentElement.controls = true
+		modalContentElement.autoplay = true
+		modalContentElement.classList.add('modal-video')
+	} else {
+		console.error('Unsupported content type for modal:', contentType)
+		return // Don't open modal for unsupported types
+	}
 
-    modal.appendChild(modalContentElement);
+	modalContentElement.style.maxWidth = '90vw'
+	modalContentElement.style.maxHeight = '90vh'
+	modal.appendChild(modalContentElement)
 
-    modal.addEventListener('click', (e) => {
-        // Close only if the modal background (not the content itself) is clicked
-        if (e.target === modal) {
-            // If it's a video, pause it before removing the modal
-            if (contentType === 'video' && modalContentElement) {
-                modalContentElement.pause();
-            }
-            modal.remove();
-        }
-    });
+	modal.addEventListener('click', (e) => {
+		// Close only if the modal background (not the content itself) is clicked
+		if (e.target === modal) {
+			// If it's a video, pause it before removing the modal
+			if (contentType === 'video' && modalContentElement) 
+				modalContentElement.pause()
+			
+			modal.remove()
+		}
+	})
 
-    document.body.appendChild(modal);
+	document.body.appendChild(modal)
 }

--- a/src/public/shells/chat/src/public/ui/modal.mjs
+++ b/src/public/shells/chat/src/public/ui/modal.mjs
@@ -1,10 +1,41 @@
-export function openModal(base64Data) {
-	const modal = document.createElement('div')
-	modal.innerHTML = `<img src="${base64Data}" class="modal-img">`
-	modal.classList.add('modal', 'modal-open')
-	modal.addEventListener('click', () => {
-		modal.remove()
-	})
+export function openModal(contentSrc, contentType) {
+    const modal = document.createElement('div');
+    modal.classList.add('modal', 'modal-open');
 
-	document.body.appendChild(modal)
+    let modalContentElement;
+
+    if (contentType === 'image') {
+        modalContentElement = document.createElement('img');
+        modalContentElement.src = contentSrc;
+        modalContentElement.classList.add('modal-img'); // Or a generic class
+    } else if (contentType === 'video') {
+        modalContentElement = document.createElement('video');
+        modalContentElement.src = contentSrc;
+        modalContentElement.controls = true;
+        modalContentElement.autoplay = true; // Optional
+        modalContentElement.classList.add('modal-video'); // Or a generic class
+        // Style the video element for the modal to ensure it's not too small or too large
+        modalContentElement.style.maxWidth = '90vw';
+        modalContentElement.style.maxHeight = '90vh';
+        modalContentElement.style.display = 'block'; // Prevents extra space below video
+        modalContentElement.style.margin = 'auto'; // Centers the video
+    } else {
+        console.error('Unsupported content type for modal:', contentType);
+        return; // Don't open modal for unsupported types
+    }
+
+    modal.appendChild(modalContentElement);
+
+    modal.addEventListener('click', (e) => {
+        // Close only if the modal background (not the content itself) is clicked
+        if (e.target === modal) {
+            // If it's a video, pause it before removing the modal
+            if (contentType === 'video' && modalContentElement) {
+                modalContentElement.pause();
+            }
+            modal.remove();
+        }
+    });
+
+    document.body.appendChild(modal);
 }

--- a/src/public/template/chat/attachment_preview.html
+++ b/src/public/template/chat/attachment_preview.html
@@ -1,4 +1,4 @@
-<div class="attachment" id="attachment-${safeName}-${index}" data-template-type="attachment_preview">
+<div class="attachment" id="attachment-${safeName}-${index}" data-template-type="attachment_preview" data-attachment-type="${file.mimeType.split('/')[0]}">
 	<span class="preview-container"></span>
 	<span class="file-name">${file.name}</span>
 	<span class="attachment-button-group ${showDownloadButton && showDeleteButton ? 'join' : ''}">

--- a/src/public/template/chat/attachment_preview.html
+++ b/src/public/template/chat/attachment_preview.html
@@ -1,4 +1,4 @@
-<div class="attachment" id="attachment-${safeName}-${index}" data-template-type="attachment_preview" data-attachment-type="${file.mimeType.split('/')[0]}">
+<div class="attachment" id="attachment-${safeName}-${index}" data-template-type="attachment_preview">
 	<span class="preview-container"></span>
 	<span class="file-name">${file.name}</span>
 	<span class="attachment-button-group ${showDownloadButton && showDeleteButton ? 'join' : ''}">


### PR DESCRIPTION
This commit enhances video attachments in the chat by introducing a modal viewer. Clicking on a video preview now opens the video in a larger, centered modal with playback controls.

Key changes include:
- Modified `src/public/shells/chat/src/public/ui/modal.mjs`:
    - The `openModal` function was refactored to accept `contentSrc` and `contentType`.
    - It now dynamically creates an `<img>` or `<video>` element based on `contentType`.
    - For videos, it enables controls, autoplay, and applies responsive styling.
    - The modal now closes only when clicking the background, and videos are paused on close.
- Updated `src/public/shells/chat/src/public/fileHandling.mjs`:
    - Video previews no longer show default controls inline.
    - A click listener is added to video previews to call `openModal(videoSrc, 'video')`.
    - The image preview's call to `openModal` was updated to `openModal(imageSrc, 'image')` to align with the new function signature.

This provides a more focused and user-friendly way to view videos shared in the chat.