### PR TITLE
feat: Implement default AI source setting

### DIFF
--- a/default/templates/user/chars/ZL-31/main.mjs
+++ b/default/templates/user/chars/ZL-31/main.mjs
@@ -2,7 +2,7 @@
  * @typedef {import('../../../../../src/decl/charAPI.ts').CharAPI_t} CharAPI_t
  */
 
-import { loadAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
+import { loadAIsource, loadDefaultAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
 import { buildPromptStruct } from '../../../../../src/public/shells/chat/src/server/prompt_struct.mjs'
 import { __dirname } from '../../../../../src/server/server.mjs'
 import fs from 'node:fs'
@@ -42,7 +42,7 @@ fount角色以mjs文件语法所书写，其可以自由导入任何npm或jsr包
  * @typedef {import('../../../../../src/decl/charAPI.ts').CharAPI_t} CharAPI_t
  */
 
-import { loadAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
+import { loadAIsource, loadDefaultAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
 import { buildPromptStruct } from '../../../../../src/public/shells/chat/src/server/prompt_struct.mjs'
 
 // AI源的实例
@@ -95,10 +95,9 @@ export default {
 			// 设置角色的配置数据
 			SetData: async (data) => {
 				// 如果传入了AI源的配置
-				if (data.AIsource) {
-					// 加载AI源
+				if (data.AIsource) // 加载AI源
 					AIsource = await loadAIsource(username, data.AIsource)
-				}
+				AIsource ||= await loadDefaultAIsource(username) // 或加载默认AI源（若未设置默认AI源则为undefined）
 			}
 		},
 		// 角色的聊天接口
@@ -713,9 +712,9 @@ Một số mã nguồn đến từ [GentianAphrodite](https://github.com/steve02
 			// 设置角色的配置数据
 			SetData: async (data) => {
 				// 如果传入了AI源的配置
-				if (data.AIsource)
-					// 加载AI源
+				if (data.AIsource) // 加载AI源
 					AIsource = await loadAIsource(username, data.AIsource)
+				AIsource ||= await loadDefaultAIsource(username) // 或加载默认AI源（若未设置默认AI源则为undefined）
 			}
 		},
 		// 角色的聊天接口

--- a/default/templates/user/chars/ZL-31/main.mjs
+++ b/default/templates/user/chars/ZL-31/main.mjs
@@ -95,8 +95,8 @@ export default {
 			// 设置角色的配置数据
 			SetData: async (data) => {
 				// 如果传入了AI源的配置
-				if (data.AIsource) // 加载AI源
-					AIsource = await loadAIsource(username, data.AIsource)
+				if (data.AIsource)  AIsource = await loadAIsource(username, data.AIsource) // 加载AI源
+				else AIsource = null // 否则设置为null
 				AIsource ||= await loadDefaultAIsource(username) // 或加载默认AI源（若未设置默认AI源则为undefined）
 			}
 		},
@@ -712,8 +712,8 @@ Một số mã nguồn đến từ [GentianAphrodite](https://github.com/steve02
 			// 设置角色的配置数据
 			SetData: async (data) => {
 				// 如果传入了AI源的配置
-				if (data.AIsource) // 加载AI源
-					AIsource = await loadAIsource(username, data.AIsource)
+				if (data.AIsource)  AIsource = await loadAIsource(username, data.AIsource) // 加载AI源
+				else AIsource = null // 否则设置为null
 				AIsource ||= await loadDefaultAIsource(username) // 或加载默认AI源（若未设置默认AI源则为undefined）
 			}
 		},

--- a/default/templates/user/worlds/fount/main.mjs
+++ b/default/templates/user/worlds/fount/main.mjs
@@ -1,7 +1,7 @@
 /** @typedef {import('../../../../../src/decl/WorldAPI.ts').WorldAPI_t} WorldAPI_t */
 /** @typedef {import('../../../../../src/decl/AIsource.ts').AIsource_t} AIsource_t */
 
-import { loadAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
+import { loadAIsource, loadDefaultAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
 
 const summary = {
 	/** @type {AIsource_t} */
@@ -81,8 +81,7 @@ export default {
 			SetData: async (data) => {
 				if (data.summaryAIsource)
 					summary.AIsource = loadAIsource(username, data.summaryAIsource)
-				else
-					summary.AIsource = null
+				summary.AIsource ||= await loadDefaultAIsource(username)
 				summary.startLength = data.summaryStartLength
 				summary.size = data.summarySize
 			}

--- a/default/templates/user/worlds/fount/main.mjs
+++ b/default/templates/user/worlds/fount/main.mjs
@@ -80,7 +80,9 @@ export default {
 			},
 			SetData: async (data) => {
 				if (data.summaryAIsource)
-					summary.AIsource = loadAIsource(username, data.summaryAIsource)
+					summary.AIsource = await loadAIsource(username, data.summaryAIsource)
+				else
+					summary.AIsource = null
 				summary.AIsource ||= await loadDefaultAIsource(username)
 				summary.startLength = data.summaryStartLength
 				summary.size = data.summarySize

--- a/src/locales/de-DE.json
+++ b/src/locales/de-DE.json
@@ -386,12 +386,17 @@
 			"save": "Speichern",
 			"delete": "Löschen"
 		},
+		"tooltips": {
+			"setDefault": "Standardmäßig festgelegt"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Fehler beim Abrufen der Dateiliste: ${error}",
 			"fetchGeneratorListFailed": "Fehler beim Abrufen der Generatorliste: ${error}",
+			"fetchDefaultsFailed": "Die Standardkomponente nicht erhalten: ${error}",
 			"fetchFileDataFailed": "Fehler beim Abrufen der Dateidaten: ${error}",
 			"noFileSelectedSave": "Keine Datei zum Speichern ausgewählt.",
 			"saveFileFailed": "Fehler beim Speichern der Datei: ${error}",
+			"setDefaultFailed": "Festlegen der Standard -AI -Quelle fehlgeschlagen: ${error}",
 			"noFileSelectedDelete": "Keine Datei zum Löschen ausgewählt.",
 			"deleteFileFailed": "Fehler beim Löschen der Datei: ${error}",
 			"invalidFileName": "Der Dateiname darf folgende Zeichen nicht enthalten: / \\ : * ? \" < > |",

--- a/src/locales/en-UK.json
+++ b/src/locales/en-UK.json
@@ -386,12 +386,17 @@
 			"save": "Save",
 			"delete": "Delete"
 		},
+		"tooltips": {
+			"setDefault": "Set as default"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Failed to get file list: ${error}",
 			"fetchGeneratorListFailed": "Failed to get generator list: ${error}",
+			"fetchDefaultsFailed": "Failed to get the default component: ${error}",
 			"fetchFileDataFailed": "Failed to get file data: ${error}",
 			"noFileSelectedSave": "No file selected to save.",
 			"saveFileFailed": "Failed to save file: ${error}",
+			"setDefaultFailed": "Setting the default AI source failed: ${error}",
 			"noFileSelectedDelete": "No file selected to delete.",
 			"deleteFileFailed": "Failed to delete file: ${error}",
 			"invalidFileName": "File name cannot contain the following characters: / \\ : * ? \" < > |",

--- a/src/locales/es-ES.json
+++ b/src/locales/es-ES.json
@@ -386,12 +386,17 @@
 			"save": "Guardar",
 			"delete": "Eliminar"
 		},
+		"tooltips": {
+			"setDefault": "Establecer como predeterminado"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Error al obtener la lista de archivos: ${error}",
 			"fetchGeneratorListFailed": "Error al obtener la lista de generadores: ${error}",
+			"fetchDefaultsFailed": "No se pudo obtener el componente predeterminado: ${error}",
 			"fetchFileDataFailed": "Error al obtener los datos del archivo: ${error}",
 			"noFileSelectedSave": "No se ha seleccionado ningún archivo para guardar.",
 			"saveFileFailed": "Error al guardar el archivo: ${error}",
+			"setDefaultFailed": "Configuración de la fuente AI predeterminada falló: ${error}",
 			"noFileSelectedDelete": "No se ha seleccionado ningún archivo para eliminar.",
 			"deleteFileFailed": "Error al eliminar el archivo: ${error}",
 			"invalidFileName": "El nombre del archivo no puede contener los siguientes caracteres: / \\ : * ? \" < > |",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -386,12 +386,17 @@
 			"save": "Enregistrer",
 			"delete": "Supprimer"
 		},
+		"tooltips": {
+			"setDefault": "Définir par défaut"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Échec de la récupération de la liste des fichiers : ${error}",
 			"fetchGeneratorListFailed": "Échec de la récupération de la liste des générateurs : ${error}",
+			"fetchDefaultsFailed": "Échec de l'obtention du composant par défaut: ${error}",
 			"fetchFileDataFailed": "Échec de la récupération des données du fichier : ${error}",
 			"noFileSelectedSave": "Aucun fichier sélectionné à enregistrer.",
 			"saveFileFailed": "Échec de l'enregistrement du fichier : ${error}",
+			"setDefaultFailed": "Définition de la source AI par défaut a échoué: ${error}",
 			"noFileSelectedDelete": "Aucun fichier sélectionné à supprimer.",
 			"deleteFileFailed": "Échec de la suppression du fichier : ${error}",
 			"invalidFileName": "Le nom de fichier ne peut pas contenir les caractères suivants : / \\ : * ? \" < > |",

--- a/src/locales/hi-IN.json
+++ b/src/locales/hi-IN.json
@@ -386,12 +386,17 @@
 			"save": "सहेजें",
 			"delete": "हटाएँ"
 		},
+		"tooltips": {
+			"setDefault": "डिफाल्ट के रूप में सेट"
+		},
 		"alerts": {
 			"fetchFileListFailed": "फ़ाइल सूची प्राप्त करने में विफल: ${error}",
 			"fetchGeneratorListFailed": "जनरेटर सूची प्राप्त करने में विफल: ${error}",
+			"fetchDefaultsFailed": "डिफ़ॉल्ट घटक प्राप्त करने में विफल: ${error}",
 			"fetchFileDataFailed": "फ़ाइल डेटा प्राप्त करने में विफल: ${error}",
 			"noFileSelectedSave": "सहेजने के लिए कोई फ़ाइल नहीं चुनी गई।",
 			"saveFileFailed": "फ़ाइल सहेजने में विफल: ${error}",
+			"setDefaultFailed": "डिफ़ॉल्ट AI स्रोत सेट करना विफल रहा: ${error}",
 			"noFileSelectedDelete": "हटाने के लिए कोई फ़ाइल नहीं चुनी गई।",
 			"deleteFileFailed": "फ़ाइल हटाने में विफल: ${error}",
 			"invalidFileName": "फ़ाइल नाम में ये वर्ण नहीं हो सकते: / \\ : * ? \" < > |",

--- a/src/locales/it-IT.json
+++ b/src/locales/it-IT.json
@@ -386,12 +386,17 @@
 			"save": "Salva",
 			"delete": "Elimina"
 		},
+		"tooltips": {
+			"setDefault": "Impostare come impostazione predefinita"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Impossibile ottenere l'elenco dei file: ${error}",
 			"fetchGeneratorListFailed": "Impossibile ottenere l'elenco dei generatori: ${error}",
+			"fetchDefaultsFailed": "Impossibile ottenere il componente predefinito: ${error}",
 			"fetchFileDataFailed": "Impossibile ottenere i dati del file: ${error}",
 			"noFileSelectedSave": "Nessun file selezionato da salvare.",
 			"saveFileFailed": "Impossibile salvare il file: ${error}",
+			"setDefaultFailed": "Impostazione della sorgente AI predefinita non riuscita: ${error}",
 			"noFileSelectedDelete": "Nessun file selezionato da eliminare.",
 			"deleteFileFailed": "Impossibile eliminare il file: ${error}",
 			"invalidFileName": "Il nome del file non può contenere i seguenti caratteri: / \\ : * ? \" < > |",

--- a/src/locales/ja-JP.json
+++ b/src/locales/ja-JP.json
@@ -386,12 +386,17 @@
 			"save": "保存",
 			"delete": "削除"
 		},
+		"tooltips": {
+			"setDefault": "デフォルトとして設定します"
+		},
 		"alerts": {
 			"fetchFileListFailed": "ファイルリストの取得に失敗しました: ${error}",
 			"fetchGeneratorListFailed": "ジェネレーターリストの取得に失敗しました: ${error}",
+			"fetchDefaultsFailed": "デフォルトのコンポーネントを取得できませんでした：${error}",
 			"fetchFileDataFailed": "ファイルデータの取得に失敗しました: ${error}",
 			"noFileSelectedSave": "保存するファイルが選択されていません。",
 			"saveFileFailed": "ファイルの保存に失敗しました: ${error}",
+			"setDefaultFailed": "デフォルトのAIソースの設定失敗：${error}",
 			"noFileSelectedDelete": "削除するファイルが選択されていません。",
 			"deleteFileFailed": "ファイルの削除に失敗しました: ${error}",
 			"invalidFileName": "ファイル名に次の文字は使用できません： / \\ : * ? \" < > |",

--- a/src/locales/ko-KR.json
+++ b/src/locales/ko-KR.json
@@ -386,12 +386,17 @@
 			"save": "저장",
 			"delete": "삭제"
 		},
+		"tooltips": {
+			"setDefault": "기본값으로 설정합니다"
+		},
 		"alerts": {
 			"fetchFileListFailed": "파일 목록을 가져오는 데 실패했습니다: ${error}",
 			"fetchGeneratorListFailed": "생성기 목록을 가져오는 데 실패했습니다: ${error}",
+			"fetchDefaultsFailed": "기본 구성 요소를 얻지 못했습니다 : ${error}",
 			"fetchFileDataFailed": "파일 데이터를 가져오는 데 실패했습니다: ${error}",
 			"noFileSelectedSave": "저장할 파일이 선택되지 않았습니다.",
 			"saveFileFailed": "파일 저장에 실패했습니다: ${error}",
+			"setDefaultFailed": "기본 AI 소스 설정 실패 : ${error}",
 			"noFileSelectedDelete": "삭제할 파일이 선택되지 않았습니다.",
 			"deleteFileFailed": "파일 삭제에 실패했습니다: ${error}",
 			"invalidFileName": "파일 이름에는 다음 문자를 사용할 수 없습니다: / \\ : * ? \" < > |",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -386,12 +386,17 @@
 			"save": "Guardar",
 			"delete": "Eliminar"
 		},
+		"tooltips": {
+			"setDefault": "Definido como padrão"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Falha ao obter a lista de ficheiros: ${error}",
 			"fetchGeneratorListFailed": "Falha ao obter a lista de geradores: ${error}",
+			"fetchDefaultsFailed": "Falha ao obter o componente padrão: ${error}",
 			"fetchFileDataFailed": "Falha ao obter os dados do ficheiro: ${error}",
 			"noFileSelectedSave": "Nenhum ficheiro selecionado para guardar.",
 			"saveFileFailed": "Falha ao guardar o ficheiro: ${error}",
+			"setDefaultFailed": "Definir a fonte de IA padrão falhada: ${error}",
 			"noFileSelectedDelete": "Nenhum ficheiro selecionado para eliminar.",
 			"deleteFileFailed": "Falha ao eliminar o ficheiro: ${error}",
 			"invalidFileName": "O nome do ficheiro não pode conter os seguintes caracteres: / \\ : * ? \" < > |",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -386,12 +386,17 @@
 			"save": "Сохранить",
 			"delete": "Удалить"
 		},
+		"tooltips": {
+			"setDefault": "Установить по умолчанию"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Не удалось получить список файлов: ${error}",
 			"fetchGeneratorListFailed": "Не удалось получить список генераторов: ${error}",
+			"fetchDefaultsFailed": "Не удалось получить компонент по умолчанию: ${error}",
 			"fetchFileDataFailed": "Не удалось получить данные файла: ${error}",
 			"noFileSelectedSave": "Файл для сохранения не выбран.",
 			"saveFileFailed": "Не удалось сохранить файл: ${error}",
+			"setDefaultFailed": "Установка исходного источника AI по умолчанию не удалось: ${error}",
 			"noFileSelectedDelete": "Файл для удаления не выбран.",
 			"deleteFileFailed": "Не удалось удалить файл: ${error}",
 			"invalidFileName": "Имя файла не может содержать следующие символы: / \\ : * ? \" < > |",

--- a/src/locales/vi-VN.json
+++ b/src/locales/vi-VN.json
@@ -386,12 +386,17 @@
 			"save": "Lưu",
 			"delete": "Xóa"
 		},
+		"tooltips": {
+			"setDefault": "Đặt làm mặc định"
+		},
 		"alerts": {
 			"fetchFileListFailed": "Lấy danh sách tệp thất bại: ${error}",
 			"fetchGeneratorListFailed": "Lấy danh sách trình tạo thất bại: ${error}",
+			"fetchDefaultsFailed": "Không nhận được thành phần mặc định: ${error}",
 			"fetchFileDataFailed": "Lấy dữ liệu tệp thất bại: ${error}",
 			"noFileSelectedSave": "Chưa chọn tệp để lưu.",
 			"saveFileFailed": "Lưu tệp thất bại: ${error}",
+			"setDefaultFailed": "Đặt nguồn AI mặc định không thành công: ${error}",
 			"noFileSelectedDelete": "Chưa chọn tệp để xóa.",
 			"deleteFileFailed": "Xóa tệp thất bại: ${error}",
 			"invalidFileName": "Tên tệp không được chứa các ký tự sau: / \\ : * ? \" < > |",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -386,12 +386,17 @@
 			"save": "保存",
 			"delete": "删除"
 		},
+		"tooltips": {
+			"setDefault": "设为默认"
+		},
 		"alerts": {
 			"fetchFileListFailed": "获取文件列表失败: ${error}",
 			"fetchGeneratorListFailed": "获取生成器列表失败: ${error}",
+			"fetchDefaultsFailed": "获取默认部件失败: ${error}",
 			"fetchFileDataFailed": "获取文件数据失败: ${error}",
 			"noFileSelectedSave": "没有选择要保存的文件。",
 			"saveFileFailed": "保存文件失败: ${error}",
+			"setDefaultFailed": "设置默认 AI 源失败: ${error}",
 			"noFileSelectedDelete": "没有选择要删除的文件。",
 			"deleteFileFailed": "删除文件失败: ${error}",
 			"invalidFileName": "文件名不能包含以下字符： / \\ : * ? \" < > |",

--- a/src/pages/scripts/parts.mjs
+++ b/src/pages/scripts/parts.mjs
@@ -48,6 +48,6 @@ export async function setDefaultPart(parttype, partname) {
 export async function getDefaultParts() {
 	return fetch('/api/getdefaultparts').then(async response => {
 		if (response.ok) return response.json()
-		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response: response }))
+		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response }))
 	})
 }

--- a/src/pages/scripts/parts.mjs
+++ b/src/pages/scripts/parts.mjs
@@ -38,3 +38,13 @@ export async function noCacheGetPersonaDetails(personaname) {
 	const response = await fetch('/api/getdetails/personas?name=' + personaname + '&nocache=true')
 	return response.json()
 }
+export async function setDefaultPart(parttype, partname) {
+	return fetch('/api/setdefaultpart', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ parttype, partname }),
+	})
+}
+export async function getDefaultParts() {
+	return fetch('/api/getdefaultparts')
+}

--- a/src/pages/scripts/parts.mjs
+++ b/src/pages/scripts/parts.mjs
@@ -46,10 +46,8 @@ export async function setDefaultPart(parttype, partname) {
 	})
 }
 export async function getDefaultParts() {
-	return fetch('/api/getdefaultparts').then(response => {
-		if (response.ok)
-			return response.json()
-		else
-			return Promise.reject(response.json())
+	return fetch('/api/getdefaultparts').then(async response => {
+		if (response.ok) return response.json()
+		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response: response }))
 	})
 }

