### PR TITLE
Refine localization data for all locales based on zh-CN

### DIFF
--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -18,7 +18,7 @@
 		"ipc": {
 			"sendCommandFailed": "Senden des Befehls fehlgeschlagen: ${error}",
 			"invalidCommand": "Ungültiger Befehl. Bitte verwenden Sie \"fount run <Part-Typ> <Benutzername> <Part-Name> <Parameter...>\".",
-			"runPartLog": "Starte ${parttype} ${partname} als ${username} mit Parametern: ${args}.",
+			"runPartLog": "Starte ${parttype} ${partname} als ${username} mit Parametern: ${args}",
 			"invokePartLog": "Rufe ${parttype} ${partname} als ${username} mit Parametern: ${invokedata} auf.",
 			"unsupportedCommand": "Nicht unterstützter Befehlstyp",
 			"processMessageError": "Fehler beim Verarbeiten der IPC-Nachricht: ${error}",
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Shell-Befehl gesendet",
 		"shellCommandFailed": "Senden des Shell-Befehls fehlgeschlagen",
 		"shellCommandError": "Fehler beim Senden des Shell-Befehls",
-		"fountNotFound": "awww :(\n\nFount wurde nicht gefunden. Vielleicht müssen Sie es zuerst installieren?",
-		"unknownError": "awww :(\n\nEin Fehler ist aufgetreten:\n"
+		"fountNotFound": "Och nö :(\n\nFount wurde nicht gefunden. Vielleicht müssen Sie es zuerst installieren?",
+		"unknownError": "Och nö :(\n\nEin Fehler ist aufgetreten:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Willkommen bei Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount wird installiert...",
 			"open_fount": "Fount öffnen",
 			"open_or_install_fount": "Fount öffnen/installieren",
-			"error_message": "awww :(\n\nEin Fehler ist aufgetreten:\n"
+			"error_message": "Och nö :(\n\nEin Fehler ist aufgetreten:\n"
 		},
 		"error": {
 			"title": "Installation fehlgeschlagen!",
@@ -202,7 +202,7 @@
 			"endButton": "Weiter!"
 		},
 		"progressMessages": {
-			"mouseMove": "Bitte bewegen Sie die Maus ${mouseIcon} mit Ihrer Hand.",
+			"mouseMove": "Bitte bewegen Sie die Maus ${mouseIcon}.",
 			"keyboardPress": "Drücken Sie eine Taste auf Ihrer Tastatur ${keyboardIcon}.",
 			"mobileTouchMove": "Berühren Sie den Bildschirm Ihres Telefons ${phoneIcon} mit einem Finger und bewegen Sie ihn dann.",
 			"mobileClick": "Tippen Sie mit einem Finger auf den Bildschirm Ihres Telefons ${phoneIcon}."
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "Quelle! Abzeichenwandler",
-		"card_title": "Fount Badge Link Converter",
-		"original_url_label": "Fügen Sie img.shields.io url ein",
-		"original_url_placeholder": "Zum Beispiel: https://img.shields.io/badge/hello-world-blue",
-		"new_url_label": "Die erzeugte neue URL",
+		"title": "Fount! Abzeichenwandler",
+		"card_title": "Fount Abzeichen Link Konverter",
+		"original_url_label": "img.shields.io URL einfügen",
+		"original_url_placeholder": "Zum Beispiel: https://img.shields.io/badge/Hello-World-blue",
+		"new_url_label": "Generierte neue URL",
 		"new_url_placeholder": "Die konvertierte URL wird hier angezeigt",
-		"copy_button": "Kopie",
-		"preview_label": "Effektvorschau",
-		"preview_alt": "Abzeichenvorschau",
+		"copy_button": "Kopieren",
+		"preview_label": "Vorschau",
+		"preview_alt": "Abzeichen-Vorschau",
 		"copied_text": "Kopiert!",
-		"copy_error": "Text kann nicht kopieren:",
-		"copy_fail_alert": "Kopie fehlgeschlagen!"
+		"copy_error": "Text konnte nicht kopiert werden:",
+		"copy_fail_alert": "Kopieren fehlgeschlagen!"
 	}
 }

--- a/src/locales/en-UK.json
+++ b/src/locales/en-UK.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Shell command sent",
 		"shellCommandFailed": "Failed to send shell command",
 		"shellCommandError": "Error sending shell command",
-		"fountNotFound": "awww :(\n\nFount was not found. Perhaps you need to install it first?",
-		"unknownError": "awww :(\n\nAn error occurred:\n"
+		"fountNotFound": "Oh dear :(\n\nFount was not found. Perhaps you need to install it first?",
+		"unknownError": "Oh dear :(\n\nAn error occurred:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Welcome to fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount is installing...",
 			"open_fount": "Open fount",
 			"open_or_install_fount": "Open/Install fount",
-			"error_message": "awww :(\n\nAn error occurred:\n"
+			"error_message": "Oh dear :(\n\nAn error occurred:\n"
 		},
 		"error": {
 			"title": "Installation failed!",
@@ -300,7 +300,7 @@
 			"synthwave": "Synthwave",
 			"retro": "Retro",
 			"cyberpunk": "Cyberpunk",
-			"valentine": "Valentine's Day",
+			"valentine": "Valentine",
 			"halloween": "Halloween",
 			"garden": "Garden",
 			"forest": "Forest",
@@ -347,16 +347,16 @@
 			"import": "Import"
 		},
 		"alerts": {
-			"importSuccess": "Import successful.",
+			"importSuccess": "Import successful",
 			"importFailed": "Import failed: ${error}",
-			"unknownError": "Unknown error."
+			"unknownError": "Unknown error"
 		},
 		"errors": {
-			"noFileSelected": "Please select a file.",
+			"noFileSelected": "Please select a file",
 			"fileImportFailed": "File import failed: ${message}",
-			"noTextContent": "Please enter text content.",
+			"noTextContent": "Please enter text content",
 			"textImportFailed": "Text import failed: ${message}",
-			"unknownError": "Unknown error.",
+			"unknownError": "Unknown error",
 			"handler": "Handler",
 			"error": "Error"
 		},
