### PR TITLE
feat: Extend OG tag refinement to shell pages

### DIFF
--- a/.github/pages/badges/index.html
+++ b/.github/pages/badges/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount!">
+	<meta property="og:title" content="Crafting Emblems: A Fount Badge Converter" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/badges/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="A tool to convert shields.io badges for fount.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="For when your project whispers for a touch of Fount's soul. Convert shields.io badges, imbuing them with a new, resonant identity." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title data-i18n="badges_maker.title"></title>

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount!">
+	<meta property="og:title" content="The Threshold of Imagination: Begin Your Fount Journey" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Redirecting to fount installation page.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="A fleeting pause, a breath held before the world of Fount unfolds. Soon, you'll be on your way to new companions." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title>fount!</title>

--- a/.github/pages/protocol/index.html
+++ b/.github/pages/protocol/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount! Protocol Handler">
+	<meta property="og:title" content="Whispers in the Digital Stream: Fount Protocol Handler" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Handles fount:// protocol URLs and redirects to the appropriate fount application page.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Guiding the unseen currents, this page ensures your Fount links lead you true, connecting intentions to immersive realities." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title data-i18n="protocolhandler.title"></title>

--- a/.github/pages/readme/index.html
+++ b/.github/pages/readme/index.html
@@ -3,10 +3,10 @@
 
 <head>
 	<meta charset="UTF-8">
-	<meta property="og:title" content="fount! Documentation">
+	<meta property="og:title" content="The Story of Fount: Unveiling the Narrative in Your Tongue" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/readme/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Redirects to the appropriate language version of the fount project's README documentation on GitHub.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="A quiet redirection to the heart of Fount's documentation, finding the words that speak most clearly to you. The journey of understanding begins here." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title>Language Redirect</title>

--- a/.github/pages/values_update/index.html
+++ b/.github/pages/values_update/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount!">
+	<meta property="og:title" content="Echoes of Preference: Fount Settings Synchronizer" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/values_update">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="values update">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="A momentary passage where Fount attunes to your choices, whispering new settings into the browser's memory before guiding you onward or gently closing the way." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title>fount!</title>

--- a/.github/pages/wait/index.html
+++ b/.github/pages/wait/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount! - Waiting for Service">
+	<meta property="og:title" content="Anticipation's Stillness: Awaiting Fount's Awakening" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/wait/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Waiting for the fount local service to become available before redirecting.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="In this quiet interlude, we await the stirring of your local Fount service. A moment of patience before the portal to your AI companions opens." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<link rel="icon" type="image/x-icon" href="https://steve02081504.github.io/fount/imgs/icon.ico">
 	<title>fount!</title>

--- a/src/pages/404/index.html
+++ b/src/pages/404/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount! - 404">
+	<meta property="og:title" content="Lost in Echoes: A Page Unfound in Fount" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/404">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="there is no page here">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="The path you sought has dissolved into mist. Perhaps a misstep, a forgotten turn? Let's guide you back to familiar shores, or pause for a game amidst the void." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="404.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount! - Welcome">
+	<meta property="og:title" content="Fount's Embrace: Awakening Your Digital Companions" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Welcome to fount! Redirecting to the main application or protocol handler.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Welcome to the threshold of Fount. A brief moment of preparation, and then, into the heart of conversations and stories yet to unfold." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title>fount!</title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/pages/login/index.html
+++ b/src/pages/login/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Login - fount!">
+	<meta property="og:title" content="The Threshold of Self: Entering Your Fount Sanctuary" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/login/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Login or register for fount to access your personalized experience.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Here, you define your presence. Whether returning to a familiar haven or carving out a new space for your stories, this is where your personal Fount journey begins." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="auth.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/pages/protocolhandler/index.html
+++ b/src/pages/protocolhandler/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="fount! Protocol Handler">
+	<meta property="og:title" content="Bridging Worlds: Fount's Internal Navigator" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/protocolhandler/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Processing fount protocol requests and redirecting to the appropriate application page.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Silently, efficiently, this page deciphers your intent, translating protocol requests into seamless transitions within your Fount experience. The magic behind the curtain." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="protocolhandler.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/AIsourceManage/index.html
+++ b/src/public/shells/AIsourceManage/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="AI Source Editor - fount!">
+	<meta property="og:title" content="Whispers of Creation: Shaping Fount's AI Oracles" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/AIsourceManage/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Manage and configure AI sources for fount. Add, edit, and delete AI source configurations using a JSON editor.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Here, you conduct the symphony of AI voices. Add, sculpt, or silence the sources that breathe life into your Fount companions. A delicate dance of code and imagination." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="aisource_editor.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/access/index.html
+++ b/src/public/shells/access/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Access fount Remotely - fount!">
+	<meta property="og:title" content="Echoes Across the Network: Reaching Your Fount Remotely" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/access/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Access your fount application from other devices on the same network using the provided URL or QR code.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Extend Fount's embrace beyond a single screen. Here lies the gateway—a URL, a QR code—to connect with your companions from other devices, a quiet bridge across the local ether." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="access.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui@5" rel="stylesheet" type="text/css" />

