### PR TITLE
feat(auth): Mitigate brute-force attacks with fake JWTs

### DIFF
--- a/src/server/endpoints.mjs
+++ b/src/server/endpoints.mjs
@@ -49,7 +49,7 @@ export function registerEndpoints(router) {
 	})
 	router.post('/api/login', rateLimit({ maxRequests: 5, windowMs: ms('1m') }), async (req, res) => {
 		const { username, password, deviceid } = req.body
-		const result = await login(username, password, deviceid)
+		const result = await login(username, password, deviceid, req)
 		// 在登录成功时设置 Cookie
 		if (result.status === 200) {
 			res.cookie('accessToken', result.accessToken, { httpOnly: true, secure: req.secure || req.headers['x-forwarded-proto'] === 'https' }) // 短效


### PR DESCRIPTION
This commit introduces a security enhancement to protect against brute-force login attacks using a "tarpit" strategy.

When the number of failed login attempts for a specific username from a single IP address exceeds a defined threshold, the server may now return a fake success response. This response includes syntactically valid access and refresh tokens, but they are signed with a temporary, randomly generated private key instead of the server's actual key.

This approach is designed to deceive and slow down attackers. They will receive what appears to be a successful login, but any subsequent API requests using the fake tokens will fail verification, effectively wasting their time and resources without immediately revealing that they have been detected.

Changes include:
- Tracking login failures per IP and username.
- Generating temporary key pairs to sign fake JWTs.
- Modifying token generation functions to accept an optional private key.
- Refactoring key generation logic into helper functions for clarity.