@@ -396,8 +396,8 @@
 			"deleteFileFailed": "Failed to delete file: ${error}",
 			"invalidFileName": "File name cannot contain the following characters: / \\ : * ? \" < > |",
 			"addFileFailed": "Failed to add file: ${error}",
-			"fetchConfigTemplateFailed": "Failed to fetch config template.",
-			"noGeneratorSelectedSave": "Please select a generator before saving."
+			"fetchConfigTemplateFailed": "Failed to fetch config template",
+			"noGeneratorSelectedSave": "Please select a generator before saving"
 		},
 		"confirm": {
 			"unsavedChanges": "You have unsaved changes. Do you want to discard changes?",
@@ -408,7 +408,7 @@
 			"newFileName": "Please enter a new AI source file name (without extension):"
 		},
 		"editor": {
-			"disabledIndicator": "Please select a generator first."
+			"disabledIndicator": "Please select a generator first"
 		}
 	},
 	"part_config": {
@@ -424,7 +424,7 @@
 		},
 		"editor": {
 			"title": "Part Configuration",
-			"disabledIndicator": "This part does not support configuration.",
+			"disabledIndicator": "This part does not support configuration",
 			"buttons": {
 				"save": "Save"
 			}
@@ -464,9 +464,9 @@
 			"back": "Back"
 		},
 		"alerts": {
-			"success": "${type}: ${name} uninstalled successfully.",
+			"success": "${type}: ${name} uninstalled successfully",
 			"failed": "Uninstall failed: ${error}",
-			"invalidParams": "Invalid request parameters.",
+			"invalidParams": "Invalid request parameters",
 			"httpError": "HTTP Error! Status code: ${status}"
 		}
 	},
@@ -503,7 +503,7 @@
 				}
 			},
 			"noSelection": "None selected",
-			"noDescription": "No description available."
+			"noDescription": "No description available"
 		},
 		"chatArea": {
 			"title": "Chat",
@@ -548,7 +548,7 @@
 			"confirmDeleteMessage": "Are you sure you want to delete this message?"
 		},
 		"voiceRecording": {
-			"errorAccessingMicrophone": "Failed to access microphone."
+			"errorAccessingMicrophone": "Failed to access microphone"
 		},
 		"messageView": {
 			"buttons": {
@@ -708,8 +708,8 @@
 		"alerts": {
 			"botExists": "A bot named \"${botname}\" already exists. Please use another name.",
 			"unsavedChanges": "You have unsaved changes. Do you want to discard these changes?",
-			"configSaved": "Configuration saved successfully.",
-			"httpError": "HTTP Error.",
+			"configSaved": "Configuration saved successfully",
+			"httpError": "HTTP Error",
 			"beforeUnload": "You have unsaved changes. Are you sure you want to leave?"
 		}
 	},
@@ -747,14 +747,14 @@
 			"botExists": "A bot named \"${botname}\" already exists. Please use a different name.",
 			"unsavedChanges": "You have unsaved changes. Are you sure you want to discard these changes?",
 			"configSaved": "Configuration has been saved successfully!",
-			"httpError": "HTTP Error.",
+			"httpError": "HTTP Error",
 			"beforeUnload": "You have unsaved changes. Are you sure you want to leave the current page?"
 		}
 	},
 	"terminal_assistant": {
 		"title": "Terminal Assistant",
 		"initialMessage": "Fount supports deploying your favourite characters to your terminal to assist you in coding!",
-		"initialMessageLink": "Click here to learn more."
+		"initialMessageLink": "Click here to learn more"
 	},
 	"access": {
 		"title": "Access Fount on other devices",
@@ -862,15 +862,15 @@
 	},
 	"badges_maker": {
 		"title": "fount! Badge Converter",
-		"card_title": "Fount badge link converter",
+		"card_title": "Fount Badge Link Converter",
 		"original_url_label": "Paste img.shields.io URL",
 		"original_url_placeholder": "For example: https://img.shields.io/badge/Hello-World-blue",
 		"new_url_label": "The generated new URL",
 		"new_url_placeholder": "The converted URL will be displayed here",
-		"copy_button": "copy",
-		"preview_label": "Effect preview",
-		"preview_alt": "Badge preview",
-		"copied_text": "Copyed!",
+		"copy_button": "Copy",
+		"preview_label": "Preview",
+		"preview_alt": "Badge Preview",
+		"copied_text": "Copied!",
 		"copy_error": "Unable to copy text:",
 		"copy_fail_alert": "Copy failed!"
 	}

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Comando de shell enviado",
 		"shellCommandFailed": "Error al enviar el comando de shell",
 		"shellCommandError": "Error enviando el comando de shell",