--- a/src/pages/scripts/parts.mjs
+++ b/src/pages/scripts/parts.mjs
@@ -46,5 +46,10 @@ export async function setDefaultPart(parttype, partname) {
 	})
 }
 export async function getDefaultParts() {
-	return fetch('/api/getdefaultparts')
+	return fetch('/api/getdefaultparts').then(response => {
+		if (response.ok)
+			return response.json()
+		else
+			return Promise.reject(response.json())
+	})
 }

--- a/src/public/ImportHandlers/Risu/Template/main.mjs
+++ b/src/public/ImportHandlers/Risu/Template/main.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { loadAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs' // 调整路径
+import { loadAIsource, loadDefaultAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs' // 调整路径
 import { saveJsonFile } from '../../../../../src/scripts/json_loader.mjs' // 调整路径
 import { promptBuilder } from '../../../../../src/public/ImportHandlers/SillyTavern/engine/prompt_builder.mjs' // 复用ST引擎
 import { buildPromptStruct } from '../../../../../src/public/shells/chat/src/server/prompt_struct.mjs' // 调整路径
@@ -114,11 +114,6 @@ const charAPI_definition = { // 先定义结构主体
 	Uninstall: () => { },
 	Load: (stat) => {
 		username = stat.username
-		// 可以在这里尝试加载与角色绑定的AI源，如果chardata.extensions中有记录
-		if (chardata.extensions?.default_aisource)
-			loadAIsource(username, chardata.extensions.default_aisource)
-				.then(ai => { AIsource = ai })
-				.catch(err => console.warn(`Failed to autoload AI source ${chardata.extensions.default_aisource}: ${err.message}`))
 	},
 	Unload: () => {
 		AIsource = null
@@ -137,12 +132,9 @@ const charAPI_definition = { // 先定义结构主体
 					charAPI_definition.info = buildCharInfo(chardata)
 					saveJsonFile(charjson, chardata) // 保存 STv2 格式
 				}
-				if (data.AIsource) {
+				if (data.AIsource)
 					AIsource = await loadAIsource(username, data.AIsource)
-					// 可以考虑将选择的AI源保存到 chardata.extensions.default_aisource
-					chardata.extensions.default_aisource = data.AIsource
-					saveJsonFile(charjson, chardata)
-				}
+				AIsource ||= loadDefaultAIsource(username)
 			}
 		},
 		chat: {

--- a/src/public/ImportHandlers/Risu/Template/main.mjs
+++ b/src/public/ImportHandlers/Risu/Template/main.mjs
@@ -132,9 +132,9 @@ const charAPI_definition = { // 先定义结构主体
 					charAPI_definition.info = buildCharInfo(chardata)
 					saveJsonFile(charjson, chardata) // 保存 STv2 格式
 				}
-				if (data.AIsource)
-					AIsource = await loadAIsource(username, data.AIsource)
-				AIsource ||= loadDefaultAIsource(username)
+				if (data.AIsource) AIsource = await loadAIsource(username, data.AIsource)
+				else AIsource = null
+				AIsource ||= await loadDefaultAIsource(username)
 			}
 		},
 		chat: {

--- a/src/public/ImportHandlers/SillyTavern/Template/main.mjs
+++ b/src/public/ImportHandlers/SillyTavern/Template/main.mjs
@@ -71,6 +71,7 @@ export default {
 					saveJsonFile(charjson, chardata)
 				}
 				if (data.AIsource) AIsource = await loadAIsource(username, data.AIsource)
+				else AIsource = null
 				AIsource ||= await loadDefaultAIsource(username)
 			}
 		},

