### PR TITLE
Add .nobackground override for background process handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /temp.txt
 /.idea
 /.noupdate
+/.nobackground
 /data
 /.vm_data_*
 /node_modules

--- a/path/fount.ps1
+++ b/path/fount.ps1
@@ -160,14 +160,20 @@ elseif ($args.Count -gt 0 -and $args[0] -eq 'background') {
 		fount.ps1 @runargs
 		exit $LastExitCode
 	}
-	Test-PWSHModule ps12exe
-	$TempDir = [System.IO.Path]::GetTempPath()
-	$exepath = Join-Path $TempDir "fount-background.exe"
-	if (!(Test-Path $exepath)) {
-		ps12exe -inputFile "$FOUNT_DIR/src/runner/background.ps1" -outputFile $exepath
+	if (Test-Path -Path "$FOUNT_DIR/.nobackground") {
+		$runargs = $args[1..$args.Count]
+		Start-Process -FilePath fount.ps1 -ArgumentList $runargs
 	}
-	$runargs = $args[1..$args.Count]
-	Start-Process -FilePath $exepath -ArgumentList $runargs
+	else {
+		Test-PWSHModule ps12exe
+		$TempDir = [System.IO.Path]::GetTempPath()
+		$exepath = Join-Path $TempDir "fount-background.exe"
+		if (!(Test-Path $exepath)) {
+			ps12exe -inputFile "$FOUNT_DIR/src/runner/background.ps1" -outputFile $exepath
+		}
+		$runargs = $args[1..$args.Count]
+		Start-Process -FilePath $exepath -ArgumentList $runargs
+	}
 	exit 0
 }
 elseif ($args.Count -gt 0 -and $args[0] -eq 'protocolhandle') {

--- a/path/fount.sh
+++ b/path/fount.sh
@@ -677,7 +677,26 @@ echo -e "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: appl
 		fi
 		;;
 	background)
-		nohup "$0" "${@:2}" >/dev/null 2>&1 &
+		if [ -f "$FOUNT_DIR/.nobackground" ]; then
+			if command -v xterm &>/dev/null; then
+				xterm -e "$0" "${@:2}" &
+			elif command -v gnome-terminal &>/dev/null; then
+				gnome-terminal -- "$0" "${@:2}"
+			elif command -v terminator &>/dev/null; then
+				terminator -- "$0" "${@:2}"
+			elif command -v konsole &>/dev/null; then
+				konsole -- "$0" "${@:2}"
+			elif command -v xfce4-terminal &>/dev/null; then
+				xfce4-terminal -- "$0" "${@:2}"
+			elif command -v lxterminal &>/dev/null; then
+				lxterminal -- "$0" "${@:2}"
+			else
+				echo "Error: No terminal emulator found." >&2
+				nohup "$0" "${@:2}" >/dev/null 2>&1 &
+			fi
+		else
+			nohup "$0" "${@:2}" >/dev/null 2>&1 &
+		fi
 		exit 0
 		;;
 	protocolhandle)


### PR DESCRIPTION
Introduces support for a .nobackground file to override default background process behavior in both fount.ps1 and fount.sh. When present, background commands are run in a new terminal emulator if available, or fallback to nohup. Updated .gitignore to include .nobackground.

fix #104 , closes #105
