### PR TITLE
together/C2: part registries and parts_loader scan

### DIFF
--- a/docs/design/together-to-master-pr-plan.md
+++ b/docs/design/together-to-master-pr-plan.md
@@ -1,15 +1,15 @@
 # together → master PR 拆分规划
 
-更新：`2026-07-20`
+更新：`2026-07-21`
 
-> 工作副本：分支 `split/together-to-master`（`together` tip soft-reset 到 `master`）。
-> 备份：`refs/backup/together-tip`、`refs/backup/pre-split-20260720212731`。
+> 工作副本：分支 `split/together-to-master`（`together` tip soft-reset 到最新 `master`）。
+> 备份：`refs/backup/together-tip`、`refs/backup/pre-resync-edf-*`。
 > 目标：用分层 PR 把 `together` 合入 `master`；每层合并后由人类通知再开下一层。
 > 全部结束后：`git diff master together` 核对无遗漏、无负向回退。
 
 ## 规模
 
-约 **1942 文件 / 337 commits**（`origin/master..together`）。
+约 **1942 文件 / 337 commits**（初始 `origin/master..together`）。E/D/F 合入后工作树脏路径约 **320+**。
 
 ## 内容组
 
@@ -17,7 +17,7 @@
 | --- | --- | --- | --- |
 | **A** | `fount/` 别名与依赖底座 | `deno.json`（`fount/`、`esm.sh`、deps、`test` task）、`package.json` exports | 极小 |
 | **B** | i18n 拆分 | `src/scripts/i18n/{bare,index}.mjs` 替扁平 `i18n.mjs`；前端 `pages/scripts/i18n/`；`.github/pages/scripts/i18n/`；`locale.mjs`；全库 import 路径 | 小–中 |
-| **C** | 服务端微基建 | `net_listen`、`registries`、`no_cors`、multipart/notify/web-push、`sentry_state` 迁移、对应 pure 测与最小接线 | 中小 |
+| **C** | 服务端微基建 | `net_listen`、`no_cors`（已合）；**C2**：`registries` + `parts_loader` 扫描（延期） | 中小 |
 | **D** | 测试框架 + CI | `src/scripts/test/`、`fount test` CLI、`.github/workflows/*`、`.esh/commands/test.ps1` | 中 |
 | **E** | Auth 模块化 | `auth.mjs`/`webauthn.mjs` → `src/server/auth/` | 小 |
 | **F** | 前端 pages/scripts 重整 | scripts 目录重组、components/api/lib/theme 等 | 中 |
@@ -30,31 +30,31 @@
 
 ## 依赖（实测修正）
 
-- **B** 的 `i18n/index.mjs` 依赖 **C** 的 `registries`；完整 `auth/index` 属 **E**。在 E 合并前，B 可暂对 `auth.mjs` 接线，E 再改路径。
-- **D** 的 playwright gate 引用 chat/social → 框架主体可先合，gate 跟 H/I。
-- **I/J/K** 依赖 **H**；**I/J/K** 均依赖 **G** 的实体/P2P 面。
+- **B** 完整 `i18n/index`（registries 扫 locales）依赖 **C2**；已合 B 仍用 `parts_locale_*` cache。
+- **D** playwright gate 引用 chat/social → 框架已合（gate 内联）；H/I 后可改回导入。
+- **G** 依赖 **E**（已合）与 **H** 的 `entity/store`（及 `identity`）→ **G 须跟在 H 后或与 H 同 PR**。
+- **C2** `parts_loader` 用 `@steve02081504/fount-p2p` 的 composite_key（deps 已在 A）；不强制整包 G。
+- **I/J/K** 依赖 **H**；亦依赖 **G** 的实体/P2P 面。
 
 ```mermaid
 flowchart TB
-  subgraph L0["第 0 层"]
-    A["A fount/ 别名与依赖"]
-    C["C 服务端微基建"]
+  subgraph done["已合入 master"]
+    A["A fount/ 别名"]
+    C["C net_listen + no_cors"]
     L["L Docs"]
-  end
-
-  subgraph L1["第 1 层"]
     B["B i18n 拆分"]
     D["D 测试框架 + CI"]
-    E["E Auth 模块化"]
+    E["E Auth"]
     F["F pages/scripts"]
-    G["G P2P 胶水"]
   end
 
-  subgraph L2["第 2 层"]
+  subgraph next["下一层"]
+    C2["C2 registries + parts_loader"]
     H["H Chat 重写"]
   end
 
-  subgraph L3["第 3 层"]
+  subgraph afterH["H 之后"]
+    G["G P2P 胶水"]
     I["I Social"]
     J["J Cabinet"]
     K["K 其它 shells/parts"]
@@ -65,15 +65,14 @@ flowchart TB
   B --> D
   B --> E
   B --> F
-  C --> D
-  C --> E
-  C --> G
-  A --> G
-  E --> G
+  C --> C2
+  A --> C2
+  C2 --> H
   F --> H
-  G --> H
   E --> H
   D -.->|"playwright gates"| H
+  H --> G
+  E --> G
   H --> I
   H --> J
   H --> K
@@ -82,24 +81,24 @@ flowchart TB
   G --> K
 ```
 
