### PR TITLE
together/C: net_listen dual-stack and no-cors proxy

### DIFF
--- a/src/scripts/net_listen.mjs
+++ b/src/scripts/net_listen.mjs
@@ -1,0 +1,139 @@
+/**
+ * HTTP/TCP listen 绑定选项。
+ *
+ * Deno 在 Windows 上对 `ipv6Only: false` 的双栈 `::` 无效（与 Node 不同），
+ * 须显式双绑 `0.0.0.0` + `::`（ipv6Only）。
+ * Linux/macOS 上 `::` + ipv6Only:false 一口吃 IPv4-mapped；若再绑 `0.0.0.0` 会 EADDRINUSE。
+ */
+import net from 'node:net'
+import process from 'node:process'
+
+/** Windows Deno 无法靠单绑 `::` 覆盖 IPv4。 */
+const explicitDualStack = process.platform === 'win32'
+
+/**
+ * @param {string | null | undefined} host config.listen
+ * @param {number} port 端口
+ * @returns {import('node:net').ListenOptions[]} 需全部尝试的绑定（某族不可用则跳过）
+ */
+export function resolveListenBinds(host, port) {
+	if (host == null) {
+		if (explicitDualStack) return [
+			{ port, host: '0.0.0.0' },
+			{ port, host: '::', ipv6Only: true },
+		]
+		return [{ port, host: '::', ipv6Only: false }]
+	}
+	if (host === 'localhost') return [
+		{ port, host: '127.0.0.1' },
+		{ port, host: '::1', ipv6Only: true },
+	]
+	return [{ port, host }]
+}
+
+/**
+ * 单绑兼容（取列表首项）。新代码请用 {@link resolveListenBinds}。
+ * @param {string | null | undefined} host config.listen
+ * @param {number} port 端口
+ * @returns {import('node:net').ListenOptions} listen 绑定
+ */
+export function resolveListenBind(host, port) {
+	return resolveListenBinds(host, port)[0]
+}
+
+/**
+ * 是否仅 loopback 范围（不打印局域网 URL / 二维码）。
+ * @param {string | null | undefined} host config.listen
+ * @returns {boolean} host 为 localhost 时为 true
+ */
+export function isLoopbackListen(host) {
+	return host === 'localhost'
+}
+
+/**
+ * 尝试绑定一次；族不支持视为可跳过。
+ * @param {import('node:net').ListenOptions} bind 绑定选项
+ * @returns {Promise<'ok' | 'busy' | 'unsupported'>} 探测结果
+ */
+function probeBind(bind) {
+	return new Promise(resolve => {
+		const server = net.createServer()
+		server.unref()
+		server.once('error', err => {
+			if (['EAFNOSUPPORT', 'EADDRNOTAVAIL'].includes(err.code)) resolve('unsupported')
+			else resolve('busy')
+		})
+		server.listen(bind, () => {
+			server.close(() => resolve('ok'))
+		})
+	})
+}
+
+/**
+ * 监听一次；族不支持返回 null。
+ * @param {import('node:net').ListenOptions} bind 绑定选项
+ * @returns {Promise<import('node:net').Server | null>} 已监听 server，或不支持时 null
+ */
+function listenOne(bind) {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer()
+		server.unref()
+		server.once('error', err => {
+			if (['EAFNOSUPPORT', 'EADDRNOTAVAIL'].includes(err.code)) resolve(null)
+			else reject(err)
+		})
+		server.listen(bind, () => resolve(server))
+	})
+}
+
+/**
+ * 检测默认双栈（或指定 host）下该端口是否可完整占用。
+ * 任一所需族 EADDRINUSE → false；全部族不支持 → false；至少一族 ok 且无 busy → true。
+ * @param {number} port 待检测端口
+ * @param {string | null | undefined} [host] config.listen；默认 null（双栈 any）
+ * @returns {Promise<boolean>} 端口是否空闲可用
+ */
+export async function isListenPortFree(port, host = null) {
+	let sawOk = false
+	for (const bind of resolveListenBinds(host, port)) {
+		const result = await probeBind(bind)
+		if (result === 'busy') return false
+		if (result === 'ok') sawOk = true
+	}
+	return sawOk
+}
+
+/**
+ * 占住默认双栈端口直至显式关闭（消除并行测试 TOCTOU）。
+ * @param {number} port 待占用端口
+ * @param {string | null | undefined} [host] config.listen；默认 null（双栈 any）
+ * @returns {Promise<import('node:net').Server[]>} 已监听的 server 列表
+ */
+export async function holdListenPort(port, host = null) {
+	/** @type {import('node:net').Server[]} */
+	const held = []
+	try {
+		for (const bind of resolveListenBinds(host, port)) {
+			const server = await listenOne(bind)
+			if (server) held.push(server)
+		}
+		if (!held.length) throw new Error(`no supported listen family for port ${port}`)
+		return held
+	}
+	catch (err) {
+		await Promise.all(held.map(s => new Promise(r => s.close(() => r()))))
+		throw err
+	}
+}
+
+/**
+ * 关闭 {@link holdListenPort} 返回的 server 列表。
+ * @param {import('node:net').Server[] | undefined} servers 待关闭的 server 列表
+ * @returns {Promise<void>} 全部关闭后兑现
+ */
+export async function closeHeldServers(servers) {
+	if (!servers?.length) return
+	await Promise.all(servers.map(s => new Promise((resolve, reject) => {
+		s.close(err => err ? reject(err) : resolve())
+	})))
+}

--- a/src/server/no_cors.mjs
+++ b/src/server/no_cors.mjs
@@ -1,0 +1,164 @@
+/**
+ * 已认证用户的通用 no-CORS 中转：双向流式转发，支持任意方法 / Range / 自定义头。
+ */
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+
+const HOP_BY_HOP = new Set([
+	'connection',
+	'keep-alive',
+	'proxy-authenticate',
+	'proxy-authorization',
+	'te',
+	'trailers',
+	'transfer-encoding',
+	'upgrade',
+])
+
+/** 不转发给上游的本机连接头（含 fount 会话 Cookie / API key）。 */
+const FOUNT_LOCAL = new Set([
+	'host',
+	'cookie',
+	'fount-apikey',
+	'content-length',
+])
+
+/**
+ * 默认同名转发的请求头（Range 断点、条件请求、Content-Type 等）。
+ * Cookie / Authorization 等敏感头须用 `No-Cors-*` 注入，避免把 fount 会话泄露给上游。
+ */
+const FORWARD_REQ = new Set([
+	'accept',
+	'accept-language',
+	'content-type',
+	'user-agent',
+	'referer',
+	'range',
+	'if-range',
+	'if-match',
+	'if-none-match',
+	'if-modified-since',
+	'if-unmodified-since',
+	'cache-control',
+	'pragma',
+])
+
+const NO_CORS_PREFIX = 'no-cors-'
+
+/**
+ * @param {import('npm:express').Request} req 入站请求
+ * @returns {Headers} 上游请求头
+ */
+export function buildUpstreamHeaders(req) {
+	const headers = new Headers()
+	for (const [key, value] of Object.entries(req.headers)) {
+		if (value == null) continue
+		const lower = key.toLowerCase()
+		const text = Array.isArray(value) ? value.join(', ') : String(value)
+		if (lower.startsWith(NO_CORS_PREFIX)) {
+			const name = lower.slice(NO_CORS_PREFIX.length)
+			if (!name || HOP_BY_HOP.has(name) || name === 'host') continue
+			headers.set(name, text)
+			continue
+		}
+		if (FOUNT_LOCAL.has(lower) || HOP_BY_HOP.has(lower)) continue
+		if (!FORWARD_REQ.has(lower)) continue
+		headers.set(lower, text)
+	}
+	return headers
+}
+
+/**
+ * @param {Headers} upstreamHeaders 上游响应头
+ * @param {import('npm:express').Response} res Express 响应
+ * @returns {void}
+ */
+function writeResponseHeaders(upstreamHeaders, res) {
+	for (const [key, value] of upstreamHeaders) {
+		const lower = key.toLowerCase()
+		if (HOP_BY_HOP.has(lower)) continue
+		res.append(key, value)
+	}
+}
+
+/**
+ * 双向流式转发：不缓冲整包 body。
+ * @param {import('npm:express').Request} req Express 请求
+ * @param {import('npm:express').Response} res Express 响应
+ * @returns {Promise<void>}
+ */
+export async function handleNoCors(req, res) {
+	const raw = String(req.query.url || '')
+	let parsed
+	try {
+		parsed = new URL(raw)
+	}
+	catch {
+		res.status(400).json({ message: 'invalid url' })
+		return
+	}
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		res.status(400).json({ message: 'only http(s) URLs are allowed' })
+		return
+	}
+
+	const method = req.method.toUpperCase()
+	const hasBody = method !== 'GET' && method !== 'HEAD'
+	const ac = new AbortController()
+	/**
+	 * 客户端断开时中止上游，避免无用灌包。
+	 * @returns {void}
+	 */
+	const onAbort = () => {
+		if (!res.writableEnded) ac.abort()
+	}
+	req.on('aborted', onAbort)
+	res.on('close', onAbort)
+
+	/** @type {RequestInit} */
+	const init = {
+		method,
+		headers: buildUpstreamHeaders(req),
+		signal: ac.signal,
+		redirect: hasBody ? 'manual' : 'follow',
+	}
+	if (hasBody) {
+		init.body = Readable.toWeb(req)
+		init.duplex = 'half'
+	}
+
+	let upstream
+	try {
+		upstream = await fetch(parsed.href, init)
+	}
+	catch (error) {
+		if (ac.signal.aborted || error?.name === 'AbortError') return
+		throw error
+	}
+
+	res.status(upstream.status)
+	writeResponseHeaders(upstream.headers, res)
+	if (upstream.url && upstream.url !== parsed.href)
+		res.setHeader('X-No-Cors-Final-Url', upstream.url)
+
+	if (method === 'HEAD' || !upstream.body) {
+		res.end()
+		return
+	}
+
+	try {
+		await pipeline(Readable.fromWeb(upstream.body), res)
+	}
+	catch (error) {
+		if (ac.signal.aborted || error?.code === 'ERR_STREAM_PREMATURE_CLOSE') return
+		throw error
+	}
+}
+
+/**
+ * @param {string} path 请求路径
+ * @returns {boolean} 是否为 no-cors 路由（跳过 body 解析中间件）
+ */
+export function isNoCorsPath(path) {
+	return path === '/api/no-cors'
+}

--- a/src/server/no_cors.mjs
+++ b/src/server/no_cors.mjs
@@ -57,7 +57,7 @@ export function buildUpstreamHeaders(req) {
 		const text = Array.isArray(value) ? value.join(', ') : String(value)
 		if (lower.startsWith(NO_CORS_PREFIX)) {
 			const name = lower.slice(NO_CORS_PREFIX.length)
-			if (!name || HOP_BY_HOP.has(name) || name === 'host') continue
+			if (!name || HOP_BY_HOP.has(name) || name === 'host' || name === 'content-length') continue
 			headers.set(name, text)
 			continue
 		}
@@ -77,6 +77,13 @@ function writeResponseHeaders(upstreamHeaders, res) {
 	for (const [key, value] of upstreamHeaders) {
 		const lower = key.toLowerCase()
 		if (HOP_BY_HOP.has(lower)) continue
+		if (lower === 'set-cookie') {
+			const cookies = typeof upstreamHeaders.getSetCookie === 'function'
+				? upstreamHeaders.getSetCookie()
+				: [value]
+			for (const cookie of cookies) res.append('Set-Cookie', cookie)
+			continue
+		}
 		res.append(key, value)
 	}
 }

--- a/src/server/server.mjs
+++ b/src/server/server.mjs
@@ -246,8 +246,8 @@ export async function init(start_config) {
 		 */
 		const listenOne = (bind) => new Promise((resolve, reject) => {
 			const server = httpsConfig?.enabled ? https.createServer({
-				key: fs.readFileSync(path.resolve(httpsConfig.keyFile, __dirname)),
-				cert: fs.readFileSync(path.resolve(httpsConfig.certFile, __dirname)),
+				key: fs.readFileSync(path.resolve(__dirname, httpsConfig.keyFile)),
+				cert: fs.readFileSync(path.resolve(__dirname, httpsConfig.certFile)),
 			}, requestListener) : http.createServer(requestListener)
 			server.on('upgrade', upgradeListener)
 			server.once('error', (err) => {

--- a/src/server/server.mjs
+++ b/src/server/server.mjs
@@ -11,6 +11,7 @@ import { getMemoryUsage } from '../scripts/gc.mjs'
 import { console } from '../scripts/i18n.mjs'
 import { loadJsonFile, saveJsonFile } from '../scripts/json_loader.mjs'
 import { ms } from '../scripts/ms.mjs'
+import { isLoopbackListen, resolveListenBinds } from '../scripts/net_listen.mjs'
 import { notify } from '../scripts/notify.mjs'
 import { get_hosturl_in_local_ip } from '../scripts/ratelimit.mjs'
 import { ClearTaskbarProgress, SetTaskbarProgress } from '../scripts/taskbar_progress.mjs'
@@ -183,20 +184,23 @@ export async function init(start_config) {
 		SetTaskbarProgress(75)
 		const { port, https: httpsConfig, trust_proxy, mdns: mdnsConfig } = config // 获取 HTTPS 配置
 		hosturl = (httpsConfig?.enabled ? 'https' : 'http') + '://localhost:' + port
-		let server
 
 		console.freshLineI18n('server start', 'fountConsole.server.starting')
 		let appPromise
+		/** @type {import('node:http').Server[]} */
+		const servers = []
 		/**
 		 * 懒加载地获取 Express 应用程序实例。
 		 * @returns {Promise<import('npm:express').Application>} Express 应用程序实例。
 		 */
 		const getApp = () => appPromise ??= import('./web_server/index.mjs').then(({ app }) => {
 			app.set('trust proxy', trust_proxy ?? 'loopback')
-			server.removeListener('request', requestListener)
-			server.on('request', app)
-			server.removeListener('upgrade', upgradeListener)
-			server.on('upgrade', app.ws_on_upgrade)
+			for (const server of servers) {
+				server.removeListener('request', requestListener)
+				server.on('request', app)
+				server.removeListener('upgrade', upgradeListener)
+				server.on('upgrade', app.ws_on_upgrade)
+			}
 			return app
 		})
 		/**
@@ -236,42 +240,56 @@ export async function init(start_config) {
 
 		SetTaskbarProgress(78)
 		/**
-		 * 监听特定地址
-		 * @param {String} listenAddress 要监听的地址
-		 * @returns {Promise<Boolean>} 是否本地
+		 * 创建并绑定单个 HTTP(S) 服务器；族不支持时返回 null。
+		 * @param {import('node:net').ListenOptions} bind 绑定选项
+		 * @returns {Promise<import('node:http').Server | null>} 已监听的 server，或族不支持时为 null
 		 */
-		const listen = async (listenAddress) => await new Promise((resolve, reject) => {
-			const ansi_hosturl = supportsAnsi ? `\x1b]8;;${hosturl}\x1b\\${hosturl}\x1b]8;;\x1b\\` : hosturl
-
-			const listen = [port, listenAddress].filter(Boolean)
-
-			if (httpsConfig?.enabled)
-				server = https.createServer({
-					key: fs.readFileSync(path.resolve(httpsConfig.keyFile, __dirname)),
-					cert: fs.readFileSync(path.resolve(httpsConfig.certFile, __dirname)),
-				}, requestListener).listen(...listen, async () => {
-					SetTaskbarProgress(80)
-					console.logI18n('fountConsole.server.showUrl.https', { url: ansi_hosturl })
-					if (starts.Web?.mDNS) mdnsModulePromise.then(({ initMdns }) => initMdns(port, 'https', mdnsConfig))
-					resolve(listenAddress == 'localhost')
-				})
-			else
-				server = http.createServer(requestListener).listen(...listen, async () => {
-					SetTaskbarProgress(80)
-					console.logI18n('fountConsole.server.showUrl.http', { url: ansi_hosturl })
-					if (starts.Web?.mDNS) mdnsModulePromise.then(({ initMdns }) => initMdns(port, 'http', mdnsConfig))
-					resolve(listenAddress == 'localhost')
-				})
-
+		const listenOne = (bind) => new Promise((resolve, reject) => {
+			const server = httpsConfig?.enabled ? https.createServer({
+				key: fs.readFileSync(path.resolve(httpsConfig.keyFile, __dirname)),
+				cert: fs.readFileSync(path.resolve(httpsConfig.certFile, __dirname)),
+			}, requestListener) : http.createServer(requestListener)
 			server.on('upgrade', upgradeListener)
-			server.on('error', (err) => {
-				console.error(err)
+			server.once('error', (err) => {
 				server.close(() => {
-					server = null
-					reject(err)
+					if (['EAFNOSUPPORT', 'EADDRNOTAVAIL'].includes(err.code)) resolve(null)
+					else reject(err)
 				})
 			})
+			server.listen(bind, () => resolve(server))
 		})
+
+		/**
+		 * 按 resolveListenBinds 双绑（Windows/Deno 上单绑 :: 无法吃到 127.0.0.1）。
+		 * @param {string | null | undefined} listenAddress config.listen
+		 * @returns {Promise<boolean>} 是否仅 localhost 范围绑定
+		 */
+		const listen = async (listenAddress) => {
+			const binds = resolveListenBinds(listenAddress, port)
+			servers.length = 0
+			try {
+				for (const bind of binds) {
+					const server = await listenOne(bind)
+					if (server) servers.push(server)
+				}
+				if (!servers.length) {
+					const server = await listenOne({ port })
+					if (!server) throw Object.assign(new Error('no supported listen family'), { code: 'EADDRNOTAVAIL' })
+					servers.push(server)
+				}
+			}
+			catch (err) {
+				await Promise.all(servers.map(server => new Promise(done => server.close(done))))
+				throw err
+			}
+			SetTaskbarProgress(80)
+			const ansi_hosturl = supportsAnsi ? `\x1b]8;;${hosturl}\x1b\\${hosturl}\x1b]8;;\x1b\\` : hosturl
+			const scheme = httpsConfig?.enabled ? 'https' : 'http'
+			console.logI18n(`fountConsole.server.showUrl.${scheme}`, { url: ansi_hosturl })
+			if (starts.Web?.mDNS) mdnsModulePromise.then(({ initMdns }) => initMdns(port, scheme, mdnsConfig))
+			return isLoopbackListen(listenAddress)
+		}
+
 		let is_localhost
 		try {
 			is_localhost = await listen(config.listen)

--- a/src/server/test/pure/net_listen.test.mjs
+++ b/src/server/test/pure/net_listen.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * listen 双栈绑定解析与端口探测。
+ */
+/* global Deno */
+import process from 'node:process'
+
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import {
+	closeHeldServers,
+	holdListenPort,
+	isListenPortFree,
+	isLoopbackListen,
+	resolveListenBind,
+	resolveListenBinds,
+} from '../../../scripts/net_listen.mjs'
+
+Deno.test('resolveListenBinds dual-stacks null and localhost', () => {
+	if (process.platform === 'win32')
+		assertEquals(resolveListenBinds(null, 8931), [
+			{ port: 8931, host: '0.0.0.0' },
+			{ port: 8931, host: '::', ipv6Only: true },
+		])
+	else
+		assertEquals(resolveListenBinds(null, 8931), [
+			{ port: 8931, host: '::', ipv6Only: false },
+		])
+	assertEquals(resolveListenBinds('localhost', 8931), [
+		{ port: 8931, host: '127.0.0.1' },
+		{ port: 8931, host: '::1', ipv6Only: true },
+	])
+	assertEquals(resolveListenBinds('192.168.1.1', 80), [{ port: 80, host: '192.168.1.1' }])
+	assertEquals(resolveListenBind(null, 1), resolveListenBinds(null, 1)[0])
+	assertEquals(isLoopbackListen('localhost'), true)
+	assertEquals(isLoopbackListen(null), false)
+})
+
+Deno.test('isListenPortFree / holdListenPort round-trip', async () => {
+	const port = 38931
+	assertEquals(await isListenPortFree(port), true)
+	const held = await holdListenPort(port)
+	assertEquals(held.length >= 1, true)
+	assertEquals(await isListenPortFree(port), false)
+	await closeHeldServers(held)
+	assertEquals(await isListenPortFree(port), true)
+})

--- a/src/server/test/pure/no_cors.test.mjs
+++ b/src/server/test/pure/no_cors.test.mjs
@@ -23,6 +23,8 @@ Deno.test('buildUpstreamHeaders forwards Range and No-Cors-* injects Cookie/Auth
 			'no-cors-cookie': 'a=1; b=2',
 			'no-cors-authorization': 'Bearer upstream',
 			'no-cors-x-custom': 'yes',
+			'no-cors-content-length': '999',
+			'no-cors-host': 'evil.example',
 			'x-random': 'nope',
 			host: 'localhost:9999',
 			connection: 'keep-alive',
@@ -34,6 +36,7 @@ Deno.test('buildUpstreamHeaders forwards Range and No-Cors-* injects Cookie/Auth
 	assertEquals(headers.get('authorization'), 'Bearer upstream')
 	assertEquals(headers.get('x-custom'), 'yes')
 	assertEquals(headers.get('host'), null)
+	assertEquals(headers.has('content-length'), false)
 	assertEquals(headers.has('fount-apikey'), false)
 	assertEquals(headers.has('connection'), false)
 	assertEquals(headers.has('x-random'), false)

--- a/src/server/test/pure/no_cors.test.mjs
+++ b/src/server/test/pure/no_cors.test.mjs
@@ -1,0 +1,40 @@
+/**
+ * no-cors 请求头装配纯函数测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { buildUpstreamHeaders, isNoCorsPath } from '../../no_cors.mjs'
+
+Deno.test('isNoCorsPath only matches exact route', () => {
+	assertEquals(isNoCorsPath('/api/no-cors'), true)
+	assertEquals(isNoCorsPath('/api/no-cors/'), false)
+	assertEquals(isNoCorsPath('/api/ping'), false)
+})
+
+Deno.test('buildUpstreamHeaders forwards Range and No-Cors-* injects Cookie/Authorization', () => {
+	const headers = buildUpstreamHeaders(/** @type {any} */{
+		headers: {
+			range: 'bytes=0-99',
+			'content-type': 'application/octet-stream',
+			cookie: 'fount_session=secret',
+			'fount-apikey': 'leak',
+			authorization: 'Bearer fount-token',
+			'no-cors-cookie': 'a=1; b=2',
+			'no-cors-authorization': 'Bearer upstream',
+			'no-cors-x-custom': 'yes',
+			'x-random': 'nope',
+			host: 'localhost:9999',
+			connection: 'keep-alive',
+		},
+	})
+	assertEquals(headers.get('range'), 'bytes=0-99')
+	assertEquals(headers.get('content-type'), 'application/octet-stream')
+	assertEquals(headers.get('cookie'), 'a=1; b=2')
+	assertEquals(headers.get('authorization'), 'Bearer upstream')
+	assertEquals(headers.get('x-custom'), 'yes')
+	assertEquals(headers.get('host'), null)
+	assertEquals(headers.has('fount-apikey'), false)
+	assertEquals(headers.has('connection'), false)
+	assertEquals(headers.has('x-random'), false)
+})

--- a/src/server/web_server/endpoints.mjs
+++ b/src/server/web_server/endpoints.mjs
@@ -11,6 +11,7 @@ import { login, register, logout, authenticate, getUserByReq, getUserDictionary,
 import { currentGitBranch, currentGitCommit } from '../autoupdate.mjs'
 import { __dirname } from '../base.mjs'
 import { processIPCCommand } from '../ipc_server/index.mjs'
+import { handleNoCors } from '../no_cors.mjs'
 import {
 	getLoadedPartList,
 	getPartList,
@@ -133,6 +134,9 @@ export function registerEndpoints(router) {
 			hosturl_in_local_ip,
 		})
 	})
+
+	/** 已认证用户通用 no-CORS 中转：双向流式；见 src/server/no_cors.mjs */
+	router.all('/api/no-cors', authenticate, handleNoCors)
 
 	router.post('/api/pow/challenge', async (req, res) => {
 		const { pow } = await import('../../scripts/pow.mjs')

--- a/src/server/web_server/middleware.mjs
+++ b/src/server/web_server/middleware.mjs
@@ -6,6 +6,7 @@ import fileUpload from 'npm:express-fileupload'
 import { console } from '../../scripts/i18n.mjs'
 import { auth_request } from '../auth.mjs'
 import { info } from '../info.mjs'
+import { isNoCorsPath } from '../no_cors.mjs'
 import { webRequestHappened } from '../server.mjs'
 
 /**
@@ -18,6 +19,19 @@ export function diff_if_auth(if_auth, if_not_auth) {
 	return async (req, res, next) => {
 		if (await auth_request(req, res)) return if_auth(req, res, next)
 		return if_not_auth(req, res, next)
+	}
+}
+
+/**
+ * 对指定路径跳过中间件（保持原始请求流）。
+ * @param {(path: string) => boolean} skip 是否跳过
+ * @param {import('npm:express').RequestHandler} mw 实际中间件
+ * @returns {import('npm:express').RequestHandler} 包装后的中间件
+ */
+function skipWhen(skip, mw) {
+	return (req, res, next) => {
+		if (skip(req.path)) return next()
+		return mw(req, res, next)
 	}
 }
 
@@ -38,25 +52,25 @@ export function registerMiddleware(router) {
 		return next()
 	})
 
-	router.use(diff_if_auth(
+	router.use(skipWhen(isNoCorsPath, diff_if_auth(
 		express.json({ limit: Infinity }),
 		express.json({ limit: 5 * 1024 * 1024 })
-	))
+	)))
 
 	router.use(diff_if_auth(
 		cors(),
 		(req, res, next) => next()
 	))
 
-	router.use(diff_if_auth(
+	router.use(skipWhen(isNoCorsPath, diff_if_auth(
 		express.urlencoded({ limit: Infinity, extended: true }),
 		express.urlencoded({ limit: 5 * 1024 * 1024, extended: true })
-	))
+	)))
 
-	router.use(diff_if_auth(
+	router.use(skipWhen(isNoCorsPath, diff_if_auth(
 		fileUpload({ limits: { fileSize: Infinity } }),
 		fileUpload({ limits: { fileSize: 5 * 1024 * 1024 } })
-	))
+	)))
 
 	router.use(cookieParser())
 }


### PR DESCRIPTION
## Summary
- Add `src/scripts/net_listen.mjs` and wire `server.mjs` to dual-stack listen (Windows Deno fix).
- Add `src/server/no_cors.mjs` with `/api/no-cors` + middleware `skipWhen` so streaming bodies are not parsed.
- Pure tests under `src/server/test/pure/` (run via `deno test`; full `fount test` comes in D).

Part of [together → master plan](https://github.com/steve02081504/fount/blob/pr/together-l/docs/design/together-to-master-pr-plan.md).

**Deferred from C:** `registries` + `parts_loader` scan (needs larger loader change) — follows after this.

## Test plan
- [x] `deno test --no-check --allow-scripts --allow-all -c ./deno.json ./src/server/test/pure/`
- [ ] Server still listens on Windows with `config.listen: null`
- [ ] `GET/POST /api/no-cors` requires auth; body parsers skip that path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated `/api/no-cors` endpoint for forwarding web requests to HTTP and HTTPS destinations.
  - Supports multiple request methods, streamed request and response bodies, selected headers, redirects, and client disconnects.
  - Improved server startup reliability across IPv4, IPv6, and platform-specific network configurations.
  - Enhanced port availability checks and temporary port reservation behavior.

- **Bug Fixes**
  - Prevented request-body parsing from interfering with no-CORS proxy requests.
  - Improved handling of unavailable network address families during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->