-		"fountNotFound": "awww :(\n\nFount no encontrado, ¿quizás necesites instalarlo primero?",
-		"unknownError": "awww :(\n\nOcurrió un error:\n"
+		"fountNotFound": "Ay ay ay :(\n\nFount no encontrado, ¿quizás necesites instalarlo primero?",
+		"unknownError": "Ay ay ay :(\n\nOcurrió un error:\n"
 	},
 	"installer_wait_screen": {
 		"title": "¡Bienvenido a Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount se está instalando...",
 			"open_fount": "Abrir Fount",
 			"open_or_install_fount": "Abrir/Instalar Fount",
-			"error_message": "awww :(\n\nOcurrió un error:\n"
+			"error_message": "Ay ay ay :(\n\nOcurrió un error:\n"
 		},
 		"error": {
 			"title": "¡Error en la instalación!",
@@ -347,16 +347,16 @@
 			"import": "Importar"
 		},
 		"alerts": {
-			"importSuccess": "Importado correctamente.",
+			"importSuccess": "Importado correctamente",
 			"importFailed": "Error al importar: ${error}",
-			"unknownError": "Error desconocido."
+			"unknownError": "Error desconocido"
 		},
 		"errors": {
-			"noFileSelected": "Por favor, selecciona un archivo.",
+			"noFileSelected": "Por favor, selecciona un archivo",
 			"fileImportFailed": "Error al importar el archivo: ${message}",
-			"noTextContent": "Por favor, introduce contenido de texto.",
+			"noTextContent": "Por favor, introduce contenido de texto",
 			"textImportFailed": "Error al importar el texto: ${message}",
-			"unknownError": "Error desconocido.",
+			"unknownError": "Error desconocido",
 			"handler": "Manejador",
 			"error": "Error"
 		},
@@ -396,8 +396,8 @@
 			"deleteFileFailed": "Error al eliminar el archivo: ${error}",
 			"invalidFileName": "El nombre del archivo no puede contener los siguientes caracteres: / \\ : * ? \" < > |",
 			"addFileFailed": "Error al añadir el archivo: ${error}",
-			"fetchConfigTemplateFailed": "Error al obtener la plantilla de configuración.",
-			"noGeneratorSelectedSave": "Por favor, selecciona un generador antes de guardar."
+			"fetchConfigTemplateFailed": "Error al obtener la plantilla de configuración",
+			"noGeneratorSelectedSave": "Por favor, selecciona un generador antes de guardar"
 		},
 		"confirm": {
 			"unsavedChanges": "Tienes cambios sin guardar. ¿Quieres descartarlos?",
@@ -408,7 +408,7 @@
 			"newFileName": "Introduce un nuevo nombre para el archivo de origen de IA (sin extensión):"
 		},
 		"editor": {
-			"disabledIndicator": "Por favor, selecciona primero un generador."
+			"disabledIndicator": "Por favor, selecciona primero un generador"
 		}
 	},
 	"part_config": {
@@ -424,7 +424,7 @@
 		},
 		"editor": {
 			"title": "Configuración de Parte",
-			"disabledIndicator": "Esta parte no admite configuración.",
+			"disabledIndicator": "Esta parte no admite configuración",
 			"buttons": {
 				"save": "Guardar"
 			}
@@ -464,9 +464,9 @@
 			"back": "Volver"
 		},
 		"alerts": {
-			"success": "${type}: ${name} desinstalado correctamente.",
+			"success": "${type}: ${name} desinstalado correctamente",
 			"failed": "Error al desinstalar: ${error}",
-			"invalidParams": "Parámetros de solicitud no válidos.",
+			"invalidParams": "Parámetros de solicitud no válidos",
 			"httpError": "¡Error HTTP! Código de estado: ${status}"
 		}
 	},
@@ -503,7 +503,7 @@
 				}
 			},
 			"noSelection": "Nada seleccionado",
-			"noDescription": "Sin descripción."
+			"noDescription": "Sin descripción"
 		},
 		"chatArea": {
 			"title": "Chat",
@@ -548,7 +548,7 @@
 			"confirmDeleteMessage": "¿Eliminar este mensaje?"
 		},
 		"voiceRecording": {
-			"errorAccessingMicrophone": "Error al acceder al micrófono."
+			"errorAccessingMicrophone": "Error al acceder al micrófono"
 		},
 		"messageView": {
 			"buttons": {
@@ -662,11 +662,11 @@
 		"confirmDeleteChat": "¿Seguro que quieres eliminar el historial de chat con ${chars}?",
 		"confirmDeleteMultiChats": "¿Seguro que quieres eliminar los ${count} historiales de chat seleccionados?",
 		"alerts": {
-			"noChatSelectedForDeletion": "Por favor, selecciona los historiales de chat que quieres eliminar.",
-			"noChatSelectedForExport": "Por favor, selecciona los historiales de chat que quieres exportar.",
-			"copyError": "Error al copiar.",
-			"deleteError": "Error al eliminar.",
-			"exportError": "Error al exportar."
+			"noChatSelectedForDeletion": "Por favor, selecciona los historiales de chat que quieres eliminar",
+			"noChatSelectedForExport": "Por favor, selecciona los historiales de chat que quieres exportar",
+			"copyError": "Error al copiar",
+			"deleteError": "Error al eliminar",
+			"exportError": "Error al exportar"
 		},
 		"chatItemButtons": {
 			"continue": "Continuar",
@@ -708,8 +708,8 @@
 		"alerts": {
 			"botExists": "Ya existe un bot con el nombre \"${botname}\". Por favor, usa otro nombre.",
 			"unsavedChanges": "Tienes cambios sin guardar. ¿Quieres descartarlos?",
-			"configSaved": "Configuración guardada correctamente.",
-			"httpError": "Error HTTP.",
+			"configSaved": "Configuración guardada correctamente",
+			"httpError": "Error HTTP",
 			"beforeUnload": "Tienes cambios sin guardar. ¿Seguro que quieres salir?"
 		}
 	},
@@ -747,14 +747,14 @@
 			"botExists": "Ya existe un bot con el nombre \"${botname}\". Por favor, usa un nombre diferente.",
 			"unsavedChanges": "Tienes cambios sin guardar. ¿Seguro que quieres descartarlos?",
 			"configSaved": "¡La configuración se ha guardado correctamente!",
-			"httpError": "Error HTTP.",
+			"httpError": "Error HTTP",
 			"beforeUnload": "Tienes cambios sin guardar. ¿Seguro que quieres salir de la página actual?"
 		}
 	},
 	"terminal_assistant": {
 		"title": "Asistente de Terminal",
 		"initialMessage": "¡Fount te permite usar tus personajes favoritos en la terminal para ayudarte a programar!",
-		"initialMessageLink": "Haz clic aquí para más información."
+		"initialMessageLink": "Haz clic aquí para más información"
 	},
 	"access": {
 		"title": "Acceder a Fount en otros dispositivos",
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "¡fuente! Convertidor de insignia",
-		"card_title": "Convertidor de enlace de insignia de fuente",
-		"original_url_label": "Pegar img.shields.io URL",
-		"original_url_placeholder": "Por ejemplo: https://img.shields.io/badge/hello-world-blue",
-		"new_url_label": "La nueva URL generada",
+		"title": "¡Fount! Convertidor de Insignias",
+		"card_title": "Convertidor de Enlaces de Insignias Fount",
+		"original_url_label": "Pegar URL de img.shields.io",
+		"original_url_placeholder": "Por ejemplo: https://img.shields.io/badge/Hello-World-blue",
+		"new_url_label": "Nueva URL generada",
 		"new_url_placeholder": "La URL convertida se mostrará aquí",
 		"copy_button": "Copiar",
-		"preview_label": "Vista previa de efectos",
+		"preview_label": "Vista previa",
 		"preview_alt": "Vista previa de la insignia",
-		"copied_text": "¡Combinado!",
-		"copy_error": "No se puede copiar texto:",
-		"copy_fail_alert": "¡Copia falló!"
+		"copied_text": "¡Copiado!",
+		"copy_error": "Error al copiar el texto:",
+		"copy_fail_alert": "¡Error al copiar!"
 	}
 }

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Commande shell envoyée.",
 		"shellCommandFailed": "Échec de l'envoi de la commande shell.",
 		"shellCommandError": "Erreur lors de l'envoi de la commande shell.",
