### PR TITLE
together/A: fount/ import alias and platform deps

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,13 @@
 {
 	"nodeModulesDir": "auto",
 	"lock": false,
+	"minimumDependencyAge": {
+		"exclude": [
+			"npm:@steve02081504/*",
+			"npm:eslint-plugin-remove-duplicates",
+			"npm:on-shutdown"
+		]
+	},
 	"unstable": [
 		"npm-lazy-caching"
 	],
@@ -24,6 +31,8 @@
 		"uninstall": "deno run -A path/fount.mjs remove"
 	},
 	"imports": {
+		"fount/": "./src/",
+		"https://esm.sh/": "npm:/",
 		"npm:estree": "npm:nop",
 		"npm:@steve02081504/async-eval": "npm:@steve02081504/async-eval@^0.0.13",
 		"npm:express": "npm:express@^5.1.0",
@@ -31,9 +40,11 @@
 		"npm:cookie-parser": "npm:cookie-parser@^1.4.0",
 		"npm:@steve02081504/virtual-console": "npm:@steve02081504/virtual-console@^0.2.13",
 		"npm:@steve02081504/exec": "npm:@steve02081504/exec@^0.0.6",
-		"npm:on-shutdown": "npm:on-shutdown@^0.0.4",
+		"npm:on-shutdown": "npm:on-shutdown@^0.0.5",
 		"npm:fs-extra": "npm:fs-extra@^11.3.2",
-		"npm:file-type": "npm:file-type@^21.0.0"
+		"npm:file-type": "npm:file-type@^21.0.0",
+		"npm:@steve02081504/fount-p2p": "npm:@steve02081504/fount-p2p@^0.0.12",
+		"npm:web-push": "npm:web-push@^3.6.7"
 	},
 	"lint": {
 		"exclude": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
 	"bin": {
 		"fount": "path/fount.mjs"
 	},
+	"exports": {
+		"./*": "./src/*"
+	},
 	"scripts": {
 		"run": "node path/fount.mjs run",
 		"init": "node path/fount.mjs init",


### PR DESCRIPTION
## Summary
- Add `fount/` and `esm.sh` import maps in `deno.json`, plus `package.json` exports.
- Bump `on-shutdown` and pre-declare `fount-p2p` / `web-push` deps for later stacked PRs.
- Part of [together → master plan](docs/design/together-to-master-pr-plan.md) (PR L).

## Test plan
- [ ] `deno` still resolves existing npm imports
- [ ] No runtime callers of `fount/` or new deps yet — additive only