--- a/src/public/ImportHandlers/SillyTavern/Template/main.mjs
+++ b/src/public/ImportHandlers/SillyTavern/Template/main.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { loadAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
+import { loadAIsource, loadDefaultAIsource } from '../../../../../src/server/managers/AIsource_manager.mjs'
 import { saveJsonFile } from '../../../../../src/scripts/json_loader.mjs'
 import { promptBuilder } from '../../../../../src/public/ImportHandlers/SillyTavern/engine/prompt_builder.mjs'
 import { buildPromptStruct } from '../../../../../src/public/shells/chat/src/server/prompt_struct.mjs'
@@ -71,6 +71,7 @@ export default {
 					saveJsonFile(charjson, chardata)
 				}
 				if (data.AIsource) AIsource = await loadAIsource(username, data.AIsource)
+				AIsource ||= await loadDefaultAIsource(username)
 			}
 		},
 		chat: {

--- a/src/public/shells/AIsourceManage/index.css
+++ b/src/public/shells/AIsourceManage/index.css
@@ -23,6 +23,6 @@
 }
 
 .file-list-item.selected-item {
-    border-left: 4px solid var(--color-primary);
-    background-color: var(--color-base-300);
+	border-left: 4px solid var(--color-primary);
+	background-color: var(--color-base-300);
 }