-		"fountNotFound": "awww :(\n\nFount introuvable. Peut-être devez-vous d'abord l'installer ?",
-		"unknownError": "awww :(\n\nUne erreur s'est produite :\n"
+		"fountNotFound": "Oh là là :(\n\nFount introuvable. Peut-être devez-vous d'abord l'installer ?",
+		"unknownError": "Oh là là :(\n\nUne erreur s'est produite :\n"
 	},
 	"installer_wait_screen": {
 		"title": "Bienvenue sur Fount !",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount est en cours d'installation...",
 			"open_fount": "Ouvrir Fount",
 			"open_or_install_fount": "Ouvrir/Installer Fount",
-			"error_message": "awww :(\n\nUne erreur s'est produite :\n"
+			"error_message": "Oh là là :(\n\nUne erreur s'est produite :\n"
 		},
 		"error": {
 			"title": "Échec de l'installation !",
@@ -347,16 +347,16 @@
 			"import": "Importer"
 		},
 		"alerts": {
-			"importSuccess": "Importation réussie.",
+			"importSuccess": "Importation réussie",
 			"importFailed": "Échec de l'importation : ${error}",
-			"unknownError": "Erreur inconnue."
+			"unknownError": "Erreur inconnue"
 		},
 		"errors": {
 			"noFileSelected": "Veuillez sélectionner un fichier.",
 			"fileImportFailed": "Échec de l'importation du fichier : ${message}",
 			"noTextContent": "Veuillez saisir du contenu texte.",
 			"textImportFailed": "Échec de l'importation du texte : ${message}",
-			"unknownError": "Erreur inconnue.",
+			"unknownError": "Erreur inconnue",
 			"handler": "Gestionnaire",
 			"error": "Erreur"
 		},
@@ -396,8 +396,8 @@
 			"deleteFileFailed": "Échec de la suppression du fichier : ${error}",
 			"invalidFileName": "Le nom de fichier ne peut pas contenir les caractères suivants : / \\ : * ? \" < > |",
 			"addFileFailed": "Échec de l'ajout du fichier : ${error}",
-			"fetchConfigTemplateFailed": "Échec de la récupération du modèle de configuration.",
-			"noGeneratorSelectedSave": "Veuillez sélectionner un générateur avant d'enregistrer."
+			"fetchConfigTemplateFailed": "Échec de la récupération du modèle de configuration",
+			"noGeneratorSelectedSave": "Veuillez sélectionner un générateur avant d'enregistrer"
 		},
 		"confirm": {
 			"unsavedChanges": "Vous avez des modifications non enregistrées. Voulez-vous annuler les modifications ?",
@@ -408,7 +408,7 @@
 			"newFileName": "Veuillez saisir un nouveau nom de fichier pour la source d'IA (sans extension) :"
 		},
 		"editor": {
-			"disabledIndicator": "Veuillez d'abord sélectionner un générateur."
+			"disabledIndicator": "Veuillez d'abord sélectionner un générateur"
 		}
 	},
 	"part_config": {
@@ -424,7 +424,7 @@
 		},
 		"editor": {
 			"title": "Configuration du Composant",
-			"disabledIndicator": "Ce composant ne prend pas en charge la configuration.",
+			"disabledIndicator": "Ce composant ne prend pas en charge la configuration",
 			"buttons": {
 				"save": "Enregistrer"
 			}
@@ -464,9 +464,9 @@
 			"back": "Retour"
 		},
 		"alerts": {
-			"success": "${type} : ${name} désinstallé avec succès.",
+			"success": "${type} : ${name} désinstallé avec succès",
 			"failed": "Échec de la désinstallation : ${error}",
-			"invalidParams": "Paramètres de requête non valides.",
+			"invalidParams": "Paramètres de requête non valides",
 			"httpError": "Erreur HTTP ! Code d'état : ${status}"
 		}
 	},