--- a/src/public/shells/chat/index.html
+++ b/src/public/shells/chat/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Chat - fount!">
+	<meta property="og:title" content="The Stage of Whispers: Your Fount Conversations" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/chat/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Engage in conversations, manage chat settings, and interact with AI personas within the fount chat interface.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Where words take flight and stories unfold. Engage with your AI companions, shape the narrative, and lose yourself in the ebb and flow of digital dialogue. The heart of Fount beats here." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="chat.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/chat/list/index.html
+++ b/src/public/shells/chat/list/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Chat History - fount!">
+	<meta property="og:title" content="Chronicles of Connection: Your Fount Chat Archives" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/chat/list/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="View, manage, sort, filter, and export your chat history in fount.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Journey through dialogues past. Here, memories of conversations linger—sort, filter, and revisit the stories you've woven with your AI companions. A quiet library of digital echoes." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="chat_history.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/chat/new/index.html
+++ b/src/public/shells/chat/new/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="New Chat - fount!">
+	<meta property="og:title" content="A Fresh Page: Beginning a New Fount Dialogue" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/chat/new/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Starting a new chat session in fount.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="The quiet anticipation of a story yet unwritten. A new chat begins, a clean slate for fresh interactions and unfolding narratives with your chosen companions." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="chat.new.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/config/index.html
+++ b/src/public/shells/config/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Part Configuration - fount!">
+	<meta property="og:title" content="The Inner Workings: Configuring Fount's Elements" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/config/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Configure various parts and components of the fount application using a JSON editor.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Peer into the heart of Fount's machinery. Here, you adjust the settings of its diverse components, tuning the engine that drives your immersive experiences. A space for careful calibration." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="part_config.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/discordbot/index.html
+++ b/src/public/shells/discordbot/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Discord Bot Management - fount!">
+	<meta property="og:title" content="Digital Emissaries: Weaving Fount into Discord's Tapestry" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/discordbot/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Configure, manage, and run Discord bots integrated with fount. Select characters, set API keys, and customize bot configurations.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Give your Fount companions a voice in the bustling halls of Discord. Configure their presence, manage their operations, and let them bridge worlds, one server at a time." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="discord_bots.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/home/index.html
+++ b/src/public/shells/home/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Home - fount!">
+	<meta property="og:title" content="Fount's Hearth: Your Worlds, Characters, and Personas Await" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/home/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Welcome to the fount dashboard. Manage your characters, worlds, personas, and access various application features.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="The heart of your Fount experience. Here, manage the denizens of your imagination—characters, worlds, and personas. Your stories begin and branch from this central nexus." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="home.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/install/index.html
+++ b/src/public/shells/install/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Import Data - fount!">
+	<meta property="og:title" content="Gathering the Threads: Importing Your Creations into Fount" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/install/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Import data into fount by uploading files or pasting text. Supports various formats for characters, worlds, or other configurations.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Bring your cherished characters, worlds, and configurations into Fount's embrace. Whether from file or pasted text, this is where new elements are woven into your personal tapestry." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="import.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/install/uninstall/index.html
+++ b/src/public/shells/install/uninstall/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Uninstall - fount!">
+	<meta property="og:title" content="A Gentle Parting: Uninstalling from Fount" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/install/uninstall/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Confirm and proceed with uninstallation. This page allows users to remove components or the entire fount application.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Should you choose to let go, this space allows for a graceful farewell. Confirm the removal of components, or Fount itself, with a quiet click. Paths diverge, memories remain." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="uninstall.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/proxy/index.html
+++ b/src/public/shells/proxy/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="API Proxy Information - fount!">
+	<meta property="og:title" content="The Conduit: Fount's API Proxy Gateway" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/proxy/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Access the fount API proxy. Provides the proxy URL and example code for integration.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="For developers and integrators, this page unveils the Fount API proxy—your connection point for weaving Fount's capabilities into other applications. A technical yet vital link." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="proxy.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/shellassist/index.html
+++ b/src/public/shells/shellassist/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Terminal Assistant - fount!">
+	<meta property="og:title" content="The Oracle's Prompt: Fount's Terminal Assistant" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/shellassist/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Interact with the fount terminal assistant. Execute commands and manage your system through a web-based terminal interface.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Beyond the veil of graphics, a space for direct command. Interact with Fount's core through the terminal assistant, a place where text weaves its own potent magic." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="terminal_assistant.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/telegrambot/index.html
+++ b/src/public/shells/telegrambot/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Telegram Bot Management - fount!">
+	<meta property="og:title" content="Telegrams from the Soul: Fount's Messengers on Telegram" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/telegrambot/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Configure, manage, and run Telegram bots integrated with fount. Select characters, set bot tokens, and customize bot configurations.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Let your Fount characters traverse the instant waves of Telegram. Configure their digital presence, manage their conversations, and extend their reach to this vibrant messaging world." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="telegram_bots.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/themeManage/index.html
+++ b/src/public/shells/themeManage/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Theme Management - fount!">
+	<meta property="og:title" content="The Canvas of Fount: Adorning Your Digital Realm" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/themeManage/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Manage and preview interface themes for fount. Select from a list of available themes to customize your experience.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Choose the aesthetic that mirrors your mood or story. Preview and select from a palette of themes, each offering a different ambiance for your Fount interactions. Your world, your style." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="themeManage.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/tutorial/index.html
+++ b/src/public/shells/tutorial/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="Tutorial - fount!">
+	<meta property="og:title" content="First Steps into Fount: A Guided Journey" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/tutorial/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Learn how to use fount with an interactive tutorial. Get started with the main features and functionalities.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Let us walk with you through the wonders of Fount. This interactive tutorial will illuminate the path, helping you discover the magic woven into its core. Your adventure begins with understanding." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="tutorial.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />

--- a/src/public/shells/userSettings/index.html
+++ b/src/public/shells/userSettings/index.html
@@ -5,10 +5,10 @@
 	<meta charset="UTF-8">
 	<meta name="darkreader-lock">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta property="og:title" content="User Settings - fount!">
+	<meta property="og:title" content="The Keeper of Self: Your Fount User Settings" />
 	<meta property="og:url" content="https://steve02081504.github.io/fount/protocol?url=fount://page/shells/userSettings/">
-	<meta property="og:type" content="website">
-	<meta property="og:description" content="Manage your fount user account settings, including profile information, password, connected devices, and account deletion.">
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="Tend to the details of your Fount identity. Manage your profile, safeguard your access, and view connected devices. This space is yours to command, a quiet sanctum for your account." />
 	<meta property="og:image" content="https://repository-images.githubusercontent.com/862251163/ef021bff-96a0-4e73-b3d0-7e7fbab660e8">
 	<title data-i18n="userSettings.title"></title>
 	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />


### PR DESCRIPTION
Further refines OG tags for index.html pages located within the src/public/shells/ directory, maintaining the evocative and melancholic user experience established previously.

This ensures that sharing links to these specific functional areas of the application also benefits from the enhanced descriptive text, providing a more consistent and engaging presentation.