### PR TITLE
[fix] gemini config is base_url in the template

### DIFF
--- a/src/public/parts/serviceGenerators/AI/gemini/display.mjs
+++ b/src/public/parts/serviceGenerators/AI/gemini/display.mjs
@@ -1,7 +1,7 @@
 /* global geti18n */
 
 let last_apikey = ''
-let last_proxy_url = ''
+let last_base_url = ''
 
 return async ({ data, containers }) => {
 	const div = containers.generatorDisplay
@@ -11,9 +11,9 @@ return async ({ data, containers }) => {
 		return
 	}
 
-	if (apikey === last_apikey && (base_url || '') === (last_proxy_url || '')) return
+	if (apikey === last_apikey && (base_url || '') === (last_base_url || '')) return
 	last_apikey = apikey
-	last_proxy_url = base_url || ''
+	last_base_url = base_url || ''
 
 	div.innerHTML = /* html */ '<div data-i18n="serviceSource_manager.common_config_interface.loadingModels"></div>'
 


### PR DESCRIPTION
---
name: 'little fix'
about: default pull request template
title: fix the config of gemini in serviceSourceManage
assignees: steve02081504
---

**感谢你对fount做出的贡献**  
**Thank you for your contribution to fount**

如果你自信其他人能通过观察你对项目的修改得知你的意图，这里可以什么都不填。如果不能，请描述你的修改直至你认为其他人可以看懂修改的缘由  
If you are confident that others will know your intentions by observing your modifications to the project, you can fill in nothing here. If not, please describe your change until you think others can understand the reason for the modification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Gemini service config from `proxy_url` to `base_url` and updates related state checks and HTTP client options.
> 
> - Replaces `proxy_url` with `base_url` in `display.mjs` data handling and `last_*` caching logic
> - Sets `httpOptions.baseUrl` using `base_url`; model listing/rendering logic unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38df3cbab129a758948ebbebd51e59d423238c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->