@@ -503,7 +503,7 @@
 				}
 			},
 			"noSelection": "Rien de sélectionné",
-			"noDescription": "Aucune description disponible."
+			"noDescription": "Aucune description disponible"
 		},
 		"chatArea": {
 			"title": "Chat",
@@ -548,7 +548,7 @@
 			"confirmDeleteMessage": "Supprimer ce message ?"
 		},
 		"voiceRecording": {
-			"errorAccessingMicrophone": "Échec de l'accès au microphone."
+			"errorAccessingMicrophone": "Échec de l'accès au microphone"
 		},
 		"messageView": {
 			"buttons": {
@@ -662,11 +662,11 @@
 		"confirmDeleteChat": "Êtes-vous sûr de vouloir supprimer l'historique des chats avec ${chars} ?",
 		"confirmDeleteMultiChats": "Êtes-vous sûr de vouloir supprimer les ${count} historiques de chats sélectionnés ?",
 		"alerts": {
-			"noChatSelectedForDeletion": "Veuillez sélectionner les historiques de chats à supprimer.",
-			"noChatSelectedForExport": "Veuillez sélectionner les historiques de chats à exporter.",
-			"copyError": "Échec de la copie.",
-			"deleteError": "Échec de la suppression.",
-			"exportError": "Échec de l'exportation."
+			"noChatSelectedForDeletion": "Veuillez sélectionner les historiques de chats à supprimer",
+			"noChatSelectedForExport": "Veuillez sélectionner les historiques de chats à exporter",
+			"copyError": "Échec de la copie",
+			"deleteError": "Échec de la suppression",
+			"exportError": "Échec de l'exportation"
 		},
 		"chatItemButtons": {
 			"continue": "Continuer",
@@ -708,8 +708,8 @@
 		"alerts": {
 			"botExists": "Un bot nommé \"${botname}\" existe déjà. Veuillez utiliser un autre nom.",
 			"unsavedChanges": "Vous avez des modifications non enregistrées. Voulez-vous annuler les modifications ?",
-			"configSaved": "Configuration enregistrée avec succès.",
-			"httpError": "Erreur HTTP.",
+			"configSaved": "Configuration enregistrée avec succès",
+			"httpError": "Erreur HTTP",
 			"beforeUnload": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter ?"
 		}
 	},
@@ -747,14 +747,14 @@
 			"botExists": "Un bot nommé \"${botname}\" existe déjà. Veuillez utiliser un autre nom.",
 			"unsavedChanges": "Vous avez des modifications non enregistrées. Voulez-vous vraiment annuler ces modifications ?",
 			"configSaved": "La configuration a été enregistrée avec succès !",
-			"httpError": "Erreur HTTP.",
+			"httpError": "Erreur HTTP",
 			"beforeUnload": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter cette page ?"
 		}
 	},
 	"terminal_assistant": {
 		"title": "Assistant Terminal",
 		"initialMessage": "Fount prend en charge le déploiement de vos personnages préférés dans votre terminal pour vous assister lors du codage !",
-		"initialMessageLink": "Cliquez ici pour en savoir plus."
+		"initialMessageLink": "Cliquez ici pour en savoir plus"
 	},
 	"access": {
 		"title": "Accéder à Fount sur d'autres appareils",
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "source! Convertisseur de badge",
-		"card_title": "Convertisseur de liaison de badge de fontaine",
-		"original_url_label": "Pâtez iMg.shields.io URL",
-		"original_url_placeholder": "Par exemple: https://img.shields.io/badge/hello-world-blue",
-		"new_url_label": "La nouvelle URL générée",
+		"title": "Fount! Convertisseur de Badges",
+		"card_title": "Convertisseur de Liens de Badges Fount",
+		"original_url_label": "Collez l'URL img.shields.io",
+		"original_url_placeholder": "Par exemple : https://img.shields.io/badge/Hello-World-blue",
+		"new_url_label": "Nouvelle URL générée",
 		"new_url_placeholder": "L'URL convertie sera affichée ici",
-		"copy_button": "copie",
-		"preview_label": "Aperçu de l'effet",
+		"copy_button": "Copier",
+		"preview_label": "Aperçu",
 		"preview_alt": "Aperçu du badge",
-		"copied_text": "Copie!",
-		"copy_error": "Impossible de copier le texte:",
-		"copy_fail_alert": "Copie a échoué!"
+		"copied_text": "Copié !",
+		"copy_error": "Impossible de copier le texte :",
+		"copy_fail_alert": "La copie a échoué !"
 	}
 }

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "शेल कमांड भेज दिया गया है।",
 		"shellCommandFailed": "शेल कमांड भेजने में विफल।",
 		"shellCommandError": "शेल कमांड भेजने में त्रुटि।",
-		"fountNotFound": "awww :(\n\nFount नहीं मिला, शायद आपको इसे पहले इंस्टॉल करने की ज़रूरत है?",
-		"unknownError": "awww :(\n\nएक त्रुटि हुई:\n"
+		"fountNotFound": "ओह हो :(\n\nFount नहीं मिला, शायद आपको इसे पहले इंस्टॉल करने की ज़रूरत है?",
+		"unknownError": "ओह हो :(\n\nएक त्रुटि हुई:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Fount में आपका स्वागत है!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount इंस्टॉल हो रहा है...",
 			"open_fount": "Fount खोलें",
 			"open_or_install_fount": "Fount खोलें/इंस्टॉल करें",