-## 本轮（第 0 层）执行顺序
-
-1. **A**、**L** — 基于 `master`，互不依赖，可并行。
-2. **C** — 基于 `master`（与 A 无边；不依赖 `fount/` 别名本轮落地）；本轮落地 `net_listen` + `no_cors`（含接线与 pure 测）。**registries / parts_loader 扫描延期**到后续 PR。
-3. **B** — 基于 `master` 并行开出：`i18n` 拆分后 part locales **暂留** master 的 `parts_locale_*` cache（不依赖 registries）；auth 仍走 `auth.mjs` 直到 E。
-
 ## 操作约定
 
 - 从 `master`（或声明的 base）建 `pr/together-<id>-…` 分支；只 `git checkout together -- <paths>` / 具名 stage，禁止 `git add .`。
-- 每层合并完毕后人类通知，再开下一层。
+- 每层合并后：soft-reset 工作树到新 `master`，**不回退** master 上已合修复；together 仍需要的文件则 **port** 修复 hunk。
 - 全部合并后比对 `master` vs `together`。
 
 ## 进度
 
 | 层 | 组 | 状态 | PR |
 | --- | --- | --- | --- |
-| 0 | A | 已开 PR | https://github.com/steve02081504/fount/pull/233 |
-| 0 | C | 已开 PR（net_listen + no_cors；registries 延期） | https://github.com/steve02081504/fount/pull/234 |
-| 0 | L | 已开 PR | https://github.com/steve02081504/fount/pull/232 |
-| 0 | B | 已开 PR（part locales 仍用旧 cache） | https://github.com/steve02081504/fount/pull/235 |
-| 1+ | D–K | 未开始 | |
+| 0 | A | **已合并** | https://github.com/steve02081504/fount/pull/233 |
+| 0 | C | **已合并**（net_listen + no_cors；registries → C2） | https://github.com/steve02081504/fount/pull/234 |
+| 0 | L | **已合并** | https://github.com/steve02081504/fount/pull/232 |
+| 0 | B | **已合并**（part locales 仍用旧 cache） | https://github.com/steve02081504/fount/pull/235 |
+| 1 | E | **已合并**（含 endpoints `getUserByReq` 去 await、`loginWithApiKey` 可选 req） | https://github.com/steve02081504/fount/pull/236 |
+| 1 | D | **已合并**（gate 内联至 H/I） | https://github.com/steve02081504/fount/pull/237 |
+| 1 | F | **已合并**（含 floatingPanel/catbox 等后续修） | https://github.com/steve02081504/fount/pull/238 |
+| 2 | C2 | 已开 PR | registries + parts_loader 扫描 |
+| 2 | H | 待开 | Chat 重写（解锁 G） |
+| 3 | G | 阻于 H | P2P 胶水 |
+| 3+ | I–K | 阻于 H（及 G） | |

--- a/docs/design/together-to-master-pr-plan.md
+++ b/docs/design/together-to-master-pr-plan.md
@@ -98,7 +98,7 @@ flowchart TB
 | 1 | E | **已合并**（含 endpoints `getUserByReq` 去 await、`loginWithApiKey` 可选 req） | https://github.com/steve02081504/fount/pull/236 |
 | 1 | D | **已合并**（gate 内联至 H/I） | https://github.com/steve02081504/fount/pull/237 |
 | 1 | F | **已合并**（含 floatingPanel/catbox 等后续修） | https://github.com/steve02081504/fount/pull/238 |
-| 2 | C2 | 已开 PR | registries + parts_loader 扫描 |
+| 2 | C2 | 已开 PR | https://github.com/steve02081504/fount/pull/239 |
 | 2 | H | 待开 | Chat 重写（解锁 G） |
 | 3 | G | 阻于 H | P2P 胶水 |
 | 3+ | I–K | 阻于 H（及 G） | |

--- a/src/scripts/i18n/index.mjs
+++ b/src/scripts/i18n/index.mjs
@@ -1,8 +1,13 @@
 export * from './bare.mjs'
 
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { events } from '../../server/events.mjs'
-import { loadData, loadTempData, saveData } from '../../server/setting_loader.mjs'
+import { getRegistry } from '../../server/registries.mjs'
+import { loadData, saveData } from '../../server/setting_loader.mjs'
 import { sendEventToAll } from '../../server/web_server/event_dispatcher.mjs'