--- a/src/public/shells/AIsourceManage/index.css
+++ b/src/public/shells/AIsourceManage/index.css
@@ -8,6 +8,9 @@
 	padding: 0.5rem;
 	border-bottom: 1px solid #4a4a4a;
 	transition: background-color 0.2s;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 .file-list-item:hover {
@@ -17,4 +20,9 @@
 .file-list-item.active {
 	background-color: var(--color-neutral);
 	color: var(--color-neutral-content);
+}
+
+.file-list-item.selected-item {
+    border-left: 4px solid var(--color-primary);
+    background-color: var(--color-base-300);
 }

--- a/src/public/shells/AIsourceManage/index.mjs
+++ b/src/public/shells/AIsourceManage/index.mjs
@@ -69,7 +69,7 @@ function renderFileList() {
 		checkboxContainer.appendChild(checkbox)
 		listItem.appendChild(checkboxContainer)
 
-checkbox.addEventListener('change', async (event) => {
+		checkbox.addEventListener('change', async (event) => {
 			event.stopPropagation() // Prevent click from triggering loadEditor
 			const isChecked = event.target.checked
 			const newDefault = isChecked ? fileName : null

--- a/src/public/shells/AIsourceManage/index.mjs
+++ b/src/public/shells/AIsourceManage/index.mjs
@@ -69,16 +69,21 @@ function renderFileList() {
 		checkboxContainer.appendChild(checkbox)
 		listItem.appendChild(checkboxContainer)
 
-		checkbox.addEventListener('change', async (event) => {
+checkbox.addEventListener('change', async (event) => {
 			event.stopPropagation() // Prevent click from triggering loadEditor
 			const isChecked = event.target.checked
-			// Update default part in backend
-			await setDefaultPart('AIsources', isChecked ? fileName : null)
-				.catch(handleFetchError('aisource_editor.alerts.setDefaultFailed'))
+			const newDefault = isChecked ? fileName : null
 
-			// Update local state and UI
-			defaultParts.AIsources = isChecked ? fileName : null
-			updateDefaultPartDisplay()
+			try {
+				await setDefaultPart('AIsources', newDefault)
+				// Update local state and UI on success
+				defaultParts.AIsources = newDefault
+				updateDefaultPartDisplay()
+			} catch (error) {
+				handleFetchError('aisource_editor.alerts.setDefaultFailed')(error)
+				// Revert checkbox on failure
+				event.target.checked = !isChecked
+			}
 		})
 
 		// Prevent checkbox click from triggering list item click

--- a/src/public/shells/AIsourceManage/index.mjs
+++ b/src/public/shells/AIsourceManage/index.mjs
@@ -1,7 +1,7 @@
 import { createJsonEditor } from '../../scripts/jsonEditor.mjs'
 import { applyTheme } from '../../scripts/theme.mjs'
 import { initTranslations, geti18n } from '../../scripts/i18n.mjs'
-import { getPartList } from '../../scripts/parts.mjs'
+import { getPartList, setDefaultPart, getDefaultParts } from '../../scripts/parts.mjs'
 import { getConfigTemplate, getAIFile, setAIFile, deleteAIFile, addAIFile } from './src/public/endpoints.mjs'
 
 const jsonEditorContainer = document.getElementById('jsonEditor')
@@ -19,6 +19,7 @@ let jsonEditor = null
 let fileList = []
 let generatorList = []
 let isDirty = false // 标记是否有未保存的更改
+let defaultParts = {} // Store default parts
 
 // 统一的错误处理函数
 function handleFetchError(customMessage) {
@@ -40,22 +41,68 @@ async function fetchGeneratorList() {
 	renderGeneratorSelect()
 }
 
+async function fetchDefaultParts() {
+	defaultParts = await getDefaultParts().catch(handleFetchError('aisource_editor.alerts.fetchDefaultsFailed'))
+	updateDefaultPartDisplay()
+}
+
 function renderFileList() {
 	fileListDiv.innerHTML = ''
 	fileList.forEach(fileName => {
 		const listItem = document.createElement('div')
 		listItem.classList.add('file-list-item')
+		listItem.dataset.name = fileName // Add data-name attribute
+
 		const p = document.createElement('p')
 		p.textContent = fileName
+		p.classList.add('flex-grow') // Allow text to take up space
 		listItem.appendChild(p)
+
+		// Default item checkbox
+		const checkboxContainer = document.createElement('div')
+		checkboxContainer.classList.add('tooltip', 'tooltip-left')
+		checkboxContainer.dataset.tip = geti18n('aisource_editor.tooltips.setDefault')
+
+		const checkbox = document.createElement('input')
+		checkbox.type = 'checkbox'
+		checkbox.classList.add('default-checkbox', 'checkbox', 'checkbox-primary')
+		checkboxContainer.appendChild(checkbox)
+		listItem.appendChild(checkboxContainer)
+
+		checkbox.addEventListener('change', async (event) => {
+			event.stopPropagation() // Prevent click from triggering loadEditor
+			const isChecked = event.target.checked
+			// Update default part in backend
+			await setDefaultPart('AIsources', isChecked ? fileName : null)
+				.catch(handleFetchError('aisource_editor.alerts.setDefaultFailed'))
+
+			// Update local state and UI
+			defaultParts.AIsources = isChecked ? fileName : null
+			updateDefaultPartDisplay()
+		})
+
+		// Prevent checkbox click from triggering list item click
+		checkboxContainer.addEventListener('click', (event) => event.stopPropagation())
 		listItem.addEventListener('click', () => loadEditor(fileName))
 		fileListDiv.appendChild(listItem)
 	})
+
+	updateDefaultPartDisplay() // Apply styles for default item
 
 	if (fileList.length > 0) {
 		const fileToLoad = activeFile && fileList.includes(activeFile) ? activeFile : fileList[0]
 		loadEditor(fileToLoad)
 	}
+}
+
+function updateDefaultPartDisplay() {
+	const defaultPartName = defaultParts.AIsources
+	fileListDiv.querySelectorAll('.file-list-item').forEach(el => {
+		const isDefault = el.dataset.name === defaultPartName
+		el.classList.toggle('selected-item', isDefault)
+		const checkbox = el.querySelector('.default-checkbox')
+		if (checkbox) checkbox.checked = isDefault
+	})
 }
 
 function renderGeneratorSelect() {
@@ -94,11 +141,8 @@ async function loadEditor(fileName) {
 		return
 
 	document.querySelectorAll('.file-list-item').forEach(item => item.classList.remove('active'))
-	const activeItemIndex = fileList.indexOf(fileName)
-	if (activeItemIndex !== -1) {
-		const fileItem = document.querySelector(`#fileList .file-list-item:nth-child(${activeItemIndex + 1})`)
-		if (fileItem) fileItem.classList.add('active')
-	}
+	const activeItem = fileListDiv.querySelector(`.file-list-item[data-name="${fileName}"]`)
+	if (activeItem) activeItem.classList.add('active')
 
 	activeFile = fileName
 	const data = await getAIFile(fileName).catch(handleFetchError('aisource_editor.alerts.fetchFileDataFailed'))
@@ -172,8 +216,10 @@ async function deleteFile() {
 	await fetchFileList()
 
 	//  不清空 jsonEditor，而是禁用并清空
-	if (fileList.length === 0)
+	if (fileList.length === 0) {
+		updateEditorContent({})
 		disableEditor()
+	}
 }
 
 async function addFile() {
@@ -197,12 +243,14 @@ function isValidFileName(fileName) {
 	return !invalidChars.test(fileName)
 }
 
-// 初始化
+// Initialization
 applyTheme()
-fetchFileList()
-fetchGeneratorList()
 initTranslations('aisource_editor')
 disableEditor()
+
+fetchFileList()
+fetchGeneratorList()
+fetchDefaultParts()
 
 saveButton.addEventListener('click', saveFile)
 deleteButton.addEventListener('click', deleteFile)
@@ -213,11 +261,10 @@ generatorSelect.addEventListener('change', async () => {
 	if (selectedGenerator) {
 		const template = await fetchConfigTemplate(selectedGenerator)
 		updateEditorContent(template)
+		enableEditor()
 	}
 	else
 		disableEditor()
-	enableEditor() //无论如何都调用
-
 })
 
 window.addEventListener('beforeunload', (event) => {

--- a/src/public/shells/chat/src/server/chat.mjs
+++ b/src/public/shells/chat/src/server/chat.mjs
@@ -14,6 +14,7 @@ import { Buffer } from 'node:buffer'
 import fs from 'node:fs'
 import { addfile, getfile } from './files.mjs'
 import { skip_report } from '../../../../../server/server.mjs'
+import { getDefaultParts } from '../../../../../server/parts_loader.mjs'
 
 /**
  * @description 聊天元数据映射表的结构。这是一个在内存中缓存聊天信息的Map。
@@ -289,12 +290,11 @@ class chatMetadata_t {
 	static async StartNewAs(username) {
 		const metadata = new chatMetadata_t(username)
 
-		const user = getUserByUsername(username)
-		metadata.LastTimeSlice.player_id = user.defaultParts?.persona
+		metadata.LastTimeSlice.player_id = getDefaultParts(username).persona
 		if (metadata.LastTimeSlice.player_id)
 			metadata.LastTimeSlice.player = await loadPersona(username, metadata.LastTimeSlice.player_id)
 
-		metadata.LastTimeSlice.world_id = user.defaultParts?.world
+		metadata.LastTimeSlice.world_id = getDefaultParts(username).world
 		if (metadata.LastTimeSlice.world_id)
 			metadata.LastTimeSlice.world = await loadWorld(username, metadata.LastTimeSlice.world_id)
 

--- a/src/public/shells/home/index.mjs
+++ b/src/public/shells/home/index.mjs
@@ -412,8 +412,14 @@ async function initializeApp() {
 
 async function fetchData() {
 	await Promise.all([
-		getHomeRegistry().then(data => homeRegistry = data).catch(error => console.error('Failed to fetch home registry:', error)),
-		getDefaultParts().then(data => defaultParts = data).catch(error => console.error('Failed to fetch default parts:', error)),
+		getHomeRegistry().then(async (data) => {
+			homeRegistry = data
+			await displayFunctionButtons()
+		}).catch(error => console.error('Failed to fetch home registry:', error)),
+		getDefaultParts().then(data => {
+			defaultParts = data
+			updateDefaultPartDisplay()
+		}).catch(error => console.error('Failed to fetch default parts:', error)),
 	])
 }
 

--- a/src/public/shells/home/index.mjs
+++ b/src/public/shells/home/index.mjs
@@ -11,7 +11,6 @@ import { parseRegexFromString, escapeRegExp } from '../../scripts/regex.mjs'
 import { initTranslations, geti18n } from '../../scripts/i18n.mjs'
 import { svgInliner } from '../../scripts/svgInliner.mjs'
 import { getHomeRegistry } from './src/public/endpoints.mjs'
-import { get } from "node:http";
 
 usingTemplates('/shells/home/src/public/templates')
 

--- a/src/public/shells/home/index.mjs
+++ b/src/public/shells/home/index.mjs
@@ -11,6 +11,7 @@ import { parseRegexFromString, escapeRegExp } from '../../scripts/regex.mjs'
 import { initTranslations, geti18n } from '../../scripts/i18n.mjs'
 import { svgInliner } from '../../scripts/svgInliner.mjs'
 import { getHomeRegistry } from './src/public/endpoints.mjs'
+import { get } from "node:http";
 
 usingTemplates('/shells/home/src/public/templates')
 
@@ -410,24 +411,10 @@ async function initializeApp() {
 }
 
 async function fetchData() {
-	const [registryResponse, defaultPartsResponse] = await Promise.all([
-		getHomeRegistry(),
-		getDefaultParts()
+	await Promise.all([
+		getHomeRegistry().then(data => homeRegistry = data).catch(error => console.error('Failed to fetch home registry:', error)),
+		getDefaultParts().then(data => defaultParts = data).catch(error => console.error('Failed to fetch default parts:', error)),
 	])
-
-	if (registryResponse.ok) {
-		homeRegistry = await registryResponse.json()
-		await displayFunctionButtons() // Update function buttons
-	}
-	else
-		console.error('Failed to fetch home registry:', await registryResponse.text())
-
-	if (defaultPartsResponse.ok) {
-		defaultParts = await defaultPartsResponse.json()
-		updateDefaultPartDisplay()
-	}
-	else
-		console.error('Failed to fetch default parts:', await defaultPartsResponse.text())
 }
 
 initializeApp().catch(error => {

--- a/src/public/shells/home/index.mjs
+++ b/src/public/shells/home/index.mjs
@@ -2,14 +2,15 @@ import { renderTemplate, usingTemplates } from '../../scripts/template.mjs'
 import {
 	getCharDetails, noCacheGetCharDetails, getCharList,
 	getPersonaList, getPersonaDetails, noCacheGetPersonaDetails,
-	getWorldList, getWorldDetails, noCacheGetWorldDetails
+	getWorldList, getWorldDetails, noCacheGetWorldDetails,
+	setDefaultPart, getDefaultParts
 } from '../../scripts/parts.mjs'
 import { renderMarkdown } from '../../scripts/markdown.mjs'
 import { applyTheme } from '../../scripts/theme.mjs'
 import { parseRegexFromString, escapeRegExp } from '../../scripts/regex.mjs'
 import { initTranslations, geti18n } from '../../scripts/i18n.mjs'
 import { svgInliner } from '../../scripts/svgInliner.mjs'
-import { setDefaultPart, getHomeRegistry, getDefaultParts } from './src/public/endpoints.mjs'
+import { getHomeRegistry } from './src/public/endpoints.mjs'
 
 usingTemplates('/shells/home/src/public/templates')
 

--- a/src/public/shells/home/src/public/endpoints.mjs
+++ b/src/public/shells/home/src/public/endpoints.mjs
@@ -1,8 +1,6 @@
 export async function getHomeRegistry() {
-	return fetch('/api/shells/home/gethomeregistry').then(response => {
-		if (response.ok)
-			return response.json()
-		else
-			return Promise.reject(response.json())
+	return fetch('/api/shells/home/gethomeregistry').then(async response => {
+		if (response.ok) return response.json()
+		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response: response }))
 	})
 }

--- a/src/public/shells/home/src/public/endpoints.mjs
+++ b/src/public/shells/home/src/public/endpoints.mjs
@@ -1,6 +1,6 @@
 export async function getHomeRegistry() {
 	return fetch('/api/shells/home/gethomeregistry').then(async response => {
 		if (response.ok) return response.json()
-		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response: response }))
+		else return Promise.reject(Object.assign(new Error(`API request failed with status ${response.status}`), await response.json().catch(() => { }), { response }))
 	})
 }

--- a/src/public/shells/home/src/public/endpoints.mjs
+++ b/src/public/shells/home/src/public/endpoints.mjs
@@ -1,3 +1,8 @@
 export async function getHomeRegistry() {
-	return fetch('/api/shells/home/gethomeregistry')
+	return fetch('/api/shells/home/gethomeregistry').then(response => {
+		if (response.ok)
+			return response.json()
+		else
+			return Promise.reject(response.json())
+	})
 }

--- a/src/public/shells/home/src/public/endpoints.mjs
+++ b/src/public/shells/home/src/public/endpoints.mjs
@@ -1,15 +1,3 @@
-export async function setDefaultPart(parttype, partname) {
-	return fetch('/api/shells/home/setdefault', {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ parttype, partname }),
-	})
-}
-
 export async function getHomeRegistry() {
 	return fetch('/api/shells/home/gethomeregistry')
-}
-
-export async function getDefaultParts() {
-	return fetch('/api/shells/home/getdefaultparts')
 }

--- a/src/public/shells/home/src/server/endpoints.mjs
+++ b/src/public/shells/home/src/server/endpoints.mjs
@@ -1,5 +1,4 @@
 import { authenticate, getUserByReq } from '../../../../../server/auth.mjs'
-import { save_config } from '../../../../../server/server.mjs'
 import { expandHomeRegistry } from './home.mjs'
 
 /**
@@ -10,25 +9,5 @@ export function setEndpoints(router) {
 		const { username } = await getUserByReq(req)
 		const expandedRegistry = await expandHomeRegistry(username)
 		res.status(200).json(expandedRegistry)
-	})
-
-	router.get('/api/shells/home/getdefaultparts', authenticate, async (req, res) => {
-		const user = await getUserByReq(req)
-		res.status(200).json(user.defaultParts || {})
-	})
-
-	router.post('/api/shells/home/setdefault', authenticate, async (req, res) => {
-		const user = await getUserByReq(req)
-		const { parttype, partname } = req.body
-
-		user.defaultParts ??= {}
-
-		if (!partname)
-			delete user.defaultParts[parttype]
-		else
-			user.defaultParts[parttype] = partname
-
-		save_config()
-		res.status(200).json({ message: 'success' })
 	})
 }

--- a/src/server/endpoints.mjs
+++ b/src/server/endpoints.mjs
@@ -1,5 +1,5 @@
 import { login, register, logout, authenticate, getUserByReq, getUserDictionary, generateAccessToken, auth_request } from './auth.mjs'
-import { getPartDetails } from './parts_loader.mjs'
+import { getDefaultParts, getPartDetails, setDefaultPart } from './parts_loader.mjs'
 import { generateVerificationCode, verifyVerificationCode } from '../scripts/verifycode.mjs'
 import { ms } from '../scripts/ms.mjs'
 import { getLoadedPartList, getPartList, loadPart, partsList } from './managers/index.mjs'
@@ -188,4 +188,16 @@ export function registerEndpoints(router) {
 			return user_static[username](req, res, next)
 		}, public_static)
 	}
+
+	router.get('/api/getdefaultparts', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		res.status(200).json(getDefaultParts(user))
+	})
+
+	router.post('/api/setdefaultpart', authenticate, async (req, res) => {
+		const user = await getUserByReq(req)
+		const { parttype, partname } = req.body
+		setDefaultPart(user, parttype, partname)
+		res.status(200).json({ message: 'success' })
+	})
 }

--- a/src/server/managers/AIsource_manager.mjs
+++ b/src/server/managers/AIsource_manager.mjs
@@ -1,6 +1,6 @@
 import { getUserDictionary } from '../auth.mjs'
 import { loadJsonFile, saveJsonFile } from '../../scripts/json_loader.mjs'
-import { isPartLoaded, loadPartBase, unloadPartBase } from '../parts_loader.mjs'
+import { getDefaultParts, isPartLoaded, loadPartBase, unloadPartBase } from '../parts_loader.mjs'
 import { skip_report } from '../server.mjs'
 
 function GetPath(username, partname) {
@@ -68,4 +68,10 @@ export function isAIsourceLoaded(username, AIsourcename) {
 export async function reloadAIsource(username, AIsourcename) {
 	await unloadAIsource(username, AIsourcename)
 	await loadAIsource(username, AIsourcename)
+}
+
+export async function loadDefaultAIsource(username) {
+	const defaultAIsourceName = getDefaultParts(username).AIsources
+	if (!defaultAIsourceName) return
+	return loadAIsource(username, defaultAIsourceName)
 }

--- a/src/server/parts_loader.mjs
+++ b/src/server/parts_loader.mjs
@@ -13,8 +13,8 @@ import { nicerWriteFileSync } from '../scripts/nicerWriteFile.mjs'
 
 export function setDefaultPart(user, parttype, partname) {
 	if (Object(user) instanceof String) user = getUserByUsername(user)
+	if (partname == defaultParts?.[parttype]) return
 	const defaultParts = user.defaultParts ??= {}
-	if (partname == defaultParts[parttype]) return
 	if (!partname) delete defaultParts[parttype]
 	else defaultParts[parttype] = partname
 	save_config()

--- a/src/server/parts_loader.mjs
+++ b/src/server/parts_loader.mjs
@@ -2,7 +2,7 @@ import { getUserByUsername, getUserDictionary } from './auth.mjs'
 import fs from 'node:fs'
 import url from 'node:url'
 import { FullProxy } from 'npm:full-proxy'
-import { __dirname, deletePartRouter, getPartRouter, setDefaultStuff } from './server.mjs'
+import { __dirname, deletePartRouter, getPartRouter, save_config, setDefaultStuff } from './server.mjs'
 import { loadData, saveData } from './setting_loader.mjs'
 import { loadPart } from './managers/index.mjs'
 import { exec } from '../scripts/exec.mjs'
@@ -11,6 +11,18 @@ import { geti18n } from '../scripts/i18n.mjs'
 import { loadJsonFile } from '../scripts/json_loader.mjs'
 import { nicerWriteFileSync } from '../scripts/nicerWriteFile.mjs'
 
+export function setDefaultPart(user, parttype, partname) {
+	if (Object(user) instanceof String) user = getUserByUsername(user)
+	const defaultParts = user.defaultParts ??= {}
+	if (partname == defaultParts[parttype]) return
+	if (!partname) delete defaultParts[parttype]
+	else defaultParts[parttype] = partname
+	save_config()
+}
+export function getDefaultParts(user) {
+	if (Object(user) instanceof String) user = getUserByUsername(user)
+	return user?.defaultParts || {}
+}
 /**
  * @typedef {Object} PartInfo
  * @property {Record<string, string>} [name] - Localized name of the part.


### PR DESCRIPTION
This commit introduces a user-specific default AI source. Users can now mark an AI source as their default from the AI Source Management page using a new star icon.

This default source is automatically loaded for characters and worlds if no other AI source is explicitly specified for the session. This simplifies the user workflow by:
- Removing the need to select an AI source for every chat.
- Replacing the previous system of saving the last-used AI source within each character's data.
- Pre-loading the default AI on the home page when a character is selected, improving user experience.