-			"error_message": "awww :(\n\nएक त्रुटि हुई:\n"
+			"error_message": "ओह हो :(\n\nएक त्रुटि हुई:\n"
 		},
 		"error": {
 			"title": "इंस्टॉलेशन विफल!",
@@ -323,7 +323,7 @@
 			"dim": "मंद",
 			"nord": "नॉर्ड",
 			"sunset": "सूर्यास्त",
-			"caramellatte": "कैरामल लाटे",
+			"caramellatte": "चॉकलेट लाटे",
 			"abyss": "अगाध",
 			"silk": "रेशम"
 		}
@@ -861,16 +861,16 @@
 		}
 	},
 	"badges_maker": {
-		"title": "फव्वारा! बैज कनवर्टर",
-		"card_title": "फाउंट बैज लिंक कनवर्टर",
-		"original_url_label": "पेस्ट img.shields.io url",
+		"title": "Fount! बैज कन्वर्टर",
+		"card_title": "Fount बैज लिंक कन्वर्टर",
+		"original_url_label": "img.shields.io URL पेस्ट करें",
 		"original_url_placeholder": "उदाहरण के लिए: https://img.shields.io/badge/hello-world-blue",
 		"new_url_label": "उत्पन्न नया URL",
 		"new_url_placeholder": "परिवर्तित URL यहां प्रदर्शित किया जाएगा",
 		"copy_button": "कॉपी",
-		"preview_label": "प्रभाव पूर्वावलोकन",
+		"preview_label": "पूर्वावलोकन",
 		"preview_alt": "बैज पूर्वावलोकन",
-		"copied_text": "कॉपी!",
+		"copied_text": "कॉपीड!",
 		"copy_error": "पाठ को कॉपी करने में असमर्थ:",
 		"copy_fail_alert": "कॉपी विफल!"
 	}

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Comando shell inviato.",
 		"shellCommandFailed": "Impossibile inviare il comando shell.",
 		"shellCommandError": "Errore durante l'invio del comando shell.",
-		"fountNotFound": "awww :(\n\nFount non trovato. Forse devi prima installarlo?",
-		"unknownError": "awww :(\n\nSi è verificato un errore:\n"
+		"fountNotFound": "Uffa :(\n\nFount non trovato. Forse devi prima installarlo?",
+		"unknownError": "Uffa :(\n\nSi è verificato un errore:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Benvenuto in Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount è in fase di installazione...",
 			"open_fount": "Apri Fount",
 			"open_or_install_fount": "Apri/Installa Fount",
-			"error_message": "awww :(\n\nSi è verificato un errore:\n"
+			"error_message": "Uffa :(\n\nSi è verificato un errore:\n"
 		},
 		"error": {
 			"title": "Installazione non riuscita!",
@@ -323,7 +323,7 @@
 			"dim": "Tenue",
 			"nord": "Nord",
 			"sunset": "Tramonto",
-			"caramellatte": "Caramel Latte",
+			"caramellatte": "Cioccolatte",
 			"abyss": "Abisso",
 			"silk": "Seta"
 		}
@@ -861,14 +861,14 @@
 		}
 	},
 	"badges_maker": {
-		"title": "fonte! Convertitore distintivo",
-		"card_title": "Convertitore di link badge di fonte",
-		"original_url_label": "Incolla img.shields.io URL",
+		"title": "Fount! Convertitore di Badge",
+		"card_title": "Convertitore di Link Badge Fount",
+		"original_url_label": "Incolla URL img.shields.io",
 		"original_url_placeholder": "Ad esempio: https://img.shields.io/badge/hello-world-blue",
-		"new_url_label": "Il nuovo URL generato",
+		"new_url_label": "Nuovo URL generato",
 		"new_url_placeholder": "L'URL convertito verrà visualizzato qui",
-		"copy_button": "copia",
-		"preview_label": "Anteprima dell'effetto",
+		"copy_button": "Copia",
+		"preview_label": "Anteprima",
 		"preview_alt": "Anteprima del badge",
 		"copied_text": "Copiato!",
 		"copy_error": "Impossibile copiare il testo:",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "シェルコマンドを送信しました。",
 		"shellCommandFailed": "シェルコマンドの送信に失敗しました。",
 		"shellCommandError": "シェルコマンドの送信中にエラーが発生しました。",
-		"fountNotFound": "awww :(\n\nFountが見つかりませんでした。最初にインストールする必要がありますか？",
-		"unknownError": "awww :(\n\nエラーが発生しました：\n"
+		"fountNotFound": "あらら…\n\nFountが見つかりませんでした。最初にインストールする必要がありますか？",
+		"unknownError": "あらら…\n\nエラーが発生しました：\n"
 	},
 	"installer_wait_screen": {
 		"title": "Fountへようこそ！",
@@ -121,7 +121,7 @@
 			"launch_button": "Fountをインストール中...",
 			"open_fount": "Fountを開く",
 			"open_or_install_fount": "Fountを開く/インストール",
-			"error_message": "awww :(\n\nエラーが発生しました：\n"
+			"error_message": "あらら…\n\nエラーが発生しました：\n"
 		},
 		"error": {
 			"title": "インストールに失敗しました！",
@@ -323,7 +323,7 @@
 			"dim": "ディム",
 			"nord": "ノール",
 			"sunset": "サンセット",
-			"caramellatte": "キャラメルラテ",
+			"caramellatte": "チョコレートラテ",
 			"abyss": "アビス",
 			"silk": "シルク"
 		}
@@ -861,16 +861,16 @@
 		}
 	},
 	"badges_maker": {
-		"title": "噴水！バッジコンバーター",
-		"card_title": "ファウントバッジリンクコンバーター",
-		"original_url_label": "IMG.Shields.io URLを貼り付けます",
-		"original_url_placeholder": "例：https：//img.shields.io/badge/hello-world-blue",
+		"title": "Fount! バッジコンバーター",
+		"card_title": "Fountバッジリンクコンバーター",
+		"original_url_label": "img.shields.io URLを貼り付けます",
+		"original_url_placeholder": "例：https://img.shields.io/badge/hello-world-blue",
 		"new_url_label": "生成された新しいURL",
 		"new_url_placeholder": "変換されたURLはここに表示されます",
 		"copy_button": "コピー",
 		"preview_label": "効果プレビュー",
 		"preview_alt": "バッジプレビュー",
-		"copied_text": "コピー！",
+		"copied_text": "コピーしました！",
 		"copy_error": "テキストをコピーできません：",
 		"copy_fail_alert": "コピーが失敗しました！"
 	}

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "셸 명령이 전송되었습니다.",
 		"shellCommandFailed": "셸 명령 전송에 실패했습니다.",
 		"shellCommandError": "셸 명령 전송 중 오류가 발생했습니다.",
-		"fountNotFound": "awww :(\n\nFount를 찾을 수 없습니다. 먼저 설치해야 할까요?",
-		"unknownError": "awww :(\n\n오류가 발생했습니다:\n"
+		"fountNotFound": "아이고…\n\nFount를 찾을 수 없습니다. 먼저 설치해야 할까요?",
+		"unknownError": "아이고…\n\n오류가 발생했습니다:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Fount에 오신 것을 환영합니다!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount 설치 중...",
 			"open_fount": "Fount 열기",
 			"open_or_install_fount": "Fount 열기/설치하기",
-			"error_message": "awww :(\n\n오류가 발생했습니다:\n"
+			"error_message": "아이고…\n\n오류가 발생했습니다:\n"
 		},
 		"error": {
 			"title": "설치 실패!",
@@ -323,7 +323,7 @@
 			"dim": "딤",
 			"nord": "노드",
 			"sunset": "선셋",
-			"caramellatte": "캐러멜 라테",
+			"caramellatte": "초콜릿 라테",
 			"abyss": "어비스",
 			"silk": "실크"
 		}
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "세례반! 배지 변환기",
-		"card_title": "배지 링크 컨버터",
-		"original_url_label": "IMG.Shields.io URL을 붙여 넣습니다",
-		"original_url_placeholder": "예 : https://img.shields.io/badge/hello-world-blue",
-		"new_url_label": "생성 된 새로운 URL",
-		"new_url_placeholder": "변환 된 URL이 여기에 표시됩니다",
+		"title": "Fount! 배지 변환기",
+		"card_title": "Fount 배지 링크 컨버터",
+		"original_url_label": "img.shields.io URL을 붙여넣으세요",
+		"original_url_placeholder": "예: https://img.shields.io/badge/hello-world-blue",
+		"new_url_label": "생성된 새 URL",
+		"new_url_placeholder": "변환된 URL이 여기에 표시됩니다",
 		"copy_button": "복사",
 		"preview_label": "효과 미리보기",
 		"preview_alt": "배지 미리보기",
-		"copied_text": "사본!",
-		"copy_error": "텍스트를 복사 할 수 없습니다 :",
+		"copied_text": "복사됨!",
+		"copy_error": "텍스트를 복사할 수 없습니다:",
 		"copy_fail_alert": "복사 실패!"
 	}
 }

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Comando shell enviado.",
 		"shellCommandFailed": "Falha ao enviar o comando shell.",
 		"shellCommandError": "Erro ao enviar o comando shell.",
-		"fountNotFound": "awww :(\n\nFount não encontrado. Talvez precise de o instalar primeiro?",
-		"unknownError": "awww :(\n\nOcorreu um erro:\n"
+		"fountNotFound": "Oh não :(\n\nFount não encontrado. Talvez precise de o instalar primeiro?",
+		"unknownError": "Oh não :(\n\nOcorreu um erro:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Bem-vindo ao Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount está a instalar...",
 			"open_fount": "Abrir Fount",
 			"open_or_install_fount": "Abrir/Instalar Fount",
-			"error_message": "awww :(\n\nOcorreu um erro:\n"
+			"error_message": "Oh não :(\n\nOcorreu um erro:\n"
 		},
 		"error": {
 			"title": "A instalação falhou!",
@@ -323,7 +323,7 @@
 			"dim": "Ténue",
 			"nord": "Nórdico",
 			"sunset": "Pôr do sol",
-			"caramellatte": "Caramel Latte",
+			"caramellatte": "Chocolate Latte",
 			"abyss": "Abismo",
 			"silk": "Seda"
 		}
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "fonte! Conversor de crachá",
-		"card_title": "Conversor de link para emblemas da fonte",
-		"original_url_label": "Colar img.shields.io url",
+		"title": "Fount! Conversor de Crachás",
+		"card_title": "Conversor de Links para Emblemas Fount",
+		"original_url_label": "Colar URL img.shields.io",
 		"original_url_placeholder": "Por exemplo: https://img.shields.io/badge/hello-world-blue",
 		"new_url_label": "O novo URL gerado",
 		"new_url_placeholder": "O URL convertido será exibido aqui",
-		"copy_button": "cópia",
-		"preview_label": "Visualização de efeito",
+		"copy_button": "Copiar",
+		"preview_label": "Antevisão",
 		"preview_alt": "Visualização de crachá",
 		"copied_text": "Copiado!",
-		"copy_error": "Incapaz de copiar o texto:",
+		"copy_error": "Não foi possível copiar o texto:",
 		"copy_fail_alert": "A cópia falhou!"
 	}
 }

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Команда оболочки отправлена.",
 		"shellCommandFailed": "Не удалось отправить команду оболочки.",
 		"shellCommandError": "Ошибка при отправке команды оболочки.",
-		"fountNotFound": "awww :(\n\nFount не найден. Возможно, вам нужно сначала его установить?",
-		"unknownError": "awww :(\n\nПроизошла ошибка:\n"
+		"fountNotFound": "Ой... :(\n\nFount не найден. Возможно, вам нужно сначала его установить?",
+		"unknownError": "Ой... :(\n\nПроизошла ошибка:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Добро пожаловать в Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount устанавливается...",
 			"open_fount": "Открыть Fount",
 			"open_or_install_fount": "Открыть/Установить Fount",
-			"error_message": "awww :(\n\nПроизошла ошибка:\n"
+			"error_message": "Ой... :(\n\nПроизошла ошибка:\n"
 		},
 		"error": {
 			"title": "Установка не удалась!",
@@ -323,7 +323,7 @@
 			"dim": "Тусклая",
 			"nord": "Норд",
 			"sunset": "Закат",
-			"caramellatte": "Карамельный латте",
+			"caramellatte": "Шоколадный латте",
 			"abyss": "Бездна",
 			"silk": "Шелк"
 		}
@@ -861,17 +861,17 @@
 		}
 	},
 	"badges_maker": {
-		"title": "Вернут! Конвертер значков",
-		"card_title": "Конвертер ссылок на фонд значков",
-		"original_url_label": "Вставьте img.shields.io url",
+		"title": "Fount! Конвертер значков",
+		"card_title": "Конвертер ссылок на значки Fount",
+		"original_url_label": "Вставьте URL img.shields.io",
 		"original_url_placeholder": "Например: https://img.shields.io/badge/hello-world-blue",
 		"new_url_label": "Сгенерированный новый URL",
 		"new_url_placeholder": "Конвертированный URL будет отображаться здесь",
-		"copy_button": "копия",
-		"preview_label": "Предварительный просмотр эффекта",
+		"copy_button": "Копировать",
+		"preview_label": "Предпросмотр",
 		"preview_alt": "Предварительный просмотр значков",
-		"copied_text": "Копировано!",
+		"copied_text": "Скопировано!",
 		"copy_error": "Невозможно скопировать текст:",
-		"copy_fail_alert": "Копия не удалась!"
+		"copy_fail_alert": "Копирование не удалось!"
 	}
 }

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -81,8 +81,8 @@
 		"shellCommandSent": "Lệnh Shell đã được gửi.",
 		"shellCommandFailed": "Gửi lệnh Shell thất bại.",
 		"shellCommandError": "Đã xảy ra lỗi khi gửi lệnh Shell.",
-		"fountNotFound": "awww :(\n\nKhông tìm thấy Fount. Có lẽ bạn cần cài đặt trước?",
-		"unknownError": "awww :(\n\nĐã xảy ra lỗi:\n"
+		"fountNotFound": "Ối... :(\n\nKhông tìm thấy Fount. Có lẽ bạn cần cài đặt trước?",
+		"unknownError": "Ối... :(\n\nĐã xảy ra lỗi:\n"
 	},
 	"installer_wait_screen": {
 		"title": "Chào mừng đến với Fount!",
@@ -121,7 +121,7 @@
 			"launch_button": "Fount đang được cài đặt...",
 			"open_fount": "Mở Fount",
 			"open_or_install_fount": "Mở/Cài đặt Fount",
-			"error_message": "awww :(\n\nĐã xảy ra lỗi:\n"
+			"error_message": "Ối... :(\n\nĐã xảy ra lỗi:\n"
 		},
 		"error": {
 			"title": "Cài đặt thất bại!",
@@ -323,7 +323,7 @@
 			"dim": "Mờ ảo",
 			"nord": "Nord",
 			"sunset": "Hoàng hôn",
-			"caramellatte": "Caramel Latte",
+			"caramellatte": "Latte Sô cô la",
 			"abyss": "Vực thẳm",
 			"silk": "Lụa"
 		}
@@ -863,12 +863,12 @@
 	"badges_maker": {
 		"title": "Fount! Bộ chuyển đổi huy hiệu",
 		"card_title": "Bộ chuyển đổi liên kết huy hiệu Fount",
-		"original_url_label": "Dán IMG.Shields.io URL",
+		"original_url_label": "Dán URL img.shields.io",
 		"original_url_placeholder": "Ví dụ: https://img.shields.io/badge/hello-world-blue",
 		"new_url_label": "URL mới được tạo",
 		"new_url_placeholder": "URL được chuyển đổi sẽ được hiển thị tại đây",
-		"copy_button": "sao chép",
-		"preview_label": "Xem trước hiệu ứng",
+		"copy_button": "Sao chép",
+		"preview_label": "Xem trước",
 		"preview_alt": "Xem trước huy hiệu",
 		"copied_text": "Đã sao chép!",
 		"copy_error": "Không thể sao chép văn bản:",


### PR DESCRIPTION
This commit includes manual polishing of all JSON files under `src/locales` based on the `zh-CN.json` reference.

Key changes include:
- Localization of the "awww :(" expression for each language.
- Correction of specific terms, such as the Fount brand name and the translation for "chocolate latte".
- Optimization of button texts and various UI messages for better natural language feel.
- Unification of end-of-sentence punctuation for Hindi (using purn viram).