+import { loadJsonFile } from '../json_loader.mjs'
 import { localesForUser } from '../locale.mjs'
 
 import {
@@ -35,17 +40,23 @@ export async function getLocaleDataForUser(username, preferredlocaleList) {
 	const result = {
 		...getLocaleData(effectivePreferred)
 	}
-	const partsLocaleLists = loadData(username, 'parts_locale_lists_cache')
 	const partsLocaleCache = loadData(username, 'parts_locales_cache')
-	const partsLocaleLoaders = loadTempData(username, 'parts_locale_loaders')
-	const partpaths = Object.keys(partsLocaleLists)
-	const partdataList = await Promise.all(partpaths.map(async partpath => {
-		const resultLocale = getbestlocale(effectivePreferred, partsLocaleLists[partpath])
-		partsLocaleCache[partpath] ??= {}
-		return partsLocaleCache[partpath][resultLocale] ??= await partsLocaleLoaders[partpath]?.(resultLocale)
-	}))
-	for (const partdata of partdataList)
+	for (const entry of getRegistry(username, 'locales', { resolve: 'fs' }).sort((a, b) => (a.level ?? 0) - (b.level ?? 0))) {
+		const fsPath = entry.path
+		if (!fs.existsSync(fsPath)) continue
+		/** @type {LocaleData} */
+		let partdata
+		if (fs.statSync(fsPath).isDirectory()) {
+			const localeFiles = fs.readdirSync(fsPath).filter(f => f.endsWith('.json'))
+			const resultLocale = getbestlocale(effectivePreferred, localeFiles.map(f => f.slice(0, -5)))
+			partsLocaleCache[entry.partpath] ??= {}
+			partdata = partsLocaleCache[entry.partpath][resultLocale]
+				??= loadJsonFile(path.join(fsPath, `${resultLocale}.json`))
+		}
+		else
+			partdata = loadJsonFile(fsPath)
 		Object.assign(result, partdata)
+	}
 	saveData(username, 'parts_locales_cache')
 	return result
 }
@@ -56,30 +67,11 @@ events.on('part-loaded', ({ username, partpath }) => {
 events.on('part-uninstalled', ({ username, partpath }) => {
 	delete loadData(username, 'parts_locales_cache')?.[partpath]
 	saveData(username, 'parts_locales_cache')
-	delete loadData(username, 'parts_locale_lists_cache')?.[partpath]
-	saveData(username, 'parts_locale_lists_cache')
-	delete loadTempData(username, 'parts_locale_loaders')?.[partpath]
 })
 
 onLocaleFileChanged(() => {
 	sendEventToAll('locale-updated', null)
 })
-
-/**
- * 为部件添加区域设置数据。
- * @param {string} username - 用户的用户名。
- * @param {string} partpath - 部件的路径（例如 'chars/GentianAphrodite'）。
- * @param {string[]} localeList - 部件的可用区域设置列表。
- * @param {Function} loader - 加载部件区域设置数据的函数。
- * @returns {void}
- */
-export function addPartLocaleData(username, partpath, localeList, loader) {
-	const partsLocaleLists = loadData(username, 'parts_locale_lists_cache')
-	const partsLocaleLoaders = loadTempData(username, 'parts_locale_loaders')
-	partsLocaleLists[partpath] = localeList
-	partsLocaleLoaders[partpath] = loader
-	saveData(username, 'parts_locale_lists_cache')
-}
 
 /**
  * 根据用户名和翻译键获取翻译后的文本。

--- a/src/server/parts_loader.mjs
+++ b/src/server/parts_loader.mjs
@@ -221,22 +221,16 @@ function applyBranchSegments(branches, segments) {
 }
 
 /**
- * 将 fount.json 的内容合并到部件分支对象中。
+ * 将已解析的 fount.json 内容合并到部件分支对象中。
  * @param {object} branches - 当前的分支对象。
- * @param {string} filePath - fount.json 路径。
+ * @param {object} info - 已解析的 fount.json 对象。
  */
-function mergeFountJsonIntoBranches(branches, filePath) {
-	try {
-		const info = loadJsonFile(filePath)
-		const type = info.type?.trim?.() || ''
-		const dirname = info.dirname?.trim?.() || ''
-		if (!dirname) return
-		const segments = [...type.split('/').filter(Boolean), dirname]
-		applyBranchSegments(branches, segments)
-	}
-	catch (error) {
-		console.warn(`Failed to parse fount.json at ${filePath}: ${error.message}`)
-	}
+function mergeFountJsonIntoBranches(branches, info) {
+	const type = info.type?.trim?.() || ''
+	const dirname = info.dirname?.trim?.() || ''
+	if (!dirname) return
+	const segments = [...type.split('/').filter(Boolean), dirname]
+	applyBranchSegments(branches, segments)
 }
 
 /**
@@ -268,14 +262,14 @@ function normalizeRegistryEntry(entry, partpath) {
 }
 
 /**
- * 将 fount.json 的 registries 字段合并到聚合对象。
+ * 将已解析的 fount.json 的 registries 字段合并到聚合对象。
  * @param {Record<string, RegistryEntryRaw[]>} registries - 聚合对象。
- * @param {string} filePath - fount.json 路径。
+ * @param {object} info - 已解析的 fount.json 对象。
+ * @param {string} filePath - fount.json 路径（用于推导 partpath）。
  * @param {string} rootPath - 扫描根目录。
  */
-function mergeFountJsonIntoRegistries(registries, filePath, rootPath) {
+function mergeFountJsonIntoRegistries(registries, info, filePath, rootPath) {
 	try {
-		const info = loadJsonFile(filePath)
 		const reg = info.registries
 		if (!reg || typeof reg !== 'object') return
 		const partpath = partpathFromFountJsonFile(filePath, rootPath)
@@ -307,8 +301,16 @@ function scanPartTrees(username) {
 
 	for (const root of roots)
 		for (const filePath of walkFountJsonFiles(root)) {
-			mergeFountJsonIntoBranches(branches, filePath)
-			mergeFountJsonIntoRegistries(registries, filePath, root)
+			let info
+			try {
+				info = loadJsonFile(filePath)
+			}
+			catch (error) {
+				console.warn(`Failed to parse fount.json at ${filePath}: ${error.message}`)
+				continue
+			}
+			mergeFountJsonIntoBranches(branches, info)
+			mergeFountJsonIntoRegistries(registries, info, filePath, root)
 		}
 
 	return { branches, registries }

--- a/src/server/parts_loader.mjs
+++ b/src/server/parts_loader.mjs
@@ -3,6 +3,8 @@ import path from 'node:path'
 import { setTimeout } from 'node:timers'
 import url from 'node:url'
 
+import { mapDelete, mapGet, mapSet } from 'npm:@steve02081504/fount-p2p/core/composite_key'
+
 import { backupGitUncommittedChanges, run_git } from '../scripts/git.mjs'
 import { console } from '../scripts/i18n/index.mjs'
 import { loadJsonFile } from '../scripts/json_loader.mjs'
@@ -121,7 +123,8 @@ export async function loadAnyPreferredDefaultPart(user, parent) {
 export function notifyPartInstall(username, partpath) {
 	events.emit('part-installed', { username, partpath })
 	sendEventToUser(username, 'part-installed', { partpath })
-	invalidatePartBranchesCache(username)
+	invalidatePartTreeCache(username)
+	invalidatePartMainCache(username, partpath)
 }
 /**
  * 部件信息
@@ -169,6 +172,11 @@ export function notifyPartInstall(username, partpath) {
 export const parts_set = {}
 
 const PARTS_BRANCH_CACHE_NAME = 'parts_branch_cache'
+const PARTS_REGISTRIES_CACHE_NAME = 'parts_registries_cache'
+
+/**
+ * @typedef {{ id: string, level: number, path: string, partpath: string }} RegistryEntryRaw
+ */
 
 /**
  * 遍历指定目录下的所有 fount.json。
@@ -191,7 +199,6 @@ function walkFountJsonFiles(rootPath) {
 			const fullPath = path.join(current, dirent.name)
 			if (dirent.isDirectory())
 				stack.push(fullPath)
-
 			else if (dirent.isFile() && dirent.name === 'fount.json')
 				files.push(fullPath)
 		}
@@ -233,33 +240,113 @@ function mergeFountJsonIntoBranches(branches, filePath) {
 }
 
 /**
- * 扫描公共与用户目录，构建部件分支对象。
- * @param {string} username - 用户名。
- * @returns {object} - 部件分支对象。
+ * 从 fount.json 文件路径推导 partpath。
+ * @param {string} filePath - fount.json 完整路径。
+ * @param {string} rootPath - 扫描根目录（public 或用户目录）。
+ * @returns {string} partpath（斜杠分隔）。
  */
-function buildPartBranches(username) {
+function partpathFromFountJsonFile(filePath, rootPath) {
+	return path.relative(rootPath, path.dirname(filePath)).replace(/\\/g, '/')
+}
+
+/**
+ * 校验并规范化单条 registry 条目。
+ * @param {unknown} entry - 原始条目。
+ * @param {string} partpath - 所属 partpath。
+ * @returns {RegistryEntryRaw | null} 规范化条目，无效时返回 null。
+ */
+function normalizeRegistryEntry(entry, partpath) {
+	const { id, level, path: entryPath, format, dataField } = entry
+	return {
+		id: id.trim(),
+		level: Number(level) || 0,
+		path: entryPath.trim().replace(/^\/+/, ''),
+		partpath,
+		...format?.trim() && { format: format.trim() },
+		...dataField?.trim() && { dataField: dataField.trim() },
+	}
+}
+
+/**
+ * 将 fount.json 的 registries 字段合并到聚合对象。
+ * @param {Record<string, RegistryEntryRaw[]>} registries - 聚合对象。
+ * @param {string} filePath - fount.json 路径。
+ * @param {string} rootPath - 扫描根目录。
+ */
+function mergeFountJsonIntoRegistries(registries, filePath, rootPath) {
+	try {
+		const info = loadJsonFile(filePath)
+		const reg = info.registries
+		if (!reg || typeof reg !== 'object') return
+		const partpath = partpathFromFountJsonFile(filePath, rootPath)
+		for (const [name, entries] of Object.entries(reg)) {
+			if (!Array.isArray(entries)) continue
+			registries[name] ??= []
+			for (const entry of entries)
+				registries[name].push(normalizeRegistryEntry(entry, partpath))
+		}
+	}
+	catch (error) {
+		console.warn(`Failed to parse registries in fount.json at ${filePath}: ${error.message}`)
+	}
+}
+
+/**
+ * 单次 walk 产出 branches 与 registries。
+ * @param {string} username - 用户名。
+ * @returns {{ branches: object, registries: Record<string, RegistryEntryRaw[]> }} branches 与 registries 聚合。
+ */
+function scanPartTrees(username) {
 	const branches = {}
+	/** @type {Record<string, RegistryEntryRaw[]>} */
+	const registries = {}
 	const roots = [
 		path.join(__dirname, 'src/public/parts'),
 		getUserDictionary(username),
 	]
 
 	for (const root of roots)
-		for (const filePath of walkFountJsonFiles(root))
+		for (const filePath of walkFountJsonFiles(root)) {
 			mergeFountJsonIntoBranches(branches, filePath)
+			mergeFountJsonIntoRegistries(registries, filePath, root)
+		}
 
-	return branches
+	return { branches, registries }
 }
 
 /**
- * 使部件分支缓存失效。
  * @param {string} username - 用户名。
+ * @param {{ nocache?: boolean }} [options] - 可选项。
+ * @returns {void}
  */
-function invalidatePartBranchesCache(username) {
-	const cache = loadData(username, PARTS_BRANCH_CACHE_NAME)
-	delete cache.branches
-	delete cache.updatedAt
+function ensurePartTreeCache(username, { nocache = false } = {}) {
+	const branchCache = loadData(username, PARTS_BRANCH_CACHE_NAME)
+	const registryCache = loadData(username, PARTS_REGISTRIES_CACHE_NAME)
+	if (!nocache && branchCache.branches && registryCache.registries) return
+
+	const { branches, registries } = scanPartTrees(username)
+	branchCache.branches = branches
+	branchCache.updatedAt = Date.now()
 	saveData(username, PARTS_BRANCH_CACHE_NAME)
+	registryCache.registries = registries
+	registryCache.updatedAt = Date.now()
+	saveData(username, PARTS_REGISTRIES_CACHE_NAME)
+}
+
+/**
+ * 使部件分支与 registries 缓存同时失效。
+ * @param {string} username - 用户名。
+ * @returns {void}
+ */
+function invalidatePartTreeCache(username) {
+	const branchCache = loadData(username, PARTS_BRANCH_CACHE_NAME)
+	delete branchCache.branches
+	delete branchCache.updatedAt
+	saveData(username, PARTS_BRANCH_CACHE_NAME)
+	const registryCache = loadData(username, PARTS_REGISTRIES_CACHE_NAME)
+	delete registryCache.registries
+	delete registryCache.updatedAt
+	saveData(username, PARTS_REGISTRIES_CACHE_NAME)
 }
 
 /**
@@ -269,14 +356,19 @@ function invalidatePartBranchesCache(username) {
  * @returns {object} - 部件分支对象。
  */
 export function getPartBranches(username, { nocache = false } = {}) {
-	const cache = loadData(username, PARTS_BRANCH_CACHE_NAME)
-	if (!nocache && cache.branches) return cache.branches
+	ensurePartTreeCache(username, { nocache })
+	return loadData(username, PARTS_BRANCH_CACHE_NAME).branches
+}
 
-	const branches = buildPartBranches(username)
-	cache.branches = branches
-	cache.updatedAt = Date.now()
-	saveData(username, PARTS_BRANCH_CACHE_NAME)
-	return branches
+/**
+ * 获取（并在需要时刷新）用户的 registries 聚合（原始条目，含 partpath）。
+ * @param {string} username - 用户名。
+ * @param {{ nocache?: boolean }} [options] - 可选项。
+ * @returns {Record<string, RegistryEntryRaw[]>} registries 聚合对象。
+ */
+export function getPartRegistriesRaw(username, { nocache = false } = {}) {
+	ensurePartTreeCache(username, { nocache })
+	return loadData(username, PARTS_REGISTRIES_CACHE_NAME).registries
 }
 
 /**
@@ -284,7 +376,7 @@ export function getPartBranches(username, { nocache = false } = {}) {
  * 它首先检查用户特定的部件，然后回退到公共部件。
  *
  * @param {string} username - 用户的用户名。
- * @param {string} partpath - 部件的路径（例如，'shells:chat'）。
+ * @param {string} partpath - 部件路径（例如 `shells/chat`；斜杠分隔，非 URL 中的冒号形式）。
  * @returns {string} 部件目录的路径。
  */
 export function GetPartPath(username, partpath) {
@@ -292,6 +384,32 @@ export function GetPartPath(username, partpath) {
 	if (fs.existsSync(userPath + '/main.mjs'))
 		return userPath
 	return __dirname + '/src/public/parts/' + partpath
+}
+
+/** @type {Map<string, Map<string, boolean>>} */
+const partMainExistsCache = new Map()
+
+/**
+ * 缓存 part 目录是否存在 main.mjs（供 part_invoke 等高频路径使用）。
+ * @param {string} username 用户
+ * @param {string} partpath 部件路径
+ * @returns {boolean} 是否存在 main.mjs
+ */
+export function hasPartMain(username, partpath) {
+	const cached = mapGet(partMainExistsCache, username, partpath)
+	if (cached !== undefined) return cached
+	const exists = fs.existsSync(GetPartPath(username, partpath) + '/main.mjs')
+	mapSet(partMainExistsCache, username, partpath, exists)
+	return exists
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} partpath 部件路径
+ * @returns {void}
+ */
+export function invalidatePartMainCache(username, partpath) {
+	mapDelete(partMainExistsCache, username, partpath)
 }
 
 /**
@@ -445,7 +563,10 @@ export async function baseloadPart(username, partpath, {
 	pathGetter = () => GetPartPath(username, partpath),
 	Loader = baseMjsPartLoader,
 } = {}) {
-	if (isPartLoaded(username, partpath)) return parts_set[username][partpath]
+	const existing = parts_set?.[username]?.[partpath]
+	// 仅复用已解析实例；in-flight Promise 不可 await（Load 内再 baseload/loadPart 会死锁）
+	if (existing && !(existing instanceof Promise)) return existing
+	if (existing instanceof Promise) return await baseMjsPartLoader(pathGetter())
 	const path = pathGetter()
 
 	if (fs.existsSync(path + '/.git')) try {
@@ -679,10 +800,12 @@ export async function loadPartBase(username, partpath, Initargs, {
 				parts_init[partpath] = initPart(username, partpath, Initargs, { pathGetter, Initer, afterInit })
 				parts_init[partpath] = await parts_init[partpath]
 			})
-			console.logI18n('fountConsole.partManager.partInited', {
-				partpath
-			})
-			console.log(profile)
+			if (!process.env.FOUNT_TEST) {
+				console.logI18n('fountConsole.partManager.partInited', {
+					partpath
+				})
+				console.log(profile)
+			}
 			parts_init[partpath] = true
 			saveData(username, 'parts_init')
 		}
@@ -691,10 +814,7 @@ export async function loadPartBase(username, partpath, Initargs, {
 		if (!parts_set[username][partpath]) {
 			const profile = await doProfile(`part:${partpath}:load`, async () => {
 				parts_set[username][partpath] = (async () => {
-					/**
-					 * 已加载的部件实例。
-					 * @type {T}
-					 */
+					/** @type {T} */
 					const part = await baseloadPart(username, partpath, {
 						pathGetter,
 						/**
@@ -715,10 +835,12 @@ export async function loadPartBase(username, partpath, Initargs, {
 				})()
 				parts_set[username][partpath] = await parts_set[username][partpath]
 			})
-			console.logI18n('fountConsole.partManager.partLoaded', {
-				partpath
-			})
-			console.log(profile)
+			if (!process.env.FOUNT_TEST) {
+				console.logI18n('fountConsole.partManager.partLoaded', {
+					partpath
+				})
+				console.log(profile)
+			}
 			events.emit('part-loaded', { username, partpath })
 		}
 		if (parts_set[username][partpath] instanceof Promise)
@@ -784,10 +906,7 @@ export async function unloadPartBase(username, partpath, unLoadargs, {
 	unLoader = part => part.Unload?.(unLoadargs),
 	afterUnload = baseMjsPartUnloader
 } = {}) {
-	/**
-	 * 待卸载的部件实例。
-	 * @type {T}
-	 */
+	/** @type {T} */
 	const part = parts_set[username]?.[partpath]
 	if (!part) return
 	try {
@@ -840,10 +959,7 @@ export async function uninstallPartBase(username, partpath, unLoadargs, uninstal
 	}
 } = {}) {
 	parts_set[username] ??= {}
-	/**
-	 * 当前或待重载的部件实例。
-	 * @type {T | undefined}
-	 */
+	/** @type {T | undefined} */
 	let part = parts_set[username][partpath]
 	const parent = path.dirname(partpath)
 	const partname = path.basename(partpath)
@@ -868,7 +984,8 @@ export async function uninstallPartBase(username, partpath, unLoadargs, uninstal
 	const parts_init = loadData(username, 'parts_init')
 	delete parts_init[partpath]
 	saveData(username, 'parts_init')
-	invalidatePartBranchesCache(username)
+	invalidatePartTreeCache(username)
+	invalidatePartMainCache(username, partpath)
 }
 
 /**
@@ -973,10 +1090,7 @@ function getSfwInfo(info) {
  * @returns {Promise<PartDetails>} 一个解析为详细部件信息的承诺。
  */
 export async function getPartDetails(username, partpath, nocache = false) {
-	/**
-	 * 部件详情（缓存或新加载）。
-	 * @type {PartDetails | undefined}
-	 */
+	/** @type {PartDetails | undefined} */
 	let details = nocache ? undefined : loadData(username, 'parts_details_cache')?.[partpath]
 	const user = getUserByUsername(username)
 	if (!details) details = await nocacheGetPartBaseDetails(username, partpath)

--- a/src/server/registries.mjs
+++ b/src/server/registries.mjs
@@ -1,0 +1,112 @@
+import path from 'node:path'
+
+import { loadJsonFile } from '../scripts/json_loader.mjs'
+
+import { GetPartPath, getPartRegistriesRaw } from './parts_loader.mjs'
+
+/**
+ * @typedef {{ id: string, level: number, path: string, partpath?: string, format?: string, dataField?: string }} RegistryEntry
+ */
+
+/**
+ * 将 partpath 转为前端 URL 前缀（`/parts/shells:chat`）。
+ * @param {string} partpath - 部件路径。
+ * @returns {string} 前端 URL 前缀。
+ */
+export function partpathToUrlPrefix(partpath) {
+	const segments = partpath.split('/').filter(Boolean)
+	if (!segments.length) return '/parts'
+	const [head, ...rest] = segments
+	return `/parts/${head}:${rest.join('/')}`
+}
+
+/**
+ * 将 registry 相对 path 解析为前端 URL。
+ * @param {string} partpath - 部件路径。
+ * @param {string} relativePath - part 相对路径。
+ * @returns {string} 完整前端 URL。
+ */
+export function resolveRegistryPathToUrl(partpath, relativePath) {
+	const normalized = relativePath.replace(/^\/+/, '')
+	return `${partpathToUrlPrefix(partpath)}/${normalized}`
+}
+
+/**
+ * 将 registry 相对 path 解析为文件系统绝对路径。
+ * @param {string} username - 用户名。
+ * @param {string} partpath - 部件路径。
+ * @param {string} relativePath - part 相对路径。
+ * @returns {string} 文件系统绝对路径。
+ */
+export function resolveRegistryPathToFs(username, partpath, relativePath) {
+	return path.join(GetPartPath(username, partpath), relativePath.replace(/^\/+/, ''))
+}
+
+/**
+ * 对原始条目按 partpath+id 去重（后者覆盖）并按 level 升序排序。
+ * 不同 part 可共用相同 id（如各 shell 的 home_registry 条目均为 `function_buttons`）。
+ * @param {Array<{ id: string, level: number, path: string, partpath: string }>} rawEntries - 原始条目列表。
+ * @returns {Array<{ id: string, level: number, path: string, partpath: string }>} 去重排序后的条目。
+ */
+export function dedupeAndSortRegistryEntries(rawEntries) {
+	/** @type {Map<string, { id: string, level: number, path: string, partpath: string }>} */
+	const byKey = new Map()
+	for (const entry of rawEntries)
+		byKey.set(`${entry.partpath}\0${entry.id}`, entry)
+	return [...byKey.values()].sort((a, b) => a.level - b.level)
+}
+
+/**
+ * 获取指定 name 的 registry 条目（已去重排序）。
+ * @param {string} username - 用户名。
+ * @param {string} name - registry 名称。
+ * @param {{ nocache?: boolean, resolve?: 'fs' | 'url' | 'raw' }} [options] - 可选项。
+ * @returns {RegistryEntry[]} registry 条目列表。
+ */
+export function getRegistry(username, name, { nocache = false, resolve = 'raw' } = {}) {
+	const all = getPartRegistriesRaw(username, { nocache })
+	const raw = dedupeAndSortRegistryEntries(all[name] ?? [])
+
+	if (resolve === 'raw') return raw
+
+	if (resolve === 'url')
+		return raw.map(({ path: entryPath, partpath, ...entry }) => ({
+			...entry,
+			path: resolveRegistryPathToUrl(partpath, entryPath),
+		}))
+
+	return raw.map(({ path: entryPath, partpath, ...entry }) => ({
+		...entry,
+		path: resolveRegistryPathToFs(username, partpath, entryPath),
+		partpath,
+	}))
+}
+
+/**
+ * 列出当前用户聚合到的全部 registry 名称。
+ * @param {string} username - 用户名。
+ * @param {{ nocache?: boolean }} [options] - 可选项。
+ * @returns {string[]} registry 名称列表。
+ */
+export function listRegistryNames(username, { nocache = false } = {}) {
+	const all = getPartRegistriesRaw(username, { nocache })
+	return Object.keys(all).sort()
+}
+
+/**
+ * 从 registry 条目加载 JSON 数据（按 registry name 取对应字段）。
+ * @param {string} username - 用户名。
+ * @param {string} registryName - registry 名称。
+ * @param {{ nocache?: boolean }} [options] - 可选项。
+ * @returns {Promise<Array<{ entry: RegistryEntry & { partpath?: string }, data: unknown }>>} 已加载的 JSON 条目。
+ */
+export async function loadRegistryJsonEntries(username, registryName, { nocache = false } = {}) {
+	const entries = getRegistry(username, registryName, { nocache, resolve: 'fs' })
+	/** @type {Array<{ entry: RegistryEntry & { partpath?: string }, data: unknown }>} */
+	const results = []
+	for (const entry of entries) {
+		const raw = loadJsonFile(entry.path)
+		results.push({ entry, data: raw[entry.dataField || registryName] ?? raw })
+	}
+	return results
+}

--- a/src/server/test/pure/registries.test.mjs
+++ b/src/server/test/pure/registries.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * 泛型 registries 聚合单元测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import {
+	dedupeAndSortRegistryEntries,
+	partpathToUrlPrefix,
+	resolveRegistryPathToUrl,
+} from '../../registries.mjs'
+
+Deno.test('partpathToUrlPrefix maps shells/chat', () => {
+	assertEquals(partpathToUrlPrefix('shells/chat'), '/parts/shells:chat')
+})
+
+Deno.test('resolveRegistryPathToUrl joins part-relative path', () => {
+	assertEquals(
+		resolveRegistryPathToUrl('shells/chat', 'markdown_extensions/index.mjs'),
+		'/parts/shells:chat/markdown_extensions/index.mjs',
+	)
+})
+
+Deno.test('dedupeAndSortRegistryEntries keeps later id and sorts by level', () => {
+	const sorted = dedupeAndSortRegistryEntries([
+		{ id: 'chatEmoji', level: 2, path: 'old.mjs', partpath: 'shells/chat' },
+		{ id: 'other', level: 0, path: 'other.mjs', partpath: 'shells/social' },
+		{ id: 'chatEmoji', level: 1, path: 'providers/emoji.mjs', partpath: 'shells/chat' },
+	])
+	assertEquals(sorted.length, 2)
+	assertEquals(sorted[0].id, 'other')
+	assertEquals(sorted[1].path, 'providers/emoji.mjs')
+})
+
+Deno.test('dedupeAndSortRegistryEntries keeps same id from different parts', () => {
+	const sorted = dedupeAndSortRegistryEntries([
+		{ id: 'function_buttons', level: 0, path: 'home_registry.json', partpath: 'shells/chat' },
+		{ id: 'function_buttons', level: 0, path: 'home_registry.json', partpath: 'shells/access' },
+	])
+	assertEquals(sorted.length, 2)
+})

--- a/src/server/web_server/endpoints.mjs
+++ b/src/server/web_server/endpoints.mjs
@@ -28,6 +28,7 @@ import {
 } from '../parts_loader.mjs'
 import { skip_report, config, save_config } from '../server.mjs'
 import { webauthnLoginBegin, webauthnLoginComplete } from '../auth/webauthn.mjs'
+import { getRegistry } from '../registries.mjs'
 
 import { renderDirectoryListingHtml } from './directory_listing.mjs'
 import { register as registerNotifier } from './event_dispatcher.mjs'
@@ -279,6 +280,14 @@ export function registerEndpoints(router) {
 	router.get('/api/whoami', authenticate, async (req, res) => {
 		const { username } = getUserByReq(req)
 		res.status(200).json({ username })
+	})
+
+	router.get('/api/registries/:name', authenticate, async (req, res) => {
+		const { username } = getUserByReq(req)
+		const nocache = req.query.nocache === 'true' || req.query.nocache === '1'
+		const name = String(req.params.name ?? '').trim()
+		if (!name) return res.status(400).json({ error: 'registry name required' })
+		res.status(200).json(getRegistry(username, name, { nocache, resolve: 'url' }))
 	})
 
 	router.post('/api/authenticate', authenticate, (req, res) => {


### PR DESCRIPTION
## Summary
- Add `src/server/registries.mjs` + pure unit tests.
- Extend `parts_loader` to scan `fount.json` `registries` (uses `fount-p2p` composite_key already in deps).
- Switch `i18n/index` part locales from `parts_locale_*` cache to `getRegistry(..., 'locales')`.
- Add authenticated `GET /api/registries/:name`.

Part of [together → master plan](docs/design/together-to-master-pr-plan.md). Unblocks full B registries path; **G** still waits on **H** entity store.

## Test plan
- [x] `deno test -A --config deno.json src/server/test/pure/registries.test.mjs`
- [ ] `fount test --no-parallel server` still green
- [ ] `GET /api/registries/home` (or any registered name) with apikey returns sorted URL entries
- [ ] Server boots; existing part load / home still works without registry-consuming shells