### PR TITLE
together/I: social shell

### DIFF
--- a/docs/design/together-to-master-pr-plan.md
+++ b/docs/design/together-to-master-pr-plan.md
@@ -102,6 +102,6 @@ flowchart TB
 | 2 | C2 | **已合并** | https://github.com/steve02081504/fount/pull/239 |
 | 2 | H | **已合并** | https://github.com/steve02081504/fount/pull/240 |
 | 3 | G | **已合并** | https://github.com/steve02081504/fount/pull/241 |
-| 3 | I | 已开 PR | Social |
-| 3 | J | 已开 PR | Cabinet |
+| 3 | I | 已开 PR | https://github.com/steve02081504/fount/pull/243 |
+| 3 | J | 已开 PR | https://github.com/steve02081504/fount/pull/242 |
 | 3+ | K | 待开 | 其它 shells/parts |

--- a/docs/design/together-to-master-pr-plan.md
+++ b/docs/design/together-to-master-pr-plan.md
@@ -101,5 +101,7 @@ flowchart TB
 | 1 | F | **已合并**（含 floatingPanel/catbox 等后续修） | https://github.com/steve02081504/fount/pull/238 |
 | 2 | C2 | **已合并** | https://github.com/steve02081504/fount/pull/239 |
 | 2 | H | **已合并** | https://github.com/steve02081504/fount/pull/240 |
-| 3 | G | 已开 PR | https://github.com/steve02081504/fount/pull/241 |
-| 3+ | I–K | 阻于 H（及 G） | |
+| 3 | G | **已合并** | https://github.com/steve02081504/fount/pull/241 |
+| 3 | I | 已开 PR | Social |
+| 3 | J | 已开 PR | Cabinet |
+| 3+ | K | 待开 | 其它 shells/parts |

--- a/src/decl/socialAPI.ts
+++ b/src/decl/socialAPI.ts
@@ -1,0 +1,526 @@
+/**
+ * Social shell API 类型（与 `shells/social/src` 运行时对齐）。
+ *
+ * 时间线骨架字段见 `DAGEvent`（`p2pAPI.ts`）；群物化状态不在此文件。
+ */
+
+import type { DAGEvent, PersonalListsResponse } from './p2pAPI.ts'
+
+/**
+ * 帖子/相册可见范围。
+ * - `public`：明文，进发现面
+ * - `unlisted`：明文可读，不进探索/热搜/搜索联邦
+ * - `followers`：GSH 加密，关注者可见
+ * - `followers_since`：GSH 加密，关注满 minFollowMs 可见
+ * - `selected`：pkw 按接收者包裹，allow 名单可见
+ * - `private`：pkw 仅作者可见
+ */
+export type SocialVisibility =
+	| 'public'
+	| 'unlisted'
+	| 'followers'
+	| 'followers_since'
+	| 'selected'
+	| 'private'
+
+/** 规范化后的可见性 spec。 */
+export interface SocialVisibilitySpec {
+	visibility: SocialVisibility
+	minFollowMs?: number
+	allow?: string[]
+	except?: string[]
+}
+
+/** 解密失败占位（`buildItem.withDecryptedPostContent`）。 */
+export interface SocialDecryptView {
+	failed: true
+	pendingGeneration?: number
+}
+
+/** 帖文媒体引用（`groupEmoji`、vault 文件等）。 */
+export interface SocialMediaRef {
+	kind?: string
+	groupId?: string
+	emojiId?: string
+	contentHash?: string
+	shareId?: string
+	owner?: string
+	url?: string
+	alt?: string
+	[key: string]: unknown
+}
+
+/** 跨帖引用（回复 / 引用 / 群频道跳转）。 */
+export interface SocialPostRef {
+	entityHash: string
+	postId: string
+}
+
+/**
+ *
+ */
+export interface SocialGroupRef {
+	groupId: string
+	channelId?: string
+}
+
+/** 帖内投票草稿（`lib/poll.mjs::normalizePollDraft`）。 */
+export interface SocialPollDraft {
+	options: string[]
+	multi: boolean
+	deadline: string | null
+}
+
+/** 谁可回复本帖。 */
+export type SocialReplyPolicy = 'everyone' | 'followers_7d' | 'author_follows'
+
+/** 回复展示策略。 */
+export type SocialReplyDisplay = 'all' | 'featured_only'
+
+/** 时间线 `post` 事件的 content 载荷。 */
+export interface SocialPostContent {
+	text?: string
+	mediaRefs?: SocialMediaRef[]
+	replyTo?: SocialPostRef
+	quoteRef?: SocialPostRef
+	groupRef?: SocialGroupRef
+	liveRef?: {
+		entityHash: string
+		liveId: string
+		status?: 'live' | 'ended'
+		startedAt?: number
+		endedAt?: number
+		duration?: number
+		totalViewers?: number
+		totalLikes?: number
+		peakViewers?: number
+	}
+	lang?: string
+	visibility?: SocialVisibility
+	minFollowMs?: number
+	allow?: string[]
+	except?: string[]
+	contentWarning?: string
+	sensitiveMedia?: boolean
+	poll?: SocialPollDraft
+	tags?: string[]
+	replyPolicy?: SocialReplyPolicy
+	replyDisplay?: SocialReplyDisplay
+}
+
+/** `post_edit` 事件 content。 */
+export interface SocialPostEditContent {
+	targetPostId: string
+	text?: string
+	mediaRefs?: SocialMediaRef[]
+	lang?: string
+	contentWarning?: string
+}
+
+/** `post_visibility_set` 事件 content（完整替换原帖 content，含重加密信封）。 */
+export interface SocialPostVisibilitySetContent extends SocialVisibilitySpec {
+	targetPostId: string
+	/** 重加密后的完整 content（明文或 GSH/pkw 信封） */
+	content: SocialPostContent | Record<string, unknown>
+}
+
+/** 相册元数据 content。 */
+export interface SocialAlbumContent extends SocialVisibilitySpec {
+	albumId: string
+	name?: string
+	description?: string
+}
+
+/** 相册成员链接。 */
+export interface SocialAlbumPostLinkContent {
+	albumId: string
+	postId: string
+}
+
+/** Feed 条目上的所属相册摘要（按观看者过滤）。 */
+export interface SocialAlbumRef {
+	albumId: string
+	name: string
+}
+
+/** 探索/资料 meta（`social_meta` 物化字段，camelCase）。 */
+export interface SocialMeta {
+	hideFromDiscovery?: boolean
+	createdAt?: number
+	recoveryPubKeyHex?: string
+	eventRetentionDepth?: number
+	eventRetentionMs?: number
+	compactTriggerEventDepth?: number
+	[key: string]: unknown
+}
+
+/** 互动类事件共有 target 字段。 */
+export interface SocialEngagementTarget {
+	targetEntityHash: string
+	targetPostId: string
+}
+
+/** `poll_vote` 事件 content。 */
+export interface SocialPollVoteContent extends SocialEngagementTarget {
+	choices: number[]
+}
+
+/**
+ *
+ */
+export type SocialLikeContent = SocialEngagementTarget
+
+/**
+ *
+ */
+export interface SocialRepostContent extends SocialEngagementTarget {
+	comment?: string
+}
+
+/**
+ *
+ */
+export interface SocialFollowContent {
+	targetEntityHash: string
+}
+
+/**
+ *
+ */
+export interface SocialBlockContent {
+	targetEntityHash: string
+}
+
+/**
+ *
+ */
+export interface SocialPostDeleteContent {
+	targetPostId: string
+}
+
+/** 时间线事件类型字面量（`SOCIAL_TIMELINE_REDUCERS` 键 + 保留类型）。 */
+export type SocialTimelineEventType =
+	| 'social_meta'
+	| 'state_summary'
+	| 'post'
+	| 'post_edit'
+	| 'post_delete'
+	| 'post_visibility_set'
+	| 'poll_vote'
+	| 'post_note'
+	| 'note_vote'
+	| 'like'
+	| 'unlike'
+	| 'dislike'
+	| 'undislike'
+	| 'tag_name'
+	| 'repost'
+	| 'follow'
+	| 'unfollow'
+	| 'tag_follow'
+	| 'tag_unfollow'
+	| 'reply_feature'
+	| 'reply_unfeature'
+	| 'live_start'
+	| 'live_end'
+	| 'follow_approve'
+	| 'block'
+	| 'unblock'
+	| 'entity_key_rotate'
+	| 'entity_key_revoke'
+	| 'file_share'
+	| 'album_create'
+	| 'album_update'
+	| 'album_delete'
+	| 'album_post_add'
+	| 'album_post_remove'
+
+/** 各事件 content 形状映射。 */
+export interface SocialTimelineEventContentMap {
+	social_meta: Partial<SocialMeta>
+	state_summary: Record<string, unknown>
+	post: SocialPostContent | Record<string, unknown>
+	post_edit: SocialPostEditContent
+	post_delete: SocialPostDeleteContent
+	post_visibility_set: SocialPostVisibilitySetContent
+	poll_vote: SocialPollVoteContent
+	post_note: Record<string, unknown>
+	note_vote: Record<string, unknown>
+	like: SocialLikeContent
+	unlike: SocialLikeContent
+	dislike: SocialLikeContent
+	undislike: SocialLikeContent
+	tag_name: Record<string, unknown>
+	repost: SocialRepostContent
+	follow: SocialFollowContent
+	unfollow: SocialFollowContent
+	tag_follow: { tag: string }
+	tag_unfollow: { tag: string }
+	reply_feature: { targetPostId: string, replierEntityHash: string, replyPostId: string }
+	reply_unfeature: { targetPostId: string, replierEntityHash: string, replyPostId: string }
+	live_start: Record<string, unknown>
+	live_end: { liveId: string }
+	follow_approve: Record<string, unknown>
+	block: SocialBlockContent
+	unblock: SocialBlockContent
+	entity_key_rotate: Record<string, unknown>
+	entity_key_revoke: Record<string, unknown>
+	file_share: Record<string, unknown>
+	album_create: SocialAlbumContent
+	album_update: SocialAlbumContent
+	album_delete: { albumId: string }
+	album_post_add: SocialAlbumPostLinkContent
+	album_post_remove: SocialAlbumPostLinkContent
+}
+
+/** 单条 Social 时间线 DAG 事件（判别联合）。 */
+export type SocialTimelineEvent = {
+	[K in SocialTimelineEventType]: Omit<DAGEvent, 'type' | 'content' | 'charId'> & {
+		type: K
+		content: SocialTimelineEventContentMap[K]
+		charPartName?: string
+	}
+}[SocialTimelineEventType]
+
+/** 物化后的帖子（含 postId 别名）。 */
+export type SocialMaterializedPost = SocialTimelineEvent & { type: 'post', postId: string }
+
+/** Feed / profile 作者摘要（`authorProfileSummary.mjs`）。 */
+export interface SocialAuthorProfile {
+	name?: string
+	avatar?: string | null
+}
+
+/** 单条 feed 条目的互动计数（`createEngagementForPost`）。 */
+export interface SocialFeedEngagement {
+	likeCount: number
+	repostCount: number
+	replyCount: number
+	viewerLiked: boolean
+}
+
+/** Feed 条目公共字段。 */
+export interface SocialFeedItemBase extends SocialFeedEngagement {
+	hlc: { wall: number, logical: number }
+	authorProfile: SocialAuthorProfile | null
+}
+
+/** 原帖 feed 条目。 */
+export interface SocialPostFeedItem extends SocialFeedItemBase {
+	kind: 'post'
+	entityHash: string
+	postId: string
+	post: SocialMaterializedPost & {
+		content: SocialPostContent | null
+		decryptView?: SocialDecryptView
+	}
+	/** 观看者可见的所属相册链接 */
+	albums?: SocialAlbumRef[]
+}
+
+/** 转发 feed 条目（外层 postId 为 repost 事件 id）。 */
+export interface SocialRepostFeedItem extends SocialFeedItemBase {
+	kind: 'repost'
+	entityHash: string
+	postId: string
+	post: SocialMaterializedPost
+	targetEntityHash: string
+	targetPostId: string
+	repostComment: string
+}
+
+/**
+ *
+ */
+export type SocialFeedItem = SocialPostFeedItem | SocialRepostFeedItem
+
+/** `GET /feed` 等分页响应。 */
+export interface SocialFeedPage {
+	items: SocialFeedItem[]
+	nextCursor: string | null
+}
+
+/** 通知类型（`notifications.mjs`）。 */
+export type SocialNotificationType = 'reply' | 'mention' | 'like' | 'repost' | 'follow' | 'care_post' | 'poll_closed'
+
+/** 聚合展示 actor 摘要。 */
+export interface SocialNotificationActor {
+	entityHash: string
+	at: number
+}
+
+/** 通知条目固定 schema（读取层可返回聚合字段）。 */
+export interface SocialNotificationItem {
+	type: SocialNotificationType
+	actorEntityHash: string
+	postId: string | null
+	targetPostId: string | null
+	targetEntityHash?: string | null
+	snippet?: string | null
+	at: number
+	actors?: SocialNotificationActor[]
+	actorCount?: number
+	latestActorEntityHash?: string | null
+	aggregateKey?: string | null
+}
+
+/**
+ *
+ */
+export interface SocialNotificationsPage {
+	notifications: SocialNotificationItem[]
+	nextCursor: string | null
+	unreadCount: number
+	viewerEntityHash: string | null
+}
+
+/** `GET …/profile/personal-lists` 与 chat `/api/parts/shells:chat/personal-lists` 共用。 */
+export type SocialPersonalListsResponse = PersonalListsResponse
+
+/** 关系写操作响应。 */
+export interface SocialFollowResponse {
+	entityHash: string
+	isFollowing: boolean
+}
+
+/**
+ *
+ */
+export interface SocialBlockResponse {
+	entityHash: string
+	blocked: boolean
+}
+
+/**
+ *
+ */
+export interface SocialHideResponse {
+	entityHash: string
+	hidden: boolean
+}
+
+/** 本地收藏夹持久化结构。 */
+export interface SavedPostsStore {
+	folders: Record<string, { name: string, posts: Array<{ entityHash: string, postId: string }> }>
+	unfiled: Array<{ entityHash: string, postId: string }>
+}
+
+/** 发帖草稿 body（与 POST /posts 字段对齐，本机私有）。 */
+export interface SocialComposerDraftBody {
+	text?: string
+	mediaRefs?: SocialMediaRef[]
+	visibility?: SocialVisibility | string
+	allow?: string[]
+	except?: string[]
+	albumIds?: string[]
+	locale?: string
+	contentWarning?: string
+	sensitiveMedia?: boolean
+	quoteRef?: SocialPostRef
+	groupRef?: SocialGroupRef
+	poll?: SocialPollDraft
+	replyPolicy?: SocialReplyPolicy
+	replyDisplay?: SocialReplyDisplay
+	publishAt?: number
+	tags?: string[]
+}
+
+/** 草稿箱单行。 */
+export interface SocialComposerDraft {
+	draftId: string
+	createdAt: number
+	updatedAt: number
+	preview: string
+	body: SocialComposerDraftBody
+}
+
+/** 草稿箱列表响应。 */
+export interface SocialDraftsList {
+	drafts: SocialComposerDraft[]
+}
+
+/** 探索页账号摘要。 */
+export interface SocialDiscoverAccount {
+	entityHash: string
+	name?: string
+	handle?: string
+	bio?: string
+	avatarUrl?: string | null
+}
+
+/** 探索页帖子摘要。 */
+export interface SocialDiscoverPost {
+	entityHash: string
+	postId: string
+	textSnippet?: string
+	mediaThumbs?: SocialMediaRef[]
+	hlc: { wall: number, logical: number }
+}
+
+/** 联邦 RPC：请求/响应 type 分离（`SOCIAL_RPC_*_TYPES`）。 */
+export interface SocialRpcDiscoverRequest {
+	type: 'social_discover_request'
+	n?: number
+	cursor?: string
+}
+
+/**
+ *
+ */
+export interface SocialRpcDiscoverResponse {
+	type: 'social_discover_response'
+	accounts: SocialDiscoverAccount[]
+	nextCursor?: string | null
+}
+
+/**
+ *
+ */
+export interface SocialRpcPostDiscoverRequest {
+	type: 'social_post_discover_request'
+	n?: number
+	mediaOnly?: boolean
+	cursor?: string
+}
+
+/**
+ *
+ */
+export interface SocialRpcPostDiscoverResponse {
+	type: 'social_post_discover_response'
+	posts: SocialDiscoverPost[]
+	nextCursor?: string | null
+}
+
+/** char.interfaces.social — 入站 post 事件（可序列化纯数据）。 */
+export interface SocialMessageEvent {
+	post: object
+	authorEntityHash: string
+	authorDisplayName: string
+	postText: string
+	replyTo?: SocialPostRef
+	mentions: { entityHashes: string[] }
+	viewerEntityHash: string
+	username: string
+	charPartName: string
+	lang: string
+}
+
+/**
+ *
+ */
+export interface SocialFollowEvent {
+	username: string
+	charPartName: string
+	followerEntityHash: string
+	followerUsername: string
+	targetEntityHash: string
+}
+
+/**
+ *
+ */
+export interface SocialCharInterface {
+	OnMessage?: (event: SocialMessageEvent) => Promise<boolean>
+	OnFollow?: (event: SocialFollowEvent) => Promise<void>
+}

--- a/src/public/parts/shells/social/fount.json
+++ b/src/public/parts/shells/social/fount.json
@@ -1,0 +1,41 @@
+{
+	"type": "shells",
+	"dirname": "social",
+	"registries": {
+		"markdown_extensions": [
+			{
+				"id": "socialMarkdown",
+				"level": 0,
+				"path": "markdown_extensions/index.mjs"
+			}
+		],
+		"home_function_buttons": [
+			{
+				"id": "function_buttons",
+				"level": 0,
+				"path": "home_registry.json"
+			}
+		],
+		"home_drag_in_handlers": [
+			{
+				"id": "drag_in_handlers",
+				"level": 0,
+				"path": "home_registry.json"
+			}
+		],
+		"home_drag_out_generators": [
+			{
+				"id": "drag_out_generators",
+				"level": 0,
+				"path": "home_registry.json"
+			}
+		],
+		"home_interfaces": [
+			{
+				"id": "interfaces",
+				"level": 0,
+				"path": "home_registry.json"
+			}
+		]
+	}
+}

--- a/src/public/parts/shells/social/home_registry.json
+++ b/src/public/parts/shells/social/home_registry.json
@@ -1,0 +1,10 @@
+{
+	"home_function_buttons": [
+		{
+			"info": "social.home_function_buttons.main",
+			"level": 2,
+			"url": "/parts/shells:social/",
+			"button": "<img src=\"https://api.iconify.design/mdi/forum-outline.svg\" class=\"text-icon\"/>"
+		}
+	]
+}

--- a/src/public/parts/shells/social/locales.json
+++ b/src/public/parts/shells/social/locales.json
@@ -1,0 +1,32 @@
+{
+	"info": {
+		"en-UK": {
+			"name": "Social",
+			"avatar": "https://api.iconify.design/mdi/account-group-outline.svg",
+			"description": "P2P open social feed, profiles, and file sharing",
+			"description_markdown": "P2P open social feed, profiles, and file sharing.",
+			"version": "0.0.0",
+			"author": "steve02081504",
+			"home_page": "",
+			"tags": [
+				"social",
+				"P2P",
+				"feed"
+			]
+		},
+		"zh-CN": {
+			"name": "社交",
+			"avatar": "https://api.iconify.design/mdi/account-group-outline.svg",
+			"description": "P2P 开放社交动态、资料与文件分享",
+			"description_markdown": "P2P 开放社交动态、资料与文件分享。",
+			"version": "0.0.0",
+			"author": "steve02081504",
+			"home_page": "",
+			"tags": [
+				"社交",
+				"P2P",
+				"动态"
+			]
+		}
+	}
+}

--- a/src/public/parts/shells/social/main.mjs
+++ b/src/public/parts/shells/social/main.mjs
@@ -1,0 +1,170 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import {
+	registerBlockReputationHandler,
+	unregisterBlockReputationHandler,
+	mutateReputation,
+} from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+import {
+	registerShellPartpath,
+	unregisterShellPartpath,
+} from 'npm:@steve02081504/fount-p2p/registries/part_path'
+
+import { getAllUserNames } from '../../../../server/auth/index.mjs'
+import { events } from '../../../../server/events.mjs'
+
+import { handleSocialRpc } from './src/discover/rpc.mjs'
+import { setEndpoints } from './src/endpoints.mjs'
+import {
+	registerFollowingScanProvider,
+	registerOperatorEntityHashProvider,
+	registerReplicaUsernamesProvider,
+	unregisterFollowingScanProvider,
+	unregisterOperatorEntityHashProvider,
+	unregisterReplicaUsernamesProvider,
+} from './src/federation/follower/registry.mjs'
+import { isRemoteTimelinePushAdmitted } from './src/federation/push_admission.mjs'
+import { applyFollowedBlockSignal } from './src/federation/reputation/index.mjs'
+import { registerSocialManifestAcl, unregisterSocialManifestAcl } from './src/manifestAcl.mjs'
+import { registerSocialManifestTransfer, unregisterSocialManifestTransfer } from './src/manifestTransfer.mjs'
+import { commitEntityKeyRevoke, commitEntityKeyRotate } from './src/timeline/entityKey/commit.mjs'
+import { getTimelineMaterialized } from './src/timeline/materialize.mjs'
+import { ingestRemoteTimelineEvent } from './src/timeline/sync.mjs'
+
+const { info } = (await import('./locales.json', { with: { type: 'json' } })).default
+
+/**
+ * @param {{ username: string, entityHash: string, kind: string, rotation: object, revokePayload?: object, recoverySecret?: Uint8Array }} payload 密钥轮换事件
+ * @returns {Promise<void>}
+ */
+async function handleEntityKeyRotated(payload) {
+	const { username, entityHash, kind, rotation, revokePayload, recoverySecret } = payload
+	if (kind === 'rotate')
+		await commitEntityKeyRotate(username, entityHash, rotation)
+	else if (kind === 'revoke')
+		await commitEntityKeyRevoke(username, entityHash, revokePayload, recoverySecret)
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @param {object} data timeline_put 载荷
+ * @returns {Promise<{ ok: boolean }>} ingest 成功
+ */
+async function handleTimelinePut(username, data) {
+	const entityHash = data.timelineEntityHash.toLowerCase()
+	if (!parseEntityHash(entityHash)) throw new Error('invalid_timeline_put')
+	if (!await isRemoteTimelinePushAdmitted(username, entityHash))
+		return { result: { ok: false } }
+	const ok = await ingestRemoteTimelineEvent(username, entityHash, data.event)
+	return { result: { ok } }
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @param {object} data social_rpc 载荷
+ * @param {{ requesterNodeHash?: string | null }} ingress 联邦入站元数据
+ * @returns {Promise<object>} RPC 响应体
+ */
+async function handleSocialRpcInvoke(username, data, ingress) {
+	const { kind, ...rpc } = data
+	const body = await handleSocialRpc(username, rpc, ingress)
+	if (!body) throw new Error('unknown_rpc')
+	return { result: body }
+}
+
+/** @type {Record<string, (username: string, data: object, ingress?: object) => Promise<object>>} */
+const p2pInvokeHandlers = {
+	timeline_put: handleTimelinePut,
+	social_rpc: handleSocialRpcInvoke,
+}
+
+/**
+ * Social shell：账号 = Chat 联邦 P2P 实体（用户 identity 或本机 agent entityHash），无需单独注册。
+ * @type {import('../../../../../src/decl/shellAPI.ts').shellAPI_t}
+ */
+export default {
+	info,
+	/**
+	 * 加载 Social shell 并注册 HTTP/WS 路由。
+	 * @param {object} root0 参数
+	 * @param {import('npm:websocket-express').Router} root0.router Express 路由
+	 * @returns {void}
+	 */
+	Load: async ({ router }) => {
+		registerShellPartpath('social', 'shells/social')
+		registerReplicaUsernamesProvider(getAllUserNames)
+		registerOperatorEntityHashProvider(
+			(await import('../chat/src/entity/identity.mjs')).resolveOperatorEntityHashForUser,
+		)
+		registerFollowingScanProvider(async username => {
+			const { resolveOperatorEntityHashForUser } = await import('../chat/src/entity/identity.mjs')
+			const operator = await resolveOperatorEntityHashForUser(username)
+			if (!operator) return []
+			const view = await getTimelineMaterialized(username, operator)
+			return view.following
+		})
+		registerBlockReputationHandler(options => applyFollowedBlockSignal(options, mutateReputation))
+		events.on('entity-key-rotated', handleEntityKeyRotated)
+		registerSocialManifestAcl()
+		registerSocialManifestTransfer()
+		const { registerSocialQueryKinds } = await import('./src/federation/partQuery.mjs')
+		const { TRENDING_HASHTAGS_KIND, localTrendingHashtagsHandler } = await import('./src/trending/network.mjs')
+		const { POST_SEARCH_KIND, localPostSearchHandler } = await import('./src/search/network.mjs')
+		const { POST_DISCOVER_KIND, localPostDiscoverHandler } = await import('./src/discover/postDiscover.mjs')
+		const { LIVE_FEED_KIND, localLiveFeedHandler } = await import('./src/live/network.mjs')
+		registerSocialQueryKinds({
+			[TRENDING_HASHTAGS_KIND]: localTrendingHashtagsHandler,
+			[POST_SEARCH_KIND]: localPostSearchHandler,
+			[POST_DISCOVER_KIND]: localPostDiscoverHandler,
+			[LIVE_FEED_KIND]: localLiveFeedHandler,
+		})
+		setEndpoints(router)
+		const { bootstrapPollDeadlineWatchers } = await import('./src/lib/pollDeadlineWatcher.mjs')
+		void bootstrapPollDeadlineWatchers()
+		const { bootstrapScheduledPostWatchers } = await import('./src/lib/scheduledPostWatcher.mjs')
+		void bootstrapScheduledPostWatchers()
+	},
+	/** 卸载 Social shell。 */
+	Unload: async () => {
+		const { unregisterSocialQueryKinds } = await import('./src/federation/partQuery.mjs')
+		unregisterSocialQueryKinds()
+		unregisterShellPartpath('social')
+		unregisterOperatorEntityHashProvider()
+		unregisterReplicaUsernamesProvider()
+		unregisterFollowingScanProvider()
+		unregisterBlockReputationHandler()
+		events.off('entity-key-rotated', handleEntityKeyRotated)
+		unregisterSocialManifestAcl()
+		unregisterSocialManifestTransfer()
+	},
+	interfaces: {
+		web: {},
+		invokes: {
+			/**
+			 * CLI / protocol run：打开 Social 帖子或资料页。
+			 * @param {string} _user 用户名
+			 * @param {string[]} args 如 `['post', entityHash, postId, sharerNodeHash?]`
+			 * @returns {Promise<{ redirect: string }>} 浏览器跳转目标
+			 */
+			ArgumentsHandler: async (_user, args) => {
+				const [subcommand, entityHash, postId, sharerNodeHash] = args
+				const { formatSocialPostHref, formatSocialProfileHref } = await import('./public/shared/runUri.mjs')
+				if (subcommand === 'post' && entityHash && postId)
+					return { redirect: formatSocialPostHref(entityHash, postId, sharerNodeHash) }
+				if (subcommand === 'profile' && entityHash)
+					return { redirect: formatSocialProfileHref(entityHash) }
+				return { redirect: '/parts/shells:social/' }
+			},
+			/**
+			 * P2P part_invoke 入站：timeline put 与 social RPC。
+			 * @param {string} username replica 登录名
+			 * @param {object} data 入站 invoke 体
+			 * @param {{ requesterNodeHash?: string | null }} [ingress] 联邦入站元数据
+			 * @returns {Promise<object | null>} 响应体
+			 */
+			P2PInvokeHandler: async (username, data, ingress = {}) => {
+				const handler = p2pInvokeHandlers[data.kind]
+				return handler ? handler(username, data, ingress) : null
+			},
+		},
+	},
+}

--- a/src/public/parts/shells/social/public/AGENTS.md
+++ b/src/public/parts/shells/social/public/AGENTS.md
@@ -1,0 +1,54 @@
+---
+description: Social Shell frontend (follow/block, federated notifications, timeline UI)
+globs: src/public/parts/shells/social/**, src/decl/socialAPI.ts
+alwaysApply: false
+---
+
+# Social Shell Frontend Guide
+
+Deeper UI (video/live, body fold, feed replay): [ui-details.md](ui-details.md).
+Timeline commit / OnMessage test traps: [test domain-harness](../../../../../../src/scripts/test/docs/domain-harness.md).
+
+## Trust & backend surface
+
+- **Local trust**: Social UI, `/api/parts/shells:social/...`, local timeline append. **Untrusted**: `part_timeline_put`, `part_invoke` — ingress `timeline/sync.mjs`, `discover/rpc.mjs`; outbound filter `timeline/federationExport.mjs`.
+- **Write auth** (`federation/write_auth.mjs`): key history chain; genesis via recovery-signed `social_meta` / gen0 rotate / EVFS `profile.json` attestation.
+- **Push admission**: `part_timeline_put` **and** `social_post_notify` accept follows-union ∪ shared group members; pull already follow-filters. Denylist/reputation still apply.
+- **Identity**: HTTP always operator via `SocialClient`. Agents: in-process `getSocialClient(username, agentEntityHash)`. No webapi identity switch.
+- **Personal block/hide**: public block → `personal_block.json` + reputation; private hide → `personal_hide.json`. Group kick/ban = node `denylist.json` (separate). Chat personal-lists HTTP: `GET …/personal-lists`.
+- **Visibility**: `socialMeta.hideFromDiscovery` ≠ post `content.visibility`. Tiers: `public` / `unlisted` / `followers`+`followers_since` / `selected`+`private` / optional `except`. Feed decrypt failure: `post.decryptView.failed`. `contentWarning` collapses body+media+poll; `sensitiveMedia` blurs media only.
+- **mediaRefs.url**: same scheme whitelist as Markdown untrusted sanitize (`isSafeHtmlUrl`). EVFS/file GET: `applySafeContentHeaders` (`nosniff`; only image/audio/video may inline).
+- **New timeline event types**: register in both `SOCIAL_TIMELINE_REDUCERS` and `SOCIAL_TIMELINE_EVENT_TYPES` (`federation/namespace.mjs`).
+- **part_query**: register/unregister in Load/Unload (`federation/partQuery.mjs`); handlers in `trending|search|discover|live/network.mjs`.
+- **Cross-shell chat HTTP**: viewer / personal-lists / entities/search / translation-prefs via `/api/parts/shells:chat/…`. Live nodes need `loadParts: ['shells/social', 'shells/chat']`.
+- **Share URL**: chat `wrapProtocolHttpsUrl`. `public/shared/runUri.mjs` must stay Deno-pure-importable (no `/parts/` URL imports).
+- **Download HTML**: post more menu → `exportHtml.mjs` → shared `markdown/standaloneDocument.mjs` (full offline document, including mediaRefs data URLs); same source as Chat message export.
+- Types: `src/decl/socialAPI.ts`; overview: `public/llms.txt`.
+
+## UI conventions
+
+- CSS: page-local, no `social-` prefix. Icons `.icon` + `.icon-*`. Ready-gate: `SOCIAL_GATE` / `fount:social-*`.
+- Prefer `data-i18n` / `setElementI18n`; placeholders must be object keys with `placeholder` (do not use `fooPlaceholder` key names). Templates: `${...}` only (no Mustache `{{...}}`). Prefer `renderTemplate` / `mountTemplate`.
+- Empty states: `lib/emptyState.mjs` + `templates/empty_state.html`. Heart anim: `lib/heartAnim.mjs` `playHeartAnim`.
+- HTTP: `endpoints/shared.mjs` `socialJson(handler)`; per-post JSON: `federation/postScopedJsonStore.mjs`.
+- Hash routing: `switchView` → `#feed`/`#explore`/…/`#drafts`/`#settings`; detail `#post;<entityHash>;<postId>`; search `#search;q` / `#search:q` / `?q=` → `#searchView`.
+- **`activateView(name)`** → `#${name}View` — `data-view` and section id must share the stem (`videos` → `#videosView`).
+- Avatars/names/@id: chat `entityAvatar.mjs` / `resolveDisplayName` / `formatEntityAtId` (`entityHandle`). Profile page: `rememberEntityHandle` before rendering posts. Hover: `lib/profileHover.mjs` → chat hover card.
+- Bio/post Markdown: chat `shared/trustedMarkdown.mjs`. Trusted: self / local-char / declared master / trust list. Remote self-declared `ownerEntityHash` does not elevate.
+- Browser imports of chat: absolute `/parts/shells:chat/...` URLs. Modules used by Deno pure tests must not contain `/parts/` imports.
+- Preference UI: `#settings` (taste is not a top-level nav entry).
+
+## Identity / private state
+
+- Axioms: [human-agent-operational-parity-review.md](../../../../../../docs/review/human-agent-operational-parity-review.md).
+- Edit/delete UI when `ownerEntityHash === viewer`. Viewer: `viewerEntityHash()` / `state.viewerEntityHash`.
+- Saved posts / drafts: per-entity JSON under `shells/social/entities/{entityHash}/`; HTTP fixed to operator; agents via `client.saved.*` / `client.drafts.*`. Missing file → **fresh** empty structure (never shared `DEFAULT` shallow copy).
+- Entity search: chat `GET …/entities/search` / `SocialClient.searchEntities`.
+
+## Agent integration
+
+New posts → `dispatchSocialMessage` → local agents `interfaces.social.OnMessage`; without it, @mention defaults to chat `GetReply` via `replyViaChat`. **Hard rule**: `User*` = operator, `Char*` = agent, `ReplyTo*` = post author — never put the post author in `User*`. Operator care → `care_post` inbox. Cross-node @ of non-local: `social_post_notify` RPC. Regression: `social_on_message` ("stranger author must not become User*").
+
+## Notifications
+
+Per-recipient `shells/social/inbox/{entityHash}/`. `GET /notifications` aggregates like/repost/follow; WS `type: 'notification'`. API operator-only.

--- a/src/public/parts/shells/social/public/index.html
+++ b/src/public/parts/shells/social/public/index.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title data-i18n="social.title"></title>
+	<link rel="icon" href="/favicon.ico" />
+	<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+	<script blocking="render" type="module" src="/preload.mjs"></script>
+	<link href="https://cdn.jsdelivr.net/npm/daisyui/daisyui.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />
+	<link href="/base.css" rel="stylesheet" type="text/css" crossorigin="anonymous" />
+	<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4" crossorigin="anonymous"></script>
+	<script type="module" src="/base.mjs"></script>
+	<link rel="stylesheet" href="/parts/shells:social/styles.css" />
+</head>
+
+<body class="bg-base-100 text-base-content min-h-screen">
+	<div id="shell" class="shell">
+		<aside class="side-nav" aria-label="Social navigation">
+			<div class="side-nav-brand">
+				<h1 class="brand-title" data-i18n="social.title"></h1>
+			</div>
+			<nav class="side-nav-links">
+				<button type="button" data-view="feed" class="nav-btn btn btn-ghost justify-start active">
+					<span class="icon icon-home" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.feed"></span>
+				</button>
+				<button type="button" data-view="explore" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-explore" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.explore"></span>
+				</button>
+				<button type="button" data-view="notifications" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-bell" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.notifications"></span>
+					<span id="notificationsBadge" class="nav-badge badge badge-primary badge-sm hidden"></span>
+				</button>
+				<button type="button" data-view="saved" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-bookmark" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.saved"></span>
+				</button>
+				<button type="button" data-view="drafts" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-draft" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.drafts"></span>
+				</button>
+				<button type="button" data-view="profile" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-user" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.profile"></span>
+				</button>
+				<button type="button" data-view="videos" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-video" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.videos"></span>
+				</button>
+				<button type="button" data-view="live" class="nav-btn btn btn-ghost justify-start">
+					<span class="icon icon-live" aria-hidden="true"></span>
+					<span class="nav-label" data-i18n="social.nav.live"></span>
+				</button>
+			</nav>
+			<button type="button" id="composeNavButton" class="compose-nav-btn btn btn-primary">
+				<span class="nav-label" data-i18n="social.composer.publish"></span>
+				<span class="icon icon-compose compose-nav-icon" aria-hidden="true"></span>
+			</button>
+		</aside>
+
+		<main class="timeline-col">
+			<section id="composer" class="composer">
+				<div class="composer-inner">
+					<div id="viewerComposerAvatar" class="composer-avatar-slot" aria-hidden="true"></div>
+					<div class="composer-body">
+						<div id="quotePreview" class="quote-preview hidden"></div>
+						<div id="groupRefPreview" class="group-ref-preview hidden"></div>
+						<textarea id="postText" rows="3" data-i18n="social.composer" placeholder=""></textarea>
+						<input id="postContentWarning" type="text" class="input input-bordered input-sm composer-cw hidden" maxlength="200" data-i18n="social.composer.contentWarning" placeholder="" />
+						<div id="pollComposerPanel" class="composer-panel poll-composer hidden">
+							<textarea id="pollComposerOptions" rows="3" class="textarea textarea-bordered textarea-sm poll-composer-options" data-i18n="social.poll.options" placeholder=""></textarea>
+							<div class="poll-composer-row">
+								<label class="composer-check">
+									<input id="pollComposerMulti" type="checkbox" class="checkbox checkbox-sm" />
+									<span data-i18n="social.poll.multi"></span>
+								</label>
+								<input id="pollComposerDeadline" type="datetime-local" class="input input-bordered input-sm" />
+								<button type="button" id="pollComposerApply" class="btn btn-primary btn-xs" data-i18n="social.poll.apply"></button>
+							</div>
+						</div>
+						<div id="mediaPreview" class="media-preview hidden"></div>
+						<div id="composerAdvancedPanel" class="composer-panel composer-advanced hidden">
+							<label class="composer-field hidden" data-visibility-field>
+								<span class="composer-field-label" data-i18n="social.visibility.allowLabel"></span>
+								<input data-visibility-allow type="text" class="input input-bordered input-sm" data-i18n="social.visibility.allow" placeholder="" />
+							</label>
+							<label class="composer-field" data-visibility-field>
+								<span class="composer-field-label" data-i18n="social.visibility.exceptLabel"></span>
+								<input data-visibility-except type="text" class="input input-bordered input-sm" data-i18n="social.visibility.except" placeholder="" />
+							</label>
+							<label class="composer-field">
+								<span class="composer-field-label" data-i18n="social.composer.replyPolicyLabel"></span>
+								<select id="postReplyPolicy" class="select select-bordered select-sm">
+									<option value="everyone" data-i18n="social.composer.replyPolicyEveryone"></option>
+									<option value="followers_7d" data-i18n="social.composer.replyPolicyFollowers7d"></option>
+									<option value="author_follows" data-i18n="social.composer.replyPolicyAuthorFollows"></option>
+								</select>
+							</label>
+							<label class="composer-field">
+								<span class="composer-field-label" data-i18n="social.composer.replyDisplayLabel"></span>
+								<select id="postReplyDisplay" class="select select-bordered select-sm">
+									<option value="all" data-i18n="social.composer.replyDisplayAll"></option>
+									<option value="featured_only" data-i18n="social.composer.replyDisplayFeaturedOnly"></option>
+								</select>
+							</label>
+							<label class="composer-field">
+								<span class="composer-field-label" data-i18n="social.composer.scheduleLabel"></span>
+								<input id="postPublishAt" type="datetime-local" class="input input-bordered input-sm" />
+							</label>
+							<label id="linkGroupField" class="composer-field hidden">
+								<span class="composer-field-label" data-i18n="social.groupRef.linking"></span>
+								<select id="linkGroupSelect" class="select select-bordered select-sm"></select>
+							</label>
+							<label id="postAlbumField" class="composer-field hidden">
+								<span class="composer-field-label" data-i18n="social.albums.pickerLabel"></span>
+								<select id="postAlbumSelect" class="select select-bordered select-sm" multiple size="3"></select>
+							</label>
+							<label class="composer-check composer-advanced-full">
+								<input id="postSensitiveMedia" type="checkbox" class="checkbox checkbox-sm" />
+								<span data-i18n="social.composer.sensitiveMedia"></span>
+							</label>
+						</div>
+						<div class="composer-toolbar">
+							<div class="composer-tools">
+								<button id="emojiPickButton" type="button" class="composer-tool-btn btn btn-ghost btn-sm btn-circle" data-i18n="social.composer.emojiButton">
+									<span class="icon icon-emoji" aria-hidden="true"></span>
+								</button>
+								<label class="composer-tool-btn btn btn-ghost btn-sm btn-circle media-upload-btn" data-i18n="social.composer.mediaButton">
+									<span class="icon icon-media" aria-hidden="true"></span>
+									<input id="mediaInput" type="file" accept="image/*,video/*" multiple hidden />
+								</label>
+								<button id="pollComposerToggle" type="button" class="composer-tool-btn btn btn-ghost btn-sm btn-circle" data-i18n="social.composer.pollButton">
+									<span class="icon icon-vote" aria-hidden="true"></span>
+								</button>
+								<button id="composerCwToggle" type="button" class="composer-tool-btn btn btn-ghost btn-sm btn-circle" data-i18n="social.composer.cwToggle">
+									<span class="icon icon-content-warning" aria-hidden="true"></span>
+								</button>
+								<select id="postVisibility" data-visibility-select class="select select-bordered select-sm composer-select composer-visibility">
+									<option value="public" data-i18n="social.visibility.public"></option>
+									<option value="unlisted" data-i18n="social.visibility.unlisted"></option>
+									<option value="followers" data-i18n="social.visibility.followers"></option>
+									<option value="followers_7d" data-i18n="social.visibility.followers7d"></option>
+									<option value="followers_30d" data-i18n="social.visibility.followers30d"></option>
+									<option value="selected" data-i18n="social.visibility.selected"></option>
+									<option value="private" data-i18n="social.visibility.private"></option>
+								</select>
+								<button id="composerAdvancedToggle" type="button" class="composer-tool-btn btn btn-ghost btn-sm btn-circle" data-i18n="social.composer.advancedToggle">
+									<span class="icon icon-options" aria-hidden="true"></span>
+								</button>
+								<input id="postLocale" type="hidden" value="zh-CN" />
+							</div>
+							<button id="saveDraftButton" type="button" class="composer-draft-btn btn btn-ghost btn-sm" data-i18n="social.composer.saveDraft"></button>
+							<button id="postButton" type="button" class="composer-post-btn btn btn-primary btn-sm" data-i18n="social.composer.publish"></button>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section id="feedView" class="view">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.nav.feed"></h2>
+					<div class="feed-ranking-tabs" role="tablist">
+						<button type="button" class="btn btn-ghost btn-xs active" data-feed-ranking="latest" data-i18n="social.feed.tabLatest"></button>
+						<button type="button" class="btn btn-ghost btn-xs" data-feed-ranking="for_you" data-i18n="social.feed.tabForYou"></button>
+					</div>
+					<button type="button" id="feedSearchOpenButton" class="view-header-btn btn btn-ghost btn-sm btn-circle mobile-only-btn" data-i18n="social.search.open">
+						<span class="icon icon-search" aria-hidden="true"></span>
+					</button>
+					<button type="button" id="feedRefreshButton" class="view-header-btn btn btn-ghost btn-sm btn-circle tooltip" data-tip="">
+						<span class="icon icon-refresh" aria-hidden="true"></span>
+					</button>
+				</header>
+				<div id="feedList" class="feed-list"></div>
+			</section>
+
+			<section id="exploreView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.nav.explore"></h2>
+				</header>
+				<div class="explore-shortcuts">
+					<button type="button" class="btn btn-ghost btn-sm" data-view="videos" data-i18n="social.nav.videos">
+						<span class="icon icon-video" aria-hidden="true"></span>
+						<span data-i18n="social.nav.videos"></span>
+					</button>
+					<button type="button" class="btn btn-ghost btn-sm" data-view="live" data-i18n="social.nav.live">
+						<span class="icon icon-live" aria-hidden="true"></span>
+						<span data-i18n="social.nav.live"></span>
+					</button>
+					<button type="button" class="btn btn-ghost btn-sm" data-view="drafts" data-i18n="social.nav.drafts">
+						<span class="icon icon-draft" aria-hidden="true"></span>
+						<span data-i18n="social.nav.drafts"></span>
+					</button>
+				</div>
+				<aside id="exploreTrending" class="feed-trending card bg-base-200 shadow-sm explore-mobile-aside"></aside>
+				<div id="exploreSuggested" class="aside-suggested card bg-base-200 shadow-sm explore-mobile-aside hidden">
+					<h3 class="aside-card-title" data-i18n="social.aside.suggested"></h3>
+					<div id="exploreSuggestedList" class="aside-suggested-list"></div>
+				</div>
+				<section class="explore-section" aria-labelledby="exploreAccountsTitle">
+					<div class="explore-section-header">
+						<h3 id="exploreAccountsTitle" class="section-title" data-i18n="social.explore.accounts"></h3>
+					</div>
+					<div id="exploreAccountList" class="explore-account-list"></div>
+				</section>
+				<section class="explore-section" aria-labelledby="explorePostsTitle">
+					<div class="explore-section-header">
+						<h3 id="explorePostsTitle" class="section-title" data-i18n="social.explore.posts"></h3>
+						<label class="explore-media-toggle">
+							<input type="checkbox" id="exploreMediaOnly" />
+							<span class="icon icon-media" aria-hidden="true"></span>
+							<span data-i18n="social.explore.mediaOnly"></span>
+						</label>
+					</div>
+					<div id="explorePostList" class="explore-post-list"></div>
+				</section>
+			</section>
+
+			<section id="notificationsView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.nav.notifications"></h2>
+					<div class="notifications-toolbar hidden" id="notificationsToolbar">
+						<button type="button" id="notificationsMarkAllButton" class="view-header-text-btn btn btn-ghost btn-sm" data-i18n="social.notifications.markAllRead"></button>
+					</div>
+				</header>
+				<div class="inbox-filter-tabs" role="tablist" data-i18n="social.inbox.filtersLabel">
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs active" data-notif-filter="all" data-i18n="social.inbox.tabs.all"></button>
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs" data-notif-filter="mention" data-i18n="social.inbox.tabs.mention"></button>
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs" data-notif-filter="reply" data-i18n="social.inbox.tabs.reply"></button>
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs" data-notif-filter="like" data-i18n="social.inbox.tabs.like"></button>
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs" data-notif-filter="follow" data-i18n="social.inbox.tabs.follow"></button>
+					<button type="button" class="inbox-filter-tab btn btn-ghost btn-xs" data-notif-filter="repost" data-i18n="social.inbox.tabs.repost"></button>
+				</div>
+			</section>
+
+			<section id="savedView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.nav.saved"></h2>
+					<button type="button" id="createFolderButton" class="view-header-btn" data-i18n="social.saved.createFolder">
+						<span class="icon icon-folder-plus" aria-hidden="true"></span>
+					</button>
+				</header>
+				<div id="savedPanel" class="saved-panel"></div>
+			</section>
+
+			<section id="draftsView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.nav.drafts"></h2>
+				</header>
+				<div id="draftsPanel" class="drafts-panel"></div>
+			</section>
+
+			<section id="settingsView" class="view hidden">
+				<header class="view-header">
+					<button type="button" class="view-header-btn btn btn-ghost btn-sm btn-circle" data-view="profile" data-i18n="social.settings.back">
+						<span class="icon icon-home" aria-hidden="true"></span>
+					</button>
+					<h2 class="view-title" data-i18n="social.settings.title"></h2>
+				</header>
+				<div id="settingsPanel" class="settings-panel"></div>
+			</section>
+
+			<section id="profileView" class="view hidden"></section>
+
+			<section id="searchView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.search.viewTitle"></h2>
+				</header>
+				<div class="search-view-filters">
+					<div class="feed-search-wrap">
+						<span class="icon icon-search search-icon" aria-hidden="true"></span>
+						<input type="search" id="searchViewInput" class="feed-search-input input input-bordered input-sm w-full" autocomplete="off" data-i18n="social.search" placeholder="" />
+					</div>
+					<div class="search-filters">
+						<input type="text" id="searchViewAuthor" class="input input-bordered input-sm" data-i18n="social.search.filterAuthor" placeholder="" />
+						<select id="searchViewMedia" class="select select-bordered select-sm">
+							<option value="" data-i18n="social.search.filterMediaAll"></option>
+							<option value="image" data-i18n="social.search.filterMediaImage"></option>
+							<option value="video" data-i18n="social.search.filterMediaVideo"></option>
+						</select>
+						<input type="text" id="searchViewTag" class="input input-bordered input-sm" data-i18n="social.search.filterTag" placeholder="" />
+						<select id="searchViewSort" class="select select-bordered select-sm">
+							<option value="recent" data-i18n="social.search.sortRecent"></option>
+							<option value="popular" data-i18n="social.search.sortPopular"></option>
+						</select>
+						<select id="searchViewScope" class="select select-bordered select-sm">
+							<option value="local" data-i18n="social.search.scopeLocal"></option>
+							<option value="nearby" data-i18n="social.search.scopeNearby"></option>
+						</select>
+						<button type="button" id="searchViewButton" class="btn btn-primary btn-sm" data-i18n="social.search.submit"></button>
+					</div>
+				</div>
+				<div id="searchViewResults" class="feed-list"></div>
+			</section>
+
+			<section id="topicView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title topic-view-title">#</h2>
+					<button type="button" id="topicFollowButton" class="btn btn-primary btn-sm" data-i18n="social.topic.follow"></button>
+				</header>
+				<div id="topicPostList" class="feed-list"></div>
+			</section>
+
+			<section id="postDetailView" class="view hidden"></section>
+
+			<section id="liveBroadcastView" class="view hidden">
+				<header class="view-header">
+					<h2 class="view-title" data-i18n="social.live.broadcast.title"></h2>
+				</header>
+				<div class="live-broadcast-panel" id="liveBroadcastPanel">
+					<input id="liveTitleInput" type="text" class="input input-bordered w-full" maxlength="120" data-i18n="social.live.broadcast.titleInput" />
+					<select id="liveMediaMode" class="select select-bordered w-full">
+						<option value="av" data-i18n="social.live.broadcast.mediaAv"></option>
+						<option value="audio" data-i18n="social.live.broadcast.mediaAudio"></option>
+						<option value="video" data-i18n="social.live.broadcast.mediaVideo"></option>
+						<option value="whip" data-i18n="social.live.broadcast.mediaWhip"></option>
+					</select>
+					<div class="live-broadcast-preview">
+						<canvas id="liveBroadcastCanvas" class="live-broadcast-canvas" width="640" height="480"></canvas>
+						<div id="liveBroadcastVoiceRing" class="live-voice-ring-host hidden"></div>
+					</div>
+					<div id="liveWhipPanel" class="live-whip-panel hidden">
+						<label class="label"><span class="label-text" data-i18n="social.live.broadcast.whipUrl"></span></label>
+						<input id="liveWhipUrl" type="text" class="input input-bordered input-sm font-mono w-full" readonly />
+						<label class="label"><span class="label-text" data-i18n="social.live.broadcast.whipToken"></span></label>
+						<input id="liveWhipToken" type="text" class="input input-bordered input-sm font-mono w-full" readonly />
+					</div>
+					<button type="button" id="liveStartButton" class="btn btn-error" data-i18n="social.live.broadcast.start"></button>
+					<button type="button" id="liveStopButton" class="btn btn-ghost hidden" data-i18n="social.live.broadcast.stop"></button>
+					<div class="live-link-row hidden" id="liveLinkRow">
+						<input id="liveLinkPeerInput" type="text" class="input input-bordered input-sm flex-1" data-i18n="social.live.link.peer" placeholder="" />
+						<button type="button" id="liveLinkInviteButton" class="btn btn-primary btn-sm" data-i18n="social.live.link.invite"></button>
+					</div>
+					<p id="liveBroadcastStatus" class="live-broadcast-status"></p>
+				</div>
+			</section>
+		</main>
+
+		<section id="videosView" class="view hidden" tabindex="-1" data-i18n="social.video.view">
+			<button type="button" class="view-back-btn" id="videosViewBackButton" data-i18n="social.video.back">
+				<span class="icon icon-home" aria-hidden="true"></span>
+			</button>
+			<div class="vertical-snap-view" id="videoSnapContainer"></div>
+		</section>
+
+		<section id="liveView" class="view hidden" aria-label="Live streams">
+			<div class="live-top-bar">
+				<button type="button" class="view-back-btn" id="liveViewBackButton" data-i18n="social.live.back">
+					<span class="icon icon-home" aria-hidden="true"></span>
+				</button>
+				<div id="liveScopeTabs" class="live-scope-tabs" role="tablist">
+					<button type="button" data-scope="local" class="live-scope-btn is-active" role="tab" aria-selected="true"></button>
+					<button type="button" data-scope="nearby" class="live-scope-btn" role="tab" aria-selected="false"></button>
+				</div>
+				<button type="button" id="liveGoBroadcastButton" class="live-go-broadcast-btn" data-view-broadcast></button>
+			</div>
+			<div class="vertical-snap-view" id="liveSnapContainer"></div>
+		</section>
+
+		<aside class="aside-col" aria-label="Social sidebar">
+			<div class="aside-search card bg-base-200 shadow-sm">
+				<div class="feed-search-wrap">
+					<span class="icon icon-search search-icon" aria-hidden="true"></span>
+					<input type="search" id="feedSearchInput" class="feed-search-input input input-bordered input-sm w-full" autocomplete="off" data-i18n="social.search" />
+					<button type="button" id="feedSearchClearButton" class="search-clear-btn hidden" data-i18n="social.search.clear" aria-label=""></button>
+				</div>
+			</div>
+			<aside id="feedTrending" class="feed-trending card bg-base-200 shadow-sm hidden"></aside>
+			<div id="asideSuggested" class="aside-suggested card bg-base-200 shadow-sm hidden">
+				<h3 class="aside-card-title" data-i18n="social.aside.suggested"></h3>
+				<div id="asideSuggestedList" class="aside-suggested-list"></div>
+			</div>
+		</aside>
+
+		<nav class="mobile-tabbar bg-base-100 border-t border-base-300" aria-label="Social mobile navigation">
+			<button type="button" data-view="feed" class="nav-btn btn btn-ghost btn-sm active" data-i18n="social.nav.feed">
+				<span class="icon icon-home" aria-hidden="true"></span>
+			</button>
+			<button type="button" data-view="explore" class="nav-btn btn btn-ghost btn-sm" data-i18n="social.nav.explore">
+				<span class="icon icon-explore" aria-hidden="true"></span>
+			</button>
+			<button type="button" data-view="notifications" class="nav-btn btn btn-ghost btn-sm" data-i18n="social.nav.notifications">
+				<span class="icon icon-bell" aria-hidden="true"></span>
+				<span id="mobileNotificationsBadge" class="nav-badge badge badge-primary badge-xs hidden"></span>
+			</button>
+			<button type="button" data-view="saved" class="nav-btn btn btn-ghost btn-sm" data-i18n="social.nav.saved">
+				<span class="icon icon-bookmark" aria-hidden="true"></span>
+			</button>
+			<button type="button" data-view="profile" class="nav-btn btn btn-ghost btn-sm" data-i18n="social.nav.profile">
+				<span class="icon icon-user" aria-hidden="true"></span>
+			</button>
+		</nav>
+
+		<button type="button" id="composeFab" class="compose-fab btn btn-primary btn-circle" data-i18n="social.composer.fab">
+			<span class="icon icon-compose" aria-hidden="true"></span>
+		</button>
+
+		<div id="saveModal" class="save-modal hidden" role="dialog" aria-modal="true">
+			<div class="save-modal-card card bg-base-200 shadow-xl">
+				<h3 data-i18n="social.saved.pickFolderTitle"></h3>
+				<select id="saveFolderSelect" class="select select-bordered w-full"></select>
+				<div class="save-modal-actions">
+					<button type="button" id="saveConfirmButton" class="btn btn-primary btn-sm" data-i18n="social.saved.confirm"></button>
+					<button type="button" id="saveCancelButton" class="btn btn-ghost btn-sm link-btn" data-i18n="social.saved.cancel"></button>
+				</div>
+			</div>
+		</div>
+	</div>
+	<script type="module" src="/parts/shells:social/index.mjs"></script>
+</body>
+
+</html>

--- a/src/public/parts/shells/social/public/index.mjs
+++ b/src/public/parts/shells/social/public/index.mjs
@@ -1,0 +1,13 @@
+/**
+ * Social shell 前端入口。
+ */
+import { usingTemplates } from '../../../scripts/features/template.mjs'
+import { initTranslations } from '../../../scripts/i18n/index.mjs'
+import { applyTheme } from '../../../scripts/theme/index.mjs'
+
+import { bootstrap } from './src/init.mjs'
+
+applyTheme()
+usingTemplates('/parts/shells:social/src/templates')
+await initTranslations('social')
+await bootstrap()

--- a/src/public/parts/shells/social/public/llms.txt
+++ b/src/public/parts/shells/social/public/llms.txt
@@ -1,0 +1,289 @@
+# social shell Web API
+
+HTTP 前缀：`/api/parts/shells:social/`。账号与 Chat 联邦 P2P 实体相同（identity/profile 见 `/api/parts/shells:chat/{viewer,entities…}`；网络级仍 `/api/p2p/{network,denylist,federation}`），无需单独注册；后端可 import chat `src/entity/`，前端**不** `loadPart('shells/chat')`。
+
+**统一实体模型**：HTTP 路由恒为 operator 实体 → `getSocialClient(username)`。本机 agent 经进程内 `getSocialClient(username, agentEntityHash)` 自签操作；**无** `actingEntityHash` 参数、无前端身份切换。收藏夹等私有状态存 `shells/social/entities/{entityHash}/…`，人类与 agent 互不可见。
+
+WebSocket：`/ws/parts/shells:social/feed`（推送 feed 更新，客户端收到后刷新首页）。
+
+联邦传输：经用户级 P2P 房间 `fount-node-{nodeHash}` action `part_timeline_put`、`part_invoke` / `part_invoke_response`（npm `@steve02081504/fount-p2p` 的 `transport/user_room`、`trust_graph/*`）。Social RPC 请求/响应 `type` 字符串分离（`SOCIAL_RPC_REQUEST_TYPES` / `SOCIAL_RPC_RESPONSE_TYPES`）。**不**依赖 Chat shell Load 即可 fanout；群 Chat 仍用 `fount-fed-{groupId}` DAG。
+
+用户级拉黑/网络：`GET|POST /api/p2p/denylist`、`GET|PUT /api/p2p/network`（`settings/denylist.json`、`settings/network.json`）。
+
+---
+
+## 页面
+
+| 路径 | 说明 |
+|------|------|
+| `GET /parts/shells:social/` | 主壳：Feed / 探索 / 通知 / 收藏 / **偏好** / 资料 |
+| Hash | `#feed` / `#explore` / … 主导航；`#profile;<entityHash>[;<postId>]` 资料；`#post;<entityHash>;<postId>` 帖子详情；`#topic:` / `#search;`·`#search:` / `#live:` 深链（搜索进 `#searchView`） |
+
+---
+
+## Feed 与探索
+
+### `GET /api/parts/shells:social/posts/:entityHash/:postId`
+单帖 feed item。响应：`{ item }`；不可见或不存在 → 404。
+
+### `GET /api/parts/shells:social/feed`
+Query：`limit`（默认 50，最大 200）、`cursor`（分页游标）、`ranking`（`latest` 默认｜`for_you` 本地启发式，含关注者 like/repost 挖出的二度公开帖）。
+
+响应：`{ items[], nextCursor }`。repost 条目外层 `postId` 为 repost 事件 id；`targetEntityHash`/`targetPostId` 指向原帖。解密失败时 `post.content` 为 null 且 `post.decryptView: { failed: true }`。`for_you` 条目可带 `score`。
+
+### `POST /api/parts/shells:social/feed/sync`
+显式同步关注时间线（联邦 mailbox / pull）。响应：`{ synced: true }`。
+
+### `GET /api/parts/shells:social/hashtags/trending`
+Query：`limit`（默认 12，最大 32）、`scope`（`local` 默认｜`nearby` 经 `part_query` kind `trending_hashtags` 聚合邻居公开话题计数）。响应：`{ tags: [{ tag, count }], scope }`。
+
+### `GET|PUT /api/parts/shells:social/profile/muted-keywords`
+本地关键词/标签屏蔽表（不联邦）。`PUT` body：`{ entries: [{ pattern, matchTags?, expiresAt? }] }`。命中正文、contentWarning 或 tags 的帖从 feed/explore/search/通知中隐藏。
+
+### `POST /api/parts/shells:social/signals/dwell`
+本地隐私停留信号（不联邦）。Body：`{ entries: [{ author, postId, tags?, dwellMs, at? }] }`（`dwellMs ≥ 3s`）。用于 `for_you` 作者亲和弱加权（每条 +0.25）与 taste 标签弱证据（每条 tag +0.15）。
+
+### `GET|POST /api/parts/shells:social/posts/:entityHash/:postId/notes`
+社区补充（Community Notes）：`POST` body `{ text }` → 调用者时间线 `post_note` 事件；`GET` 返回 `{ notes[], topNote }`（净 helpful 分 > 0 的最高分附在 feed `communityNote.topNote`）。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/notes/:noteEventId/vote`
+Body：`{ helpful: boolean }` → `note_vote`。通知类型含 `post_note`。
+
+### `GET /api/parts/shells:social/search`
+Query：`q`（≥2 或配合过滤器）、`limit`、`cursor?`、`author?`、`media=image|video`、`tag?`、`sort=latest|top`、`scope=local|nearby`、`before?`/`after?`（毫秒）。
+
+本地：观看者已知时间线倒排 + 扫描回退。`scope=nearby`：`part_query` kind `post_search` 聚合邻居公开帖摘录（入站清洗）。响应：`{ query, items[], nextCursor?, filters?, scope }`。
+
+### `POST /api/parts/shells:social/topics/follow`
+Body：`{ tag, follow?: boolean }` → 时间线 `tag_follow`/`tag_unfollow`。响应：`{ tag, isFollowing, tags[] }`。
+
+### `GET /api/parts/shells:social/topics/followed`
+响应：`{ tags[] }`。
+
+### `GET /api/parts/shells:social/topics/:tag/posts`
+话题帖流（cursor 分页）。响应：`{ tag, items[], nextCursor }`。首页 feed 也会把订阅话题公开帖并入 merge（`via: topic`）。
+
+### `GET /api/parts/shells:social/videos/feed`
+短视频竖屏流（含 video mediaRef 的公开帖，for_you 启发式）。响应：`{ items[], nextCursor }`。
+
+### `POST /api/parts/shells:social/live/start`
+Body：`{ title?, visibility?, groupId?, channelId?, bridgeOrigin? }`。无 group 时 social 原生 `avRoomId=social:{entityHash}:{liveId}`；有则挂载 chat streaming。写 `live_start`，**同步发 `post`（`content.liveRef`）**，通知关注者 `live_started`。公开场生成 `publicWatchSecret` 供大厅多跳观看代理。
+
+### `POST /api/parts/shells:social/live/stop`
+Body：`{ liveId }` → `live_end` + 对开播帖 `post_edit` 附 `liveStats`（时长 / 观看 / 点赞）。
+
+### `GET /api/parts/shells:social/live/feed`
+Query：`limit`、`cursor?`、`scope=local|nearby`。在播列表；`nearby` 经 `part_query` kind=`live_feed` 多跳。条目可含 `bridgeOrigin`、`watchSecret`（公开）。
+
+### `POST /api/parts/shells:social/live/:liveId/link/invite`
+Body：`{ peerEntityHash, peerLiveId, bridgeOrigin? }`。双方均在播时经 `live_link_invite` RPC 互连；同节点桥接 AV+弹幕/点赞，跨节点走 `live-bridge` WS。
+
+### `POST /api/parts/shells:social/live/:liveId/link/stop`
+断开连线。
+
+### WS `/ws/parts/shells:social/live/:entityHash/:liveId`
+弹幕/点赞信令：客户端发 `{ type:'danmaku', text }` / `{ type:'like' }`；服务端广播 `danmaku` / `like` / `viewer_count` / `like_count` / `link_*`。联邦直播可加 `?proxy=1&bridgeOrigin=&watchSecret=`。
+
+### WS `/ws/parts/shells:social/live-av/:entityHash/:liveId`
+复用 chat `avRelay`（WebCodecs 二进制帧）。联邦可同样带 proxy 查询串；本节点代理连主播 `live-bridge`。
+
+### WS `/ws/parts/shells:social/live-bridge/:entityHash/:liveId?token=`
+节点间连线 / 公开观看代理；`token` = HMAC(`linkSecret`|`publicWatchSecret`)。
+
+### `GET /api/parts/shells:social/posts/scheduled` / `DELETE …/posts/scheduled/:scheduledId`
+定时发帖队列。`POST /posts` 带未来 `publishAt`（毫秒）则入队而非即时 commit。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/feature-reply`
+Body：`{ replierEntityHash, replyPostId, feature?: boolean }` → `reply_feature`/`reply_unfeature`。
+
+发帖 body 扩展：`replyPolicy`（`everyone`|`followers_7d`|`author_follows`）、`replyDisplay`（`all`|`featured_only`）、`publishAt`。
+
+### `GET /api/parts/shells:chat/entities/search`
+Query：`q`（≥2）、`limit`（默认 20）。经 chat `part_query`（`kind=entity_search`）多跳搜实体。Social 前端搜索页用户段改调此路由。
+
+### `GET /api/parts/shells:social/explore`
+Query：`limit`。账户发现（本地 + 邻居 RPC 合并）。
+
+### `GET /api/parts/shells:social/explore/posts`
+Query：`limit`、`mediaOnly=true`。帖子发现。
+
+### `GET /api/parts/shells:social/notifications`
+Query：`limit`（默认 30，最大 100）、`cursor`（分页游标）、`types`（可选，逗号分隔）。
+
+响应：`{ notifications[], nextCursor, unreadCount, viewerEntityHash }`。读取层按目标聚合高频互动（like/repost 按目标帖、follow 按 24h 窗口）；`unreadCount` 为聚合卡片未读数。
+
+每条字段：`{ type, actorEntityHash, postId, targetPostId, at }` 必填；可选 `targetEntityHash`, `snippet`, `actors[]`, `actorCount`, `latestActorEntityHash`, `aggregateKey`。类型：`reply` | `mention` | `like` | `repost` | `follow` | `care_post` | `poll_closed` | `post_note` | `live_started`。
+
+### `POST /api/parts/shells:social/translate`
+Body：`{ text, targetLang }` — 帖子翻译（缓存于用户侧）。
+
+### `GET/PUT /api/parts/shells:chat/translation-prefs`
+`{ prefs: { autoTranslate, targetLocale?, excludeLocales? } }`。存 `shells/chat/entities/{hash}/translationPreferences.json`；Social 偏好页改调此路由。
+
+### `GET /api/parts/shells:social/mentions/suggest`
+Query：`q`、`limit`。返回 `{ suggestions: [{ entityHash, displayName, kind }] }`（self / following / agent）。
+
+---
+
+## 资料（只读）
+
+### `GET /api/parts/shells:chat/viewer`
+当前观看者 `viewerEntityHash` 与 `profile` 摘要。Social 前端 bootstrap 改调此路由。
+
+### `POST /api/parts/shells:social/profile/meta`
+Body：`hideFromDiscovery?` — 追加 `social_meta` 事件更新探索可见性。
+
+### `GET /api/parts/shells:social/profile/:entityHash`
+资料、`postCount`、`followingCount`、`followerCount`（本 replica 已知粉丝投影）、`isFollowing`、`socialMeta`（不含拉黑名单）。
+
+### `GET /api/parts/shells:social/profile/:entityHash/posts`
+物化帖子列表（与首页 feed 同构的 `items[]`）。
+
+### `GET /api/parts/shells:social/profile/:entityHash/likes`
+该 entity 点赞过的帖子列表。
+
+### `GET /api/parts/shells:social/profile/:entityHash/following`
+关注列表。响应：`{ following: [{ entityHash, profile }] }`（不含隐式自关注；`profile` 为作者摘要）。
+
+### `GET /api/parts/shells:social/profile/:entityHash/followers`
+已知粉丝列表（本地关注 + 已同步远程时间线投影）。响应：`{ followers: [{ entityHash, profile }] }`。
+
+### `GET /api/parts/shells:social/profile/:entityHash/replies/:postId`
+帖下回复。响应：`{ replies[] }`，每条为完整 feed item（含 `authorProfile`、互动计数、`featured`）。
+
+### `GET /api/parts/shells:social/profile/:entityHash/replies/:postId`
+跨已知时间线的回复聚合。
+
+### `GET /api/parts/shells:chat/personal-lists`
+返回 `{ entries: [{ scope, value, kind: 'block'|'hide' }] }`。Social 拉黑/隐藏列表 UI 改调此路由。
+
+---
+
+## 帖文写操作
+
+### `POST /api/parts/shells:social/posts`
+Body：`text`、`visibility`（`public`|`unlisted`|`followers`|`followers_7d`|`followers_30d`|`followers_since`|`selected`|`private`）、`minFollowMs?`、`allow?`、`except?`、`albumIds?`、`locale`、`mediaRefs[]`、`replyTo`、`quoteRef`、`groupRef`、`contentWarning?`、`sensitiveMedia?`、`poll?`、`tags?`、`replyPolicy?`、`replyDisplay?`、`publishAt?`（未来毫秒 → 定时队列）、`entityHash?`、`charPartName?`。
+定时成功响应：`{ scheduled: true, scheduledId, publishAt }`；即时发布：`{ event }`。
+可见性：`followers*`=GSH；`selected`/`private`=pkw 按接收者包裹；`unlisted`明文可读但不进发现面；`except`仅过滤层。入册时帖密级派生为所选相册最公开档位。
+
+### 相册（帖子链接合集）
+
+- `GET /albums` / `GET /albums/:entityHash` → `{ albums }`（含虚拟 `default`）
+- `GET /albums/:entityHash/:albumId` → `{ album, items }`（成员帖 feed item）
+- `POST /albums` Body：`name`、`description?`、可见性字段
+- `POST /albums/:albumId/update`、`DELETE /albums/:albumId?deletePosts=0|1`
+- `POST /albums/:albumId/posts` Body：`postId`；`DELETE /albums/:albumId/posts/:postId`
+- `POST /albums/move-post` Body：`postId`、`fromAlbumId?`、`toAlbumId`
+
+### `DELETE /api/parts/shells:social/posts`
+Body：`postId`、`entityHash?`（缺省 = operator；可删自有帖或 `ownerEntityHash` 为自己的 agent 帖）。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/edit`
+Body：`text?`、`mediaRefs?`、`locale?`、`contentWarning?` — 追加 `post_edit`；物化 `revisions[]`。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/poll-vote`
+Body：`choices`（选项下标数组） — 追加 `poll_vote`。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/like`
+Body：`like?`（默认 true）。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/dislike`
+Body：`dislike?`（默认 true）。与 like 互斥；reducer 写入时清对立反应。
+
+### `POST /api/parts/shells:social/posts/:entityHash/:postId/repost`
+Body：`comment?`。
+
+---
+
+## 口味偏好（taste）
+
+### `GET /api/parts/shells:social/taste`
+Query：`locale?`（默认 `zh-CN`）。响应：`{ privacy, clusteredAt, aliases, tags: [{ tagHash, weight, label }] }`。
+
+### `PUT /api/parts/shells:social/taste`
+Body：`privacy?`（`{ publishPreferences, publishReactions }`，默认皆 true）、`tags?`（`Record<tagHash, weight>` 写入 **manual** 覆盖，0 删除）。响应：`{ privacy, computed, manual, aliases, tagCount? }`。
+关闭 `publishPreferences`：不共享标签命名与合并声明。关闭 `publishReactions`：like/dislike 不 fanout、不进 `reaction_index`、联邦 pull 不导出。
+
+### `POST /api/parts/shells:social/taste/rebuild`
+从 like/dislike 反应图重建本地 `computed` 权重（manual 不动），顺带懒验证合并收件箱与本地发现 gossip。响应：`{ clusteredAt, tagCount }`。
+
+### `POST /api/parts/shells:social/taste/names`
+Body：`{ tagHash, label, locale? }` — 写入签名时间线事件 `tag_name`（受 `publishPreferences` 控制 fanout）。响应：`{ event }`。
+
+### `DELETE /api/parts/shells:social/taste/aliases/:fromTag`
+撤销软别名。响应：`{ aliases }`。
+
+SocialClient：`client.taste.get|update|rebuild|setName|revokeAlias`（与上同构）。
+
+联邦 RPC：`social_reaction_pull_request` → `{ type: 'social_reaction_pull_response', targetEntityHash, postId, events[] }`（签名 like/dislike 事件分页，`afterReactor` 游标；`postId`/`targetEntityHash` 须合法 hex）；`social_tag_merge_claim`（声明入有界收件箱，本地验证后软别名）。标签命名走时间线 `tag_name`，无独立命名 RPC。
+
+---
+
+## 关系写操作
+
+### `POST /api/parts/shells:social/relationships/follow`
+Body：`entityHash`、`follow?`（默认 true）。响应：`{ entityHash, isFollowing }`。
+
+### `POST /api/parts/shells:social/relationships/block`
+Body：`entityHash`、`block?`。写入公开联邦 `block`/`unblock` 时间线事件。
+
+### `POST /api/parts/shells:social/relationships/hide`
+Body：`entityHash`、`hide?`。纯本地 `personal_hide.json`，不联邦。
+
+### `POST /api/parts/shells:social/relationships/mute`
+Body：`entityHash`、`mute?`。纯本地 `personal_mute.json`，不联邦；过滤 feed 并压制来自该作者的通知。
+
+### `POST /api/parts/shells:social/relationships/follow-approve`
+Body：`followerPubKeyHex` — 为关注者签发 GSH vault H（解密 followers 帖；**不是** locked-account 审批关注队列）。
+
+---
+
+## 收藏 / 文件
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/saved-posts` | operator 收藏 `{ folders, unfiled }`；含 `preview`、`authorName`（`entities/{entityHash}/savedPosts.json`） |
+| GET | `/saved-posts/search?q=&limit=` | 在收藏夹内搜索正文/作者；`{ query, posts[] }` |
+| POST | `/saved-posts/add` | body: `{ entityHash, postId, folderId? }`（帖作者 entityHash，非换身份） |
+| POST | `/saved-posts/remove` | body: `{ entityHash, postId, folderId? }` |
+| POST | `/saved-posts/folders` | body: `{ name }` |
+| POST | `/saved-posts/folders/rename` | body: `{ folderId, name }` |
+| POST | `/saved-posts/folders/delete` | body: `{ folderId }` |
+| GET | `/drafts` | operator 草稿箱 `{ drafts[] }`（`entities/{entityHash}/drafts.json`；含 `preview`） |
+| GET | `/drafts/:draftId` | 单条草稿（完整 `body`） |
+| POST | `/drafts` | 创建/更新草稿；body 同发帖字段，可选 `draftId` 更新 |
+| DELETE | `/drafts/:draftId` | 删除草稿，返回更新后列表 |
+| POST | `/files` | 注册 vault 文件并写入 `file_share` 事件 |
+| GET | `/files/:shareId?owner=` | 文件元数据 |
+
+---
+
+## 时间线事件类型
+
+写入 `shells/social/timelines/<entityHash>/events.jsonl`：`social_meta`、`state_summary`、`post`、`post_edit`、`post_delete`、`poll_vote`、`like`、`unlike`、`dislike`、`undislike`、`repost`、`follow`、`unfollow`、`follow_approve`、`block`、`unblock`、`file_share`、`entity_key_rotate`、`entity_key_revoke`。`poll_closed` 为 inbox 通知类型（非 timeline 事件）。`suspect`/`unsuspect` 为**保留类型名**（无 reducer、无写入 API、不可物化）。
+
+逐帖反应投影：`shells/social/reaction_index/<author>/<postId>.json`（reactor → 签名 like/dislike 事件；联邦 `social_reaction_pull_request` 分页拉取）。
+
+时间线事件使用 `charPartName`（本地 agent 目录名）。`social_meta.hideFromDiscovery` 控制探索/联邦隐藏；`content.visibility` 见上文（GSH / pkw）。相册为帖链接合集；feed item 可带 `albums[]`。Feed 解密失败时 `post.content` 为 null 且 `post.decryptView: { failed: true }`。
+
+---
+
+## Agent 集成
+
+新帖入账（本地 commit 或联邦 ingest）统一经 `dispatchSocialMessage`：对本机每个可见托管 agent 调 `interfaces.social.onMessage`（返回 boolean 意愿）；无 `onMessage` 时被 @ 默认意愿 true 并经 `lib/replyViaChat.mjs` → `chat.GetReply` 生成公开回复。operator 特别关心（chat `care` 模块）作者发帖写 `care_post` inbox 行 + `notifyUser`。跨节点 @ 非本机实体走 `social_post_notify` RPC。`OnFollow` 保留（被关注不是消息）。
+
+进程内操作面：`src/api/client/index.mjs` → `getSocialClient(username, entityHash?)`（发帖 / 关系 / feed / 收藏 / vault 等与 HTTP 同构）。owner 改/删所属实体帖：`POST …/edit` 或 `DELETE /posts` 带被管实体的 `entityHash`，主人自签落入 **被管实体时间线**。
+
+---
+
+## 深链
+
+- `fount://run/shells:social/post;<entityHash>;<postId>[;<sharerNodeHash>]`（外部分享优先 `fount://page/parts/shells:social/#post;…`）
+- `fount://run/shells:social/profile;<entityHash>`
+- `fount://run/shells:social/post;<entityHash>;<postId>[;<sharerNodeHash>]`
+- `fount://run/shells:social/search;<query>`（浏览器：`/parts/shells:social/#search;<query>`；`?q=` 查询参数亦可）
+- 分享链可选第 4 段 `sharerNodeHash`：接收方打开帖子时对分享者与作者节点 `POST /api/p2p/federation/connect-node`
+
+帖子 Markdown 中 `#话题` 渲染为话题页深链 `#topic:…`（不作用于 Chat `#[group/channel]` 标记）。见 `public/shared/runUri.mjs`、`markdown_ext/index.mjs`。
+
+从 Social 跳转 Chat DM：`/parts/shells:chat/hub/?contact=<entityHash>`。

--- a/src/public/parts/shells/social/public/markdown_extensions/index.mjs
+++ b/src/public/parts/shells/social/public/markdown_extensions/index.mjs
@@ -1,0 +1,66 @@
+/**
+ * Social shell 注册的 markdown 扩展：@entity、帖子深链、话题标签、Chat 频道链接。
+ */
+import { visit, SKIP } from 'https://esm.sh/unist-util-visit'
+
+import { expandChannelLinksInText } from '/parts/shells:chat/shared/expandChannelLinks.mjs'
+import { formatSocialTopicHref } from '../shared/runUri.mjs'
+
+/** 话题标签（不含 Chat `#[channel:…]` 等 typed hash token）。 */
+const HASHTAG_RE = /#([\p{L}\p{N}_-]{2,32})/gu
+
+/**
+ * remark：展开 Social 方言链接。
+ *
+ * hashtag 转为真正的 MDAST link 节点，确保 rehype 能生成可点击的 `<a>` 元素。
+ * @returns {(tree: import('npm:@types/mdast').Root) => void} remark 插件。
+ */
+function remarkSocialDialect() {
+	return tree => {
+		visit(tree, 'text', (node, index, parent) => {
+			if (typeof node.value !== 'string' || !parent || typeof index !== 'number') return
+
+			let value = expandChannelLinksInText(node.value)
+			value = value
+				.replace(/@\[([\da-f]{128})\]/giu, '[$1](/parts/shells:social/#profile;$1)')
+				.replace(/social:post:([\da-f]{128}):([\da-f]{64})/gi, '[$2](/parts/shells:social/#post;$1;$2)')
+
+			/** @type {import('npm:@types/mdast').RootContent[]} */
+			const parts = []
+			let lastIndex = 0
+			let hasHashtags = false
+			for (const match of value.matchAll(HASHTAG_RE)) {
+				const start = match.index ?? 0
+				if (start > 0 && value[start - 1] === '[') continue
+				hasHashtags = true
+				if (start > lastIndex)
+					parts.push({ type: 'text', value: value.slice(lastIndex, start) })
+				parts.push({
+					type: 'link',
+					url: formatSocialTopicHref(match[1]),
+					title: null,
+					children: [{ type: 'text', value: `#${match[1]}` }],
+				})
+				lastIndex = start + match[0].length
+			}
+
+			if (!hasHashtags) {
+				if (value !== node.value) node.value = value
+				return
+			}
+			if (lastIndex < value.length)
+				parts.push({ type: 'text', value: value.slice(lastIndex) })
+
+			parent.children.splice(index, 1, ...parts)
+			return [SKIP, index + parts.length]
+		})
+	}
+}
+
+/**
+ *
+ */
+export default {
+	remarkPlugins: [remarkSocialDialect],
+	rehypePlugins: [],
+}

--- a/src/public/parts/shells/social/public/src/actions.mjs
+++ b/src/public/parts/shells/social/public/src/actions.mjs
@@ -1,0 +1,27 @@
+import { handleComposerFeedClick } from './actions/composerFeed.mjs'
+import { handleDraftsClick } from './actions/drafts.mjs'
+import { handlePostEngagementClick } from './actions/postEngagementActions.mjs'
+import { handlePostProfileActionsClick } from './actions/postProfileActions.mjs'
+import { handleProfileNavClick } from './actions/profileNavActions.mjs'
+import { handleSavedClick } from './actions/saved.mjs'
+import { closePostMoreMenus } from './actions/shared.mjs'
+
+/**
+ * 处理主内容区点击：点赞、转发、收藏、关注等交互委托。
+ * @param {Event} event 点击事件
+ * @returns {Promise<void>}
+ */
+export async function handleMainClick(event) {
+	const { target } = event
+	if (!(target instanceof HTMLElement)) return
+
+	if (!target.closest('.post-more-dropdown'))
+		closePostMoreMenus()
+
+	await handleComposerFeedClick(target)
+	if (await handleDraftsClick(target)) return
+	await handleSavedClick(target)
+	await handleProfileNavClick(target)
+	if (await handlePostProfileActionsClick(target)) return
+	await handlePostEngagementClick(target)
+}

--- a/src/public/parts/shells/social/public/src/actions/composerFeed.mjs
+++ b/src/public/parts/shells/social/public/src/actions/composerFeed.mjs
@@ -1,0 +1,68 @@
+import {
+	refreshGroupRefPreview,
+	refreshQuotePreview,
+	setComposerAdvancedOpen,
+	setComposerContentWarningOpen,
+	syncGroupRefInComposer,
+} from '../composer.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { state } from '../state.mjs'
+import { loadFeed, setFeedRanking, updateFeedSearchChrome } from '../views/feed.mjs'
+import { markNotificationsSeen, setNotificationFilter } from '../views/notifications.mjs'
+
+/**
+ * 处理发帖框与 Feed 顶栏相关点击。
+ * @param {HTMLElement} target 点击目标
+ * @returns {Promise<void>}
+ */
+export async function handleComposerFeedClick(target) {
+	if (target.closest('.clear-quote-btn')) {
+		state.pendingQuoteRef = null
+		await refreshQuotePreview()
+	}
+	if (target.closest('.clear-group-ref-btn')) {
+		state.pendingGroupRef = null
+		syncGroupRefInComposer(null)
+		await refreshGroupRefPreview()
+		const groupSelect = document.getElementById('linkGroupSelect')
+		if (groupSelect instanceof HTMLSelectElement)
+			groupSelect.value = ''
+	}
+	if (target.closest('#feedRefreshButton')) {
+		state.activeFeedSearchQuery = null
+		const searchInput = document.getElementById('feedSearchInput')
+		if (searchInput instanceof HTMLInputElement) searchInput.value = ''
+		state.feedCursor = null
+		await socialApi('/feed/sync', { method: 'POST' })
+		await loadFeed(false)
+		updateFeedSearchChrome()
+	}
+	const rankingTab = target.closest('[data-feed-ranking]')
+	if (rankingTab instanceof HTMLElement && rankingTab.dataset.feedRanking)
+		await setFeedRanking(rankingTab.dataset.feedRanking)
+	if (target.closest('#pollComposerToggle')) {
+		const panel = document.getElementById('pollComposerPanel')
+		panel?.classList.toggle('hidden')
+		document.getElementById('pollComposerToggle')?.classList.toggle('active', !panel?.classList.contains('hidden'))
+	}
+	if (target.closest('#composerCwToggle'))
+		setComposerContentWarningOpen()
+	if (target.closest('#composerAdvancedToggle'))
+		setComposerAdvancedOpen()
+	if (target.closest('#pollComposerApply')) {
+		const optionsRaw = document.getElementById('pollComposerOptions')?.value || ''
+		const options = optionsRaw.split('\n').map(line => line.trim()).filter(Boolean)
+		const multi = document.getElementById('pollComposerMulti')?.checked === true
+		const deadlineRaw = document.getElementById('pollComposerDeadline')?.value?.trim()
+		state.pendingPoll = options.length >= 2
+			? { options, multi, deadline: deadlineRaw ? new Date(deadlineRaw).toISOString() : null }
+			: null
+		document.getElementById('pollComposerPanel')?.classList.add('hidden')
+		document.getElementById('pollComposerToggle')?.classList.toggle('active', Boolean(state.pendingPoll))
+	}
+	if (target.closest('#notificationsMarkAllButton'))
+		void markNotificationsSeen()
+	const filterButton = target.closest('[data-notif-filter]')
+	if (filterButton instanceof HTMLButtonElement && filterButton.dataset.notifFilter)
+		void setNotificationFilter(filterButton.dataset.notifFilter)
+}

--- a/src/public/parts/shells/social/public/src/actions/drafts.mjs
+++ b/src/public/parts/shells/social/public/src/actions/drafts.mjs
@@ -1,0 +1,51 @@
+import { showToastI18n } from '../../../../../scripts/features/toast.mjs'
+import { loadDraftIntoComposer, saveComposerDraft } from '../composer.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { focusComposer, switchView } from '../navigation.mjs'
+import { state } from '../state.mjs'
+import { removeDraft } from '../views/drafts.mjs'
+
+/**
+ * 处理草稿箱相关点击。
+ * @param {HTMLElement} target 点击目标
+ * @returns {Promise<boolean>} 是否已处理
+ */
+export async function handleDraftsClick(target) {
+	if (target.closest('#saveDraftButton')) {
+		try {
+			await saveComposerDraft()
+		}
+		catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error))
+			showToastI18n('error', 'social.drafts.saveFailed', { error: err.message })
+		}
+		return true
+	}
+
+	const openBtn = target.closest('[data-open-draft]')
+	if (openBtn instanceof HTMLElement && openBtn.dataset.openDraft) {
+		const draftId = openBtn.dataset.openDraft
+		try {
+			const row = await socialApi(`/drafts/${encodeURIComponent(draftId)}`)
+			await switchView('feed')
+			await loadDraftIntoComposer(row)
+			await focusComposer()
+		}
+		catch (error) {
+			const err = error instanceof Error ? error : new Error(String(error))
+			showToastI18n('error', 'social.drafts.loadFailed', { error: err.message })
+		}
+		return true
+	}
+
+	const deleteBtn = target.closest('[data-delete-draft]')
+	if (deleteBtn instanceof HTMLElement && deleteBtn.dataset.deleteDraft) {
+		const draftId = deleteBtn.dataset.deleteDraft
+		if (state.activeDraftId === draftId)
+			state.activeDraftId = null
+		await removeDraft(draftId)
+		return true
+	}
+
+	return false
+}

--- a/src/public/parts/shells/social/public/src/actions/postEngagementActions.mjs
+++ b/src/public/parts/shells/social/public/src/actions/postEngagementActions.mjs
@@ -1,0 +1,181 @@
+import { mountTranslationBlock, requestTranslation, resolveTargetLang } from '/scripts/features/translate.mjs'
+import { refreshQuotePreview } from '../composer.mjs'
+import { parseActionKey, queryByActionKey } from '../lib/actionKey.mjs'
+import { SOCIAL_API, socialApi } from '../lib/apiClient.mjs'
+import { submitReply } from '../lib/replies.mjs'
+import {
+	applyDislikeButtonOptimistic,
+	applyLikeButtonOptimistic,
+	bumpRepostCount,
+	clearDislikeOnCard,
+	clearLikeOnCard,
+	rollbackDislikeButton,
+	rollbackLikeButton,
+	runWrite,
+} from '../lib/socialWrite.mjs'
+import { focusComposer } from '../navigation.mjs'
+import { state } from '../state.mjs'
+import { renderRepliesPanel } from '../views/replies.mjs'
+import { syncVideoCommentTicker } from '../views/video.mjs'
+
+import { closePostMoreMenus } from './shared.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * @param {HTMLElement} target 点击目标元素
+ * @returns {Promise<boolean>} 是否已处理
+ */
+export async function handlePostEngagementClick(target) {
+	// 短视频 slide 与 feed 卡可能共享同一 actionKey；必须先收窄到当前容器
+	const cardRoot = target.closest('.post-card, .reply, .video-slide') || document
+	const dislikeButton = target.closest('[data-dislike]')
+	if (dislikeButton instanceof HTMLElement && dislikeButton.dataset.dislike) {
+		const parsed = parseActionKey(dislikeButton.dataset.dislike)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const disliked = dislikeButton.dataset.disliked === '1'
+			const snapshot = applyDislikeButtonOptimistic(dislikeButton, !disliked)
+			const card = dislikeButton.closest('.post-card, .reply')
+			if (!disliked && card instanceof HTMLElement) clearLikeOnCard(card)
+			try {
+				await runWrite('dislike', () => socialApi(`/posts/${entityHash}/${postId}/dislike`, {
+					method: 'POST',
+					body: JSON.stringify({ dislike: !disliked }),
+				}))
+			}
+			catch {
+				rollbackDislikeButton(dislikeButton, snapshot)
+			}
+		}
+	}
+
+	const likeButton = target.closest('[data-like]')
+	if (likeButton instanceof HTMLElement && likeButton.dataset.like) {
+		const parsed = parseActionKey(likeButton.dataset.like)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const liked = likeButton.dataset.liked === '1'
+			const snapshot = applyLikeButtonOptimistic(likeButton, !liked)
+			const card = likeButton.closest('.post-card, .reply')
+			if (!liked && card instanceof HTMLElement) clearDislikeOnCard(card)
+			try {
+				await runWrite('like', () => socialApi(`/posts/${entityHash}/${postId}/like`, {
+					method: 'POST',
+					body: JSON.stringify({ like: !liked }),
+				}))
+			}
+			catch {
+				rollbackLikeButton(likeButton, snapshot)
+			}
+		}
+	}
+
+	const repostButton = target.closest('[data-repost]')
+	if (repostButton instanceof HTMLElement && repostButton.dataset.repost)
+		queryByActionKey('data-repost-for', repostButton.dataset.repost, cardRoot)?.classList.toggle('hidden')
+
+	const submitRepostButton = target.closest('[data-submit-repost]')
+	if (submitRepostButton instanceof HTMLElement && submitRepostButton.dataset.submitRepost) {
+		const actionKey = submitRepostButton.dataset.submitRepost
+		const panel = queryByActionKey('data-repost-for', actionKey, cardRoot)
+		const textarea = panel?.querySelector('textarea')
+		const comment = textarea?.value.trim() || ''
+		const parsed = parseActionKey(actionKey)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const card = submitRepostButton.closest('.post-card, .reply')
+			const prevRepost = card ? bumpRepostCount(card, 1) : 0
+			try {
+				await runWrite('repost', () => socialApi(`/posts/${entityHash}/${postId}/repost`, {
+					method: 'POST',
+					body: JSON.stringify({ comment }),
+				}))
+				if (textarea) textarea.value = ''
+				panel?.classList.add('hidden')
+			}
+			catch {
+				if (card) bumpRepostCount(card, -1)
+			}
+		}
+	}
+
+	const quoteButton = target.closest('[data-quote]')
+	if (quoteButton instanceof HTMLElement && quoteButton.dataset.quote) {
+		const parsed = parseActionKey(quoteButton.dataset.quote)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const card = quoteButton.closest('.post-card')
+			const text = decodeURIComponent(card?.dataset.postText || '')
+			state.pendingQuoteRef = { entityHash, postId, text }
+			await refreshQuotePreview()
+			await focusComposer({ switchToFeed: true })
+			closePostMoreMenus()
+		}
+	}
+
+	const repliesButton = target.closest('[data-replies]')
+	if (repliesButton instanceof HTMLElement && repliesButton.dataset.replies) {
+		const actionKey = repliesButton.dataset.replies
+		const parsed = parseActionKey(actionKey)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const panel = queryByActionKey('data-replies-for', actionKey, cardRoot)
+			if (!panel) return false
+			panel.classList.toggle('hidden')
+			if (panel.dataset.loaded) return false
+			const data = await socialApi(`/profile/${entityHash}/replies/${postId}`)
+			await renderRepliesPanel(panel, data.replies || [])
+			panel.dataset.loaded = '1'
+		}
+	}
+
+	const submitReplyButton = target.closest('[data-submit-reply]')
+	if (submitReplyButton instanceof HTMLElement && submitReplyButton.dataset.submitReply) {
+		const actionKey = submitReplyButton.dataset.submitReply
+		const parsed = parseActionKey(actionKey)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const panel = queryByActionKey('data-replies-for', actionKey, cardRoot)
+			const textarea = panel?.querySelector('textarea')
+			const text = textarea?.value.trim()
+			if (!text) return false
+			try {
+				await runWrite('reply', () => submitReply(entityHash, postId, text))
+				textarea.value = ''
+				const data = await socialApi(`/profile/${entityHash}/replies/${postId}`)
+				const replies = data.replies || []
+				await renderRepliesPanel(panel, replies)
+				panel.dataset.loaded = '1'
+				panel.classList.remove('hidden')
+				const countElement = queryByActionKey('data-replies', actionKey, cardRoot)?.querySelector('.action-count')
+				if (countElement) countElement.textContent = String(replies.length)
+				const slide = panel.closest('.video-slide')
+				if (slide instanceof HTMLElement) syncVideoCommentTicker(slide, replies)
+			}
+			catch { /* toast 已展示 */ }
+		}
+	}
+
+	const translateButton = target.closest('[data-translate]')
+	if (translateButton instanceof HTMLElement) {
+		const cardBody = translateButton.closest('.post-card')?.querySelector('.body')
+		const card = translateButton.closest('.post-card')
+		if (!cardBody || !card) return false
+		const text = decodeURIComponent(card.dataset.postText || '')
+		const translated = await requestTranslation(
+			`${SOCIAL_API}/translate`,
+			text,
+			resolveTargetLang(),
+		)
+		mountTranslationBlock(cardBody, {
+			originalText: text,
+			translatedText: translated,
+			translationLabel: geti18n('social.translate.label'),
+			showOriginalLabel: geti18n('common.translate.showOriginal'),
+			showTranslationLabel: geti18n('common.translate.showTranslation'),
+		})
+		closePostMoreMenus()
+	}
+
+	return false
+}

--- a/src/public/parts/shells/social/public/src/actions/postProfileActions.mjs
+++ b/src/public/parts/shells/social/public/src/actions/postProfileActions.mjs
@@ -1,0 +1,189 @@
+import { formatSocialShareHttpsUrl } from '../../shared/protocolUrl.mjs'
+import { downloadPostHtml } from '../exportHtml.mjs'
+import { parseActionKey } from '../lib/actionKey.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { promptText, promptTextArea, showText } from '../lib/dialog.mjs'
+import { handlePollVoteClick } from '../lib/pollUi.mjs'
+import { purgeFeedShownPost, restoreFeedShownItems, runWrite } from '../lib/socialWrite.mjs'
+import { refreshVisiblePosts } from '../navigation.mjs'
+import { state } from '../state.mjs'
+
+import { closePostMoreMenus, copyTextToClipboard, flashCopiedLabel, shareOrCopyPostLink } from './shared.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * @param {HTMLElement} target 点击目标元素
+ * @returns {Promise<boolean>} 是否已处理
+ */
+export async function handlePostProfileActionsClick(target) {
+	if (await handlePollVoteClick(target)) return true
+
+	const editButton = target.closest('[data-edit]')
+	if (editButton instanceof HTMLElement && editButton.dataset.edit) {
+		const parsed = parseActionKey(editButton.dataset.edit)
+		if (parsed) {
+			closePostMoreMenus()
+			const card = editButton.closest('.post-card')
+			const current = decodeURIComponent(card?.dataset.postText || '')
+			const next = await promptText(geti18n('social.post.editPrompt'), current)
+			if (next == null || next === current) return true
+			await runWrite('edit', () => socialApi(
+				`/posts/${encodeURIComponent(parsed.entityHash)}/${encodeURIComponent(parsed.postId)}/edit`,
+				{ method: 'POST', body: JSON.stringify({ text: next }) },
+			))
+			await refreshVisiblePosts()
+		}
+		return true
+	}
+
+	const historyButton = target.closest('[data-edit-history]')
+	if (historyButton instanceof HTMLElement && historyButton.dataset.editHistory) {
+		const card = historyButton.closest('.post-card')
+		const postId = card?.dataset.postId
+		const author = card?.dataset.authorEntity
+		if (postId && author) {
+			closePostMoreMenus()
+			void socialApi(`/profile/${encodeURIComponent(author)}/posts?limit=50`).then(async data => {
+				const item = (data.items || []).find(row => row.postId === postId)
+				const revisions = item?.post?.revisions || []
+				const lines = revisions.map((rev, idx) => `#${idx + 1} ${rev.text || ''}`).join('\n---\n')
+				await showText(lines || geti18n('social.post.editHistoryEmpty'), geti18n('social.post.editHistory'))
+			})
+		}
+		return true
+	}
+
+	const addNoteButton = target.closest('[data-add-note]')
+	if (addNoteButton instanceof HTMLElement && addNoteButton.dataset.addNote) {
+		const parsed = parseActionKey(addNoteButton.dataset.addNote)
+		if (parsed) {
+			closePostMoreMenus()
+			const text = await promptTextArea(geti18n('social.notes.prompt'))
+			if (!text?.trim()) return true
+			await runWrite('addNote', () => socialApi(
+				`/posts/${encodeURIComponent(parsed.entityHash)}/${encodeURIComponent(parsed.postId)}/notes`,
+				{ method: 'POST', body: JSON.stringify({ text: text.trim() }) },
+			))
+			await refreshVisiblePosts()
+		}
+		return true
+	}
+
+	const noteVoteButton = target.closest('[data-note-vote]')
+	if (noteVoteButton instanceof HTMLElement && noteVoteButton.dataset.noteVote) {
+		const parsed = parseActionKey(noteVoteButton.dataset.noteVote)
+		const noteId = noteVoteButton.dataset.noteId
+		if (parsed && noteId) {
+			const helpful = noteVoteButton.dataset.helpful !== '0'
+			await runWrite('noteVote', () => socialApi(
+				`/posts/${encodeURIComponent(parsed.entityHash)}/${encodeURIComponent(parsed.postId)}/notes/${encodeURIComponent(noteId)}/vote`,
+				{ method: 'POST', body: JSON.stringify({ helpful }) },
+			))
+			await refreshVisiblePosts()
+		}
+		return true
+	}
+
+	const noteMoreButton = target.closest('[data-note-more]')
+	if (noteMoreButton instanceof HTMLElement && noteMoreButton.dataset.noteMore) {
+		const parsed = parseActionKey(noteMoreButton.dataset.noteMore)
+		if (parsed) {
+			const data = await socialApi(
+				`/posts/${encodeURIComponent(parsed.entityHash)}/${encodeURIComponent(parsed.postId)}/notes`,
+			)
+			await showText((data.notes || []).map(note =>
+				`[${note.score >= 0 ? '+' : ''}${note.score}] ${note.text || ''}`).join('\n---\n')
+				|| geti18n('social.notes.empty'), geti18n('social.notes.listTitle'))
+		}
+		return true
+	}
+
+	const copyLinkButton = target.closest('[data-copy-link]')
+	if (copyLinkButton instanceof HTMLElement && copyLinkButton.dataset.copyLink) {
+		const parsed = parseActionKey(copyLinkButton.dataset.copyLink)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			await copyTextToClipboard(formatSocialShareHttpsUrl(entityHash, postId))
+			flashCopiedLabel(copyLinkButton.querySelector('[data-i18n="social.actions.copyLink"]'))
+			closePostMoreMenus()
+		}
+		return true
+	}
+
+	const downloadHtmlButton = target.closest('[data-download-html]')
+	if (downloadHtmlButton instanceof HTMLElement && downloadHtmlButton.dataset.downloadHtml) {
+		const parsed = parseActionKey(downloadHtmlButton.dataset.downloadHtml)
+		if (parsed) {
+			closePostMoreMenus()
+			const card = downloadHtmlButton.closest('.post-card')
+			const fallbackText = decodeURIComponent(card?.dataset.postText || '')
+			try {
+				const data = await socialApi(
+					`/posts/${encodeURIComponent(parsed.entityHash)}/${encodeURIComponent(parsed.postId)}`,
+				)
+				const content = data?.item?.post?.content || data?.post?.content || {
+					text: fallbackText,
+				}
+				await downloadPostHtml(content, `post-${parsed.postId}.html`)
+			}
+			catch {
+				await downloadPostHtml({ text: fallbackText }, `post-${parsed.postId}.html`)
+			}
+		}
+		return true
+	}
+
+	const shareButton = target.closest('[data-share]')
+	if (shareButton instanceof HTMLElement && shareButton.dataset.share) {
+		const parsed = parseActionKey(shareButton.dataset.share)
+		if (parsed) {
+			const result = await shareOrCopyPostLink(parsed.entityHash, parsed.postId)
+			if (result === 'copied')
+				flashCopiedLabel(
+					shareButton.querySelector('[data-i18n="social.actions.share"]')
+						|| shareButton.querySelector('.action-count'),
+				)
+			closePostMoreMenus()
+		}
+		return true
+	}
+
+	const moreToggle = target.closest('[data-more-toggle]')
+	if (moreToggle instanceof HTMLElement && moreToggle.dataset.moreToggle) {
+		const card = moreToggle.closest('.post-card')
+		const menu = card?.querySelector(`[data-more-menu="${CSS.escape(moreToggle.dataset.moreToggle)}"]`)
+			|| document.querySelector(`[data-more-menu="${CSS.escape(moreToggle.dataset.moreToggle)}"]`)
+		if (menu instanceof HTMLElement) {
+			const willOpen = menu.classList.contains('hidden')
+			closePostMoreMenus(willOpen ? menu : null)
+			menu.classList.toggle('hidden')
+		}
+		return true
+	}
+
+	const deleteButton = target.closest('button[data-delete]')
+	if (deleteButton instanceof HTMLElement && deleteButton.dataset.delete) {
+		const card = deleteButton.closest('.post-card')
+		const parent = card?.parentElement
+		const next = card?.nextSibling
+		const postId = deleteButton.dataset.delete
+		const purged = purgeFeedShownPost(state, postId)
+		card?.remove()
+		closePostMoreMenus()
+		const entityHash = deleteButton.dataset.deleteEntity
+			|| state.viewerEntityHash
+		try {
+			await runWrite('delete', () => socialApi('/posts', {
+				method: 'DELETE',
+				body: JSON.stringify({ postId, entityHash }),
+			}))
+		}
+		catch {
+			restoreFeedShownItems(state, purged)
+			if (card && parent)
+				parent.insertBefore(card, next)
+		}
+	}
+
+	return false
+}

--- a/src/public/parts/shells/social/public/src/actions/profileNavActions.mjs
+++ b/src/public/parts/shells/social/public/src/actions/profileNavActions.mjs
@@ -1,0 +1,197 @@
+import { showToastI18n } from '../../../../../scripts/features/toast.mjs'
+import { aliasForEntity, setEntityAlias } from '/parts/shells:chat/shared/aliases.mjs'
+import { setCared } from '/parts/shells:chat/shared/care.mjs'
+import { formatChatDmFromSocial } from '../../shared/runUri.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { promptText } from '../lib/dialog.mjs'
+import {
+	purgeFeedShownAuthor,
+	removePostsByAuthor,
+	restoreFeedShownItems,
+	restoreRemovedPosts,
+	runWrite,
+} from '../lib/socialWrite.mjs'
+import { state } from '../state.mjs'
+import { loadExplore } from '../views/explore.mjs'
+import {
+	activateProfileTab,
+	loadProfileFor,
+	openProfileRelationshipList,
+	openProfileSettingsDialog,
+	renderBlocklist,
+} from '../views/profile.mjs'
+
+import { closePostMoreMenus } from './shared.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * 乐观隐藏作者帖子，失败回滚。
+ * @param {string} entityHash 作者
+ * @param {() => Promise<void>} write 写请求
+ * @param {string} failKey i18n 失败键
+ * @returns {Promise<void>}
+ */
+async function optimisticAuthorFilter(entityHash, write, failKey) {
+	const purged = purgeFeedShownAuthor(state, entityHash)
+	const removed = removePostsByAuthor(entityHash)
+	closePostMoreMenus()
+	try {
+		await runWrite(failKey, write)
+	}
+	catch {
+		restoreFeedShownItems(state, purged)
+		restoreRemovedPosts(removed)
+	}
+}
+
+/**
+ * 处理个人资料、关注、拉黑与 Tab 切换相关点击。
+ * @param {HTMLElement} target 点击目标元素
+ * @returns {Promise<void>}
+ */
+export async function handleProfileNavClick(target) {
+	if (target.closest('[data-profile-edit]')) {
+		window.location.href = '/parts/shells:chat/profile/'
+		return
+	}
+
+	if (target.closest('[data-profile-settings]')) {
+		await openProfileSettingsDialog(state.profileSocialMeta || {})
+		return
+	}
+
+	const settingsBack = target.closest('#settingsView [data-view="profile"]')
+	if (settingsBack) {
+		const { switchView } = await import('../navigation.mjs')
+		await switchView('profile')
+		return
+	}
+
+	const exploreShortcut = target.closest('.explore-shortcuts [data-view]')
+	if (exploreShortcut instanceof HTMLElement && exploreShortcut.dataset.view) {
+		const { switchView } = await import('../navigation.mjs')
+		await switchView(exploreShortcut.dataset.view)
+		return
+	}
+
+	const statButton = target.closest('[data-profile-stat]')
+	if (statButton instanceof HTMLElement && statButton.dataset.profileStat) {
+		const kind = statButton.dataset.profileStat
+		const entityHash = statButton.dataset.entityHash || state.profileEntityHash
+		if (kind === 'posts') {
+			await activateProfileTab('posts')
+			document.getElementById('profilePostsPanel')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+			return
+		}
+		if ((kind === 'following' || kind === 'followers') && entityHash) {
+			await openProfileRelationshipList(entityHash, kind)
+			return
+		}
+	}
+
+	const followButton = target.closest('[data-follow]')
+	if (followButton instanceof HTMLElement && followButton.dataset.follow) {
+		const entityHash = followButton.dataset.follow
+		const wasFollowing = followButton.dataset.isFollowing === '1'
+		const prevKey = followButton.dataset.i18n
+		followButton.dataset.i18n = wasFollowing ? 'social.actions.follow' : 'social.actions.following'
+		followButton.dataset.isFollowing = wasFollowing ? '0' : '1'
+		try {
+			await runWrite('follow', () => socialApi('/relationships/follow', {
+				method: 'POST',
+				body: JSON.stringify({ entityHash, follow: !wasFollowing }),
+			}))
+			if (state.profileEntityHash === entityHash)
+				await loadProfileFor(entityHash)
+			else
+				await loadExplore()
+		}
+		catch {
+			followButton.dataset.i18n = prevKey
+			followButton.dataset.isFollowing = wasFollowing ? '1' : '0'
+		}
+	}
+
+	const careButton = target.closest('[data-care]')
+	if (careButton instanceof HTMLElement && careButton.dataset.care) {
+		const entityHash = careButton.dataset.care
+		const owner = state.viewerEntityHash
+		if (!owner) return
+		const wasCared = careButton.dataset.isCared === '1'
+		const prevKey = careButton.dataset.i18n
+		careButton.dataset.i18n = wasCared ? 'social.actions.care' : 'social.actions.careRemove'
+		careButton.dataset.isCared = wasCared ? '0' : '1'
+		try {
+			await setCared(owner, entityHash, !wasCared)
+			showToastI18n('success', wasCared ? 'social.actions.careRemoved' : 'social.actions.careAdded')
+		}
+		catch {
+			careButton.dataset.i18n = prevKey
+			careButton.dataset.isCared = wasCared ? '1' : '0'
+		}
+	}
+
+	const aliasButton = target.closest('[data-set-alias]')
+	if (aliasButton instanceof HTMLElement && aliasButton.dataset.setAlias) {
+		const entityHash = aliasButton.dataset.setAlias
+		const next = await promptText(geti18n('social.actions.setAliasPrompt'), aliasForEntity(entityHash) || '')
+		if (next != null) {
+			await setEntityAlias(entityHash, next)
+			showToastI18n('success', 'social.actions.aliasSaved')
+			if (state.profileEntityHash === entityHash)
+				await loadProfileFor(entityHash)
+		}
+	}
+
+	const blockButton = target.closest('[data-block], [data-hide], [data-mute]')
+	if (blockButton instanceof HTMLElement) {
+		const kind = blockButton.dataset.block ? 'block'
+			: blockButton.dataset.hide ? 'hide'
+				: 'mute'
+		const entityHash = blockButton.dataset[kind]
+		if (entityHash)
+			await optimisticAuthorFilter(entityHash, () => socialApi(`/relationships/${kind}`, {
+				method: 'POST',
+				body: JSON.stringify({ entityHash, [kind]: true }),
+			}), kind)
+	}
+
+	const unblockButton = target.closest('[data-unblock]')
+	if (unblockButton instanceof HTMLElement && unblockButton.dataset.unblock) {
+		await socialApi('/relationships/block', {
+			method: 'POST',
+			body: JSON.stringify({ entityHash: unblockButton.dataset.unblock, block: false }),
+		})
+		const section = document.getElementById('blocklistSection')
+		if (section) await renderBlocklist(section)
+	}
+
+	const unhideButton = target.closest('[data-unhide]')
+	if (unhideButton instanceof HTMLElement && unhideButton.dataset.unhide) {
+		await socialApi('/relationships/hide', {
+			method: 'POST',
+			body: JSON.stringify({ entityHash: unhideButton.dataset.unhide, hide: false }),
+		})
+		const section = document.getElementById('blocklistSection')
+		if (section) await renderBlocklist(section)
+	}
+
+	const dmButton = target.closest('[data-dm]')
+	if (dmButton instanceof HTMLElement && dmButton.dataset.dm)
+		window.location.href = formatChatDmFromSocial(dmButton.dataset.dm)
+
+	const profileTab = target.closest('[data-profile-tab]')
+	if (profileTab instanceof HTMLElement && profileTab.dataset.profileTab)
+		await activateProfileTab(profileTab.dataset.profileTab)
+
+	const albumChip = target.closest('[data-album-open][data-album-id]')
+	if (albumChip instanceof HTMLElement && albumChip.dataset.albumOpen && albumChip.dataset.albumId) {
+		const { openAlbumDetail } = await import('../views/albums.mjs')
+		const { switchView } = await import('../navigation.mjs')
+		await switchView('profile')
+		await activateProfileTab('albums', { force: true })
+		const panel = document.getElementById('profileAlbumsPanel')
+		if (panel)
+			await openAlbumDetail(albumChip.dataset.albumOpen, albumChip.dataset.albumId, panel)
+	}
+}

--- a/src/public/parts/shells/social/public/src/actions/saved.mjs
+++ b/src/public/parts/shells/social/public/src/actions/saved.mjs
@@ -1,0 +1,75 @@
+import { parseActionKey } from '../lib/actionKey.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { confirmAction, promptText } from '../lib/dialog.mjs'
+import { loadSaved, openSaveModal, setSavedFilter } from '../views/saved.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * 处理收藏夹与保存帖子相关点击。
+ * @param {HTMLElement} target 点击目标
+ * @returns {Promise<void>}
+ */
+export async function handleSavedClick(target) {
+	const filterTab = target.closest('[data-saved-filter]')
+	if (filterTab instanceof HTMLElement && filterTab.dataset.savedFilter) {
+		setSavedFilter(filterTab.dataset.savedFilter)
+		return
+	}
+
+	const renameFolderButton = target.closest('[data-rename-folder]')
+	if (renameFolderButton instanceof HTMLElement && renameFolderButton.dataset.renameFolder) {
+		const name = await promptText(geti18n('social.saved.renameFolderPrompt'))
+		if (!name) return
+		await socialApi('/saved-posts/folders/rename', {
+			method: 'POST',
+			body: JSON.stringify({ folderId: renameFolderButton.dataset.renameFolder, name }),
+		})
+		await loadSaved()
+		return
+	}
+
+	const deleteFolderButton = target.closest('[data-delete-folder]')
+	if (deleteFolderButton instanceof HTMLElement && deleteFolderButton.dataset.deleteFolder) {
+		if (!await confirmAction(geti18n('social.saved.deleteFolderConfirm'))) return
+		await socialApi('/saved-posts/folders/delete', {
+			method: 'POST',
+			body: JSON.stringify({ folderId: deleteFolderButton.dataset.deleteFolder }),
+		})
+		await loadSaved()
+		return
+	}
+
+	if (target.closest('#createFolderButton')) {
+		const name = await promptText(geti18n('social.saved.createFolderPrompt'))
+		if (!name) return
+		await socialApi('/saved-posts/folders', { method: 'POST', body: JSON.stringify({ name }) })
+		await loadSaved()
+		return
+	}
+
+	const saveButton = target.closest('[data-save]')
+	if (saveButton instanceof HTMLElement && saveButton.dataset.save) {
+		const parsed = parseActionKey(saveButton.dataset.save)
+		if (parsed)
+			await openSaveModal(parsed.entityHash, parsed.postId, saveButton)
+		return
+	}
+
+	const removeSavedButton = target.closest('[data-remove-saved]')
+	if (removeSavedButton instanceof HTMLElement && removeSavedButton.dataset.removeSaved) {
+		const parsed = parseActionKey(removeSavedButton.dataset.removeSaved)
+		if (parsed) {
+			const { entityHash, postId } = parsed
+			const folderId = removeSavedButton.dataset.savedFolder || undefined
+			await socialApi('/saved-posts/remove', {
+				method: 'POST',
+				body: JSON.stringify({
+					entityHash,
+					postId,
+					...folderId ? { folderId } : {},
+				}),
+			})
+			await loadSaved()
+		}
+	}
+}

--- a/src/public/parts/shells/social/public/src/actions/shared.mjs
+++ b/src/public/parts/shells/social/public/src/actions/shared.mjs
@@ -1,0 +1,72 @@
+import { formatSocialShareHttpsUrl } from '../../shared/protocolUrl.mjs'
+import { state } from '../state.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * 关闭所有帖子溢出菜单（可选排除某一菜单）。
+ * @param {HTMLElement | null} [exceptMenu] 保留打开的菜单
+ * @returns {void}
+ */
+export function closePostMoreMenus(exceptMenu = null) {
+	for (const menu of document.querySelectorAll('.post-more-menu'))
+		if (menu !== exceptMenu)
+			menu.classList.add('hidden')
+}
+
+/**
+ * 将文本复制到系统剪贴板（含降级方案）。
+ * @param {string} link 文本
+ * @returns {Promise<void>}
+ */
+export async function copyTextToClipboard(link) {
+	try {
+		await navigator.clipboard.writeText(link)
+	}
+	catch {
+		const input = document.createElement('textarea')
+		input.value = link
+		document.body.appendChild(input)
+		input.select()
+		document.execCommand('copy')
+		input.remove()
+	}
+}
+
+/**
+ * 系统分享帖子链接；不支持则复制到剪贴板。
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖子
+ * @param {string} [title] 分享标题
+ * @returns {Promise<'shared' | 'copied'>} 结果
+ */
+export async function shareOrCopyPostLink(entityHash, postId, title) {
+	const url = formatSocialShareHttpsUrl(entityHash, postId, state.viewerNodeHash || undefined)
+	if (typeof navigator.share === 'function')
+		try {
+			await navigator.share({ title: title || 'fount', url })
+			return 'shared'
+		}
+		catch (err) {
+			if (err?.name === 'AbortError') return 'shared'
+		}
+
+	await copyTextToClipboard(url)
+	return 'copied'
+}
+
+/**
+ * 短暂把标签文案切成「已复制」再还原。
+ * @param {HTMLElement | null | undefined} label 文案节点
+ * @param {string} [restoreKey] 还原用 i18n 键；缺省时还原 textContent
+ * @returns {void}
+ */
+export function flashCopiedLabel(label, restoreKey) {
+	if (!(label instanceof HTMLElement)) return
+	const prev = restoreKey ? null : label.textContent
+	if (restoreKey) label.dataset.i18n = 'social.actions.copied'
+	else label.textContent = geti18n('social.actions.copied')
+	setTimeout(() => {
+		if (restoreKey) label.dataset.i18n = restoreKey
+		else if (prev != null) label.textContent = prev
+	}, 1500)
+}

--- a/src/public/parts/shells/social/public/src/composer.mjs
+++ b/src/public/parts/shells/social/public/src/composer.mjs
@@ -1,0 +1,27 @@
+/**
+ * Social composer 公共入口（薄 barrel；实现见 composerState / composerPublish）。
+ */
+export {
+	addComposerMedia,
+	clearComposer,
+	initComposerVisibilityPicker,
+	loadAlbumPickerOptions,
+	loadDraftIntoComposer,
+	loadGroupPickerOptions,
+	refreshGroupRefPreview,
+	refreshMediaPreview,
+	refreshQuotePreview,
+	setComposerAdvancedOpen,
+	setComposerContentWarningOpen,
+	setPendingGroupRef,
+	syncGroupRefInComposer,
+} from './composerState.mjs'
+
+/**
+ *
+ */
+export {
+	buildPostBody,
+	publishPost,
+	saveComposerDraft,
+} from './composerPublish.mjs'

--- a/src/public/parts/shells/social/public/src/composerPublish.mjs
+++ b/src/public/parts/shells/social/public/src/composerPublish.mjs
@@ -1,0 +1,139 @@
+import { showToastI18n } from '../../../../scripts/features/toast.mjs'
+import { readCwSensitive } from '/parts/shells:chat/shared/composerAttachmentFields.mjs'
+import { geti18n, primaryLocale } from '/scripts/i18n/index.mjs'
+
+import {
+	clearComposer,
+	refreshMediaPreview,
+} from './composerState.mjs'
+import { socialApi } from './lib/apiClient.mjs'
+import { uploadMedia } from './media.mjs'
+import { state } from './state.mjs'
+import { readVisibilityPicker } from './visibilityPicker.mjs'
+
+const SOCIAL_CW_IDS = { cwId: 'postContentWarning', sensitiveId: 'postSensitiveMedia' }
+
+/**
+ * 从 composer 表单构建发帖 API 请求体（媒体须已上传）。
+ * @param {object[]} mediaRefs 已上传 refs
+ * @returns {object} 发帖 body
+ */
+export function buildPostBody(mediaRefs = state.pendingMediaRefs) {
+	const { contentWarning, sensitiveMedia } = readCwSensitive(SOCIAL_CW_IDS)
+	const visibilityDraft = readVisibilityPicker(document.getElementById('composer'))
+	const albumSelect = document.getElementById('postAlbumSelect')
+	const albumIds = albumSelect instanceof HTMLSelectElement
+		? [...albumSelect.selectedOptions].map(opt => opt.value).filter(id => id && id !== 'default')
+		: []
+	const body = {
+		text: document.getElementById('postText').value.trim(),
+		mediaRefs: mediaRefs.map(ref => {
+			const { file: _file, objectUrl: _url, pending: _pending, ...rest } = ref
+			return rest
+		}),
+		...visibilityDraft,
+		...albumIds.length ? { albumIds } : {},
+		locale: document.getElementById('postLocale').value.trim() || primaryLocale(),
+		...contentWarning ? { contentWarning } : {},
+		...sensitiveMedia ? { sensitiveMedia: true } : {},
+	}
+	if (state.pendingQuoteRef)
+		body.quoteRef = {
+			entityHash: state.pendingQuoteRef.entityHash,
+			postId: state.pendingQuoteRef.postId,
+		}
+	if (state.pendingGroupRef)
+		body.groupRef = {
+			groupId: state.pendingGroupRef.groupId,
+			channelId: state.pendingGroupRef.channelId,
+		}
+	if (state.pendingPoll)
+		body.poll = state.pendingPoll
+
+	const replyPolicy = document.getElementById('postReplyPolicy')?.value
+	if (replyPolicy && replyPolicy !== 'everyone') body.replyPolicy = replyPolicy
+
+	const replyDisplay = document.getElementById('postReplyDisplay')?.value
+	if (replyDisplay && replyDisplay !== 'all') body.replyDisplay = replyDisplay
+
+	const publishAtEl = document.getElementById('postPublishAt')
+	if (publishAtEl instanceof HTMLInputElement && publishAtEl.value) {
+		const ms = new Date(publishAtEl.value).getTime()
+		if (!Number.isNaN(ms) && ms > Date.now()) body.publishAt = ms
+	}
+
+	return body
+}
+
+/**
+ * @param {object[]} refs 待发布 refs
+ * @returns {Promise<object[]>} 已上传 refs
+ */
+async function ensureUploadedMediaRefs(refs) {
+	const out = []
+	const pendingFiles = []
+	const pendingIndexes = []
+	for (const [index, ref] of refs.entries())
+		if (ref.pending && ref.file instanceof Blob) {
+			pendingFiles.push(ref.file)
+			pendingIndexes.push(index)
+			out.push(null)
+		}
+		else {
+			const { file: _f, objectUrl: _o, pending: _p, ...rest } = ref
+			out.push(rest)
+		}
+
+	if (pendingFiles.length) {
+		const uploaded = await uploadMedia(pendingFiles)
+		for (const [i, uploadedRef] of uploaded.entries()) {
+			const original = refs[pendingIndexes[i]]
+			out[pendingIndexes[i]] = {
+				...uploadedRef,
+				...original.alt ? { alt: original.alt } : {},
+			}
+		}
+	}
+	return out
+}
+
+/**
+ * 将当前 composer 存入草稿箱（有 activeDraftId 则更新）。
+ * @returns {Promise<object>} 写入后的草稿行
+ */
+export async function saveComposerDraft() {
+	if (!document.getElementById('postText')?.value?.trim()
+		&& !state.pendingMediaRefs.length
+		&& !state.pendingPoll)
+		throw new Error(geti18n('social.drafts.empty'))
+	const uploadedRefs = await ensureUploadedMediaRefs(state.pendingMediaRefs)
+	state.pendingMediaRefs = uploadedRefs.map(ref => ({ ...ref }))
+	refreshMediaPreview()
+	const body = buildPostBody(uploadedRefs)
+	if (state.activeDraftId)
+		body.draftId = state.activeDraftId
+	const row = await socialApi('/drafts', { method: 'POST', body: JSON.stringify(body) })
+	state.activeDraftId = row.draftId
+	showToastI18n('success', 'social.drafts.saved')
+	return row
+}
+
+/**
+ * 提交发帖请求并清空 composer 状态。
+ * @returns {Promise<void>}
+ */
+export async function publishPost() {
+	if (!document.getElementById('postText').value.trim()
+		&& !state.pendingMediaRefs.length
+		&& !state.pendingPoll) return
+	const uploadedRefs = await ensureUploadedMediaRefs(state.pendingMediaRefs)
+	const body = buildPostBody(uploadedRefs)
+	const isScheduled = !!body.publishAt
+	const draftId = state.activeDraftId
+	await socialApi('/posts', { method: 'POST', body: JSON.stringify(body) })
+	if (draftId)
+		await socialApi(`/drafts/${encodeURIComponent(draftId)}`, { method: 'DELETE' }).catch(() => {})
+	await clearComposer()
+	if (isScheduled)
+		showToastI18n('success', 'social.composer.scheduleSuccess')
+}

--- a/src/public/parts/shells/social/public/src/composerState.mjs
+++ b/src/public/parts/shells/social/public/src/composerState.mjs
@@ -1,0 +1,431 @@
+import { mountTemplate } from '../../../../scripts/features/template.mjs'
+import { groupRefLabel, renderGroupRefBlockHtml } from '../shared/groupRef.mjs'
+import { clearCwSensitive } from '/parts/shells:chat/shared/composerAttachmentFields.mjs'
+
+import { chatApi, socialApi } from './lib/apiClient.mjs'
+import { renderQuoteBlockHtml } from './lib/display.mjs'
+import { renderMediaPreview } from './mediaRender.mjs'
+import { state } from './state.mjs'
+import { bindVisibilityPicker, applyVisibilityPicker } from './visibilityPicker.mjs'
+import { formatChannelToken, stripChannelTokens } from '/parts/shells:chat/shared/inlineTokenSyntax.mjs'
+import { openImageEditor } from '/scripts/imageEditor/index.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+const SOCIAL_CW_IDS = { cwId: 'postContentWarning', sensitiveId: 'postSensitiveMedia' }
+
+/**
+ * @param {number} n 数值
+ * @returns {string} 两位补零
+ */
+export function pad2(n) {
+	return String(n).padStart(2, '0')
+}
+
+/** @type {number} */
+let quotePreviewGeneration = 0
+
+/**
+ * 刷新引用预览面板。
+ * @returns {void}
+ */
+export async function refreshQuotePreview() {
+	const panel = document.getElementById('quotePreview')
+	if (!panel) return
+	const generation = ++quotePreviewGeneration
+	if (!state.pendingQuoteRef) {
+		panel.classList.add('hidden')
+		panel.replaceChildren()
+		return
+	}
+	panel.classList.remove('hidden')
+	await mountTemplate(panel, 'quote_preview', {})
+	if (generation !== quotePreviewGeneration) return
+	const body = panel.querySelector('.quote-preview-body')
+	if (body) body.innerHTML = await renderQuoteBlockHtml(state.pendingQuoteRef)
+	panel.querySelector('.clear-quote-btn')?.addEventListener('click', () => {
+		state.pendingQuoteRef = null
+		void refreshQuotePreview()
+	})
+}
+
+/**
+ * 刷新群关联预览面板。
+ * @returns {void}
+ */
+export async function refreshGroupRefPreview() {
+	const panel = document.getElementById('groupRefPreview')
+	if (!panel) return
+	if (!state.pendingGroupRef) {
+		panel.classList.add('hidden')
+		panel.replaceChildren()
+		return
+	}
+	panel.classList.remove('hidden')
+	await mountTemplate(panel, 'group_ref_preview', {})
+	const body = panel.querySelector('.group-ref-preview-body')
+	if (body) body.innerHTML = renderGroupRefBlockHtml(state.pendingGroupRef)
+	panel.querySelector('.clear-group-ref-btn')?.addEventListener('click', () => {
+		state.pendingGroupRef = null
+		syncGroupRefInComposer(null)
+		void refreshGroupRefPreview()
+	})
+}
+
+/**
+ * 同步发帖框正文中的群链 Markdown 标记。
+ * @param {{ groupId: string, channelId: string } | null} ref 群关联
+ * @returns {void}
+ */
+export function syncGroupRefInComposer(ref) {
+	const textarea = document.getElementById('postText')
+	if (!(textarea instanceof HTMLTextAreaElement)) return
+	let text = stripChannelTokens(textarea.value)
+	if (ref?.groupId) {
+		const channel = ref.channelId?.trim() || 'default'
+		const token = formatChannelToken(ref.groupId, channel)
+		text = text ? `${text}\n\n${token}` : token
+	}
+	textarea.value = text
+}
+
+/**
+ * 加载可入册的相册到多选。
+ * @returns {Promise<void>}
+ */
+export async function loadAlbumPickerOptions() {
+	const select = document.getElementById('postAlbumSelect')
+	const field = document.getElementById('postAlbumField')
+	if (!(select instanceof HTMLSelectElement)) return
+	select.replaceChildren()
+	try {
+		const data = await socialApi('/albums')
+		const albums = (data.albums || []).filter(album => !album.virtual)
+		if (!albums.length) {
+			field?.classList.add('hidden')
+			return
+		}
+		field?.classList.remove('hidden')
+		for (const album of albums) {
+			const option = document.createElement('option')
+			option.value = album.albumId
+			option.textContent = album.name
+			select.appendChild(option)
+		}
+	}
+	catch {
+		field?.classList.add('hidden')
+	}
+}
+
+/**
+ * 绑定 composer 可见性 picker（选择器在工具栏，allow/except 输入在高级面板）。
+ * 选择「指定成员可见」时自动展开高级面板，让 allow 输入可见。
+ * @returns {void}
+ */
+export function initComposerVisibilityPicker() {
+	const root = document.getElementById('composer')
+	if (!root) return
+	bindVisibilityPicker(root)
+	document.getElementById('postVisibility')?.addEventListener('change', event => {
+		if (event.target.value === 'selected')
+			setComposerAdvancedOpen(true)
+	})
+}
+
+/**
+ * 展开/收起 composer 高级选项面板并同步按钮状态。
+ * @param {boolean} [open] 指定目标状态；缺省为切换
+ * @returns {void}
+ */
+export function setComposerAdvancedOpen(open) {
+	const panel = document.getElementById('composerAdvancedPanel')
+	if (!panel) return
+	const next = open ?? panel.classList.contains('hidden')
+	panel.classList.toggle('hidden', !next)
+	document.getElementById('composerAdvancedToggle')?.classList.toggle('active', next)
+}
+
+/**
+ * 展开/收起内容警告输入框；收起时清空内容。
+ * @param {boolean} [open] 指定目标状态；缺省为切换
+ * @returns {void}
+ */
+export function setComposerContentWarningOpen(open) {
+	const input = document.getElementById('postContentWarning')
+	if (!(input instanceof HTMLInputElement)) return
+	const next = open ?? input.classList.contains('hidden')
+	input.classList.toggle('hidden', !next)
+	document.getElementById('composerCwToggle')?.classList.toggle('active', next)
+	if (next) input.focus()
+	else input.value = ''
+}
+
+/**
+ * 加载可关联的 Chat 群到下拉选择器。
+ * @returns {Promise<void>}
+ */
+export async function loadGroupPickerOptions() {
+	const select = document.getElementById('linkGroupSelect')
+	const field = document.getElementById('linkGroupField')
+	if (!select) return
+	select.innerHTML = `<option value="">${geti18n('social.groupRef.pick')}</option>`
+	try {
+		const rows = await chatApi('/groups/')
+		const groups = Array.isArray(rows) ? rows : []
+		if (!groups.length) {
+			field?.classList.add('hidden')
+			return
+		}
+		field?.classList.remove('hidden')
+		for (const row of groups) {
+			const groupId = String(row.groupId || '').trim()
+			if (!groupId) continue
+			const channelId = String(row.defaultChannelId || 'default').trim() || 'default'
+			const title = String(row.name || groupId).trim()
+			const option = document.createElement('option')
+			option.value = `${groupId}\t${channelId}`
+			option.textContent = `${title} (#${groupId}/${channelId})`
+			select.appendChild(option)
+		}
+	}
+	catch {
+		field?.classList.add('hidden')
+	}
+}
+
+/**
+ * 刷新待发布媒体预览区。
+ * @returns {void}
+ */
+export function refreshMediaPreview() {
+	renderMediaPreview(
+		document.getElementById('mediaPreview'),
+		state.pendingMediaRefs,
+		() => refreshMediaPreview(),
+		{
+			editLabel: geti18n('social.composer.editImage'),
+			/**
+			 * @param {number} index 媒体下标
+			 * @param {object} ref 媒体引用
+			 */
+			onEditImage: async (index, ref) => {
+				const source = ref.file
+				if (!(source instanceof Blob)) return
+				const edited = await openImageEditor(source, {
+					title: geti18n('social.composer.editImage'),
+					cropLabel: geti18n('social.composer.editCrop'),
+					mosaicLabel: geti18n('social.composer.editMosaic'),
+					brushLabel: geti18n('social.composer.editBrush'),
+					applyLabel: geti18n('social.composer.editApply'),
+					cancelLabel: geti18n('social.composer.editCancel'),
+				})
+				if (!edited) return
+				if (ref.objectUrl) URL.revokeObjectURL(ref.objectUrl)
+				state.pendingMediaRefs[index] = {
+					...ref,
+					file: edited,
+					objectUrl: URL.createObjectURL(edited),
+					name: edited.name,
+					mimeType: edited.type || ref.mimeType,
+					pending: true,
+					kind: 'image',
+				}
+				refreshMediaPreview()
+			},
+		},
+	)
+}
+
+/**
+ * 暂存 composer 媒体（延迟到发帖时再上传，便于编辑）。
+ * @param {FileList | File[]} files 媒体文件
+ * @returns {Promise<void>}
+ */
+export async function addComposerMedia(files) {
+	for (const file of files) {
+		const kind = file.type.startsWith('image/')
+			? 'image'
+			: file.type.startsWith('video/')
+				? 'video'
+				: 'file'
+		state.pendingMediaRefs.push({
+			kind,
+			name: file.name,
+			mimeType: file.type || 'application/octet-stream',
+			file,
+			objectUrl: URL.createObjectURL(file),
+			pending: true,
+			alt: '',
+		})
+	}
+	refreshMediaPreview()
+}
+
+/**
+ * 清空 composer 表单与 pending 状态。
+ * @param {{ keepDraftId?: boolean }} [options] 是否保留 activeDraftId
+ * @returns {Promise<void>}
+ */
+export async function clearComposer(options = {}) {
+	const postText = document.getElementById('postText')
+	if (postText instanceof HTMLTextAreaElement)
+		postText.value = ''
+	setComposerContentWarningOpen(false)
+	clearCwSensitive(SOCIAL_CW_IDS)
+	const publishAtEl = document.getElementById('postPublishAt')
+	if (publishAtEl instanceof HTMLInputElement)
+		publishAtEl.value = ''
+	const replyPolicy = document.getElementById('postReplyPolicy')
+	if (replyPolicy instanceof HTMLSelectElement)
+		replyPolicy.value = 'everyone'
+	const replyDisplay = document.getElementById('postReplyDisplay')
+	if (replyDisplay instanceof HTMLSelectElement)
+		replyDisplay.value = 'all'
+	applyVisibilityPicker(document.getElementById('composer'), { visibility: 'public' })
+	const albumSelect = document.getElementById('postAlbumSelect')
+	if (albumSelect instanceof HTMLSelectElement)
+		for (const opt of albumSelect.options) opt.selected = false
+	for (const ref of state.pendingMediaRefs)
+		if (ref.objectUrl) URL.revokeObjectURL(ref.objectUrl)
+	state.pendingMediaRefs = []
+	state.pendingQuoteRef = null
+	state.pendingGroupRef = null
+	state.pendingPoll = null
+	if (!options.keepDraftId)
+		state.activeDraftId = null
+	document.getElementById('pollComposerToggle')?.classList.remove('active')
+	document.getElementById('pollComposerPanel')?.classList.add('hidden')
+	const pollOptions = document.getElementById('pollComposerOptions')
+	if (pollOptions instanceof HTMLTextAreaElement) pollOptions.value = ''
+	refreshMediaPreview()
+	await refreshQuotePreview()
+	void refreshGroupRefPreview()
+	syncGroupRefInComposer(null)
+	const groupSelect = document.getElementById('linkGroupSelect')
+	if (groupSelect instanceof HTMLSelectElement)
+		groupSelect.value = ''
+	setComposerAdvancedOpen(false)
+}
+
+/**
+ * 将草稿 body 填入 composer。
+ * @param {object} row 草稿行（含 draftId / body）
+ * @returns {Promise<void>}
+ */
+export async function loadDraftIntoComposer(row) {
+	const body = row?.body || row || {}
+	await clearComposer({ keepDraftId: true })
+	state.activeDraftId = row?.draftId || null
+
+	const postText = document.getElementById('postText')
+	if (postText instanceof HTMLTextAreaElement)
+		postText.value = String(body.text || '')
+
+	if (body.contentWarning) {
+		setComposerContentWarningOpen(true)
+		const cw = document.getElementById('postContentWarning')
+		if (cw instanceof HTMLInputElement) cw.value = String(body.contentWarning)
+	}
+	const sensitiveEl = document.getElementById('postSensitiveMedia')
+	if (sensitiveEl instanceof HTMLInputElement)
+		sensitiveEl.checked = Boolean(body.sensitiveMedia)
+
+	applyVisibilityPicker(document.getElementById('composer'), body)
+	if (body.visibility === 'selected' || body.allow?.length || body.except?.length
+		|| body.replyPolicy && body.replyPolicy !== 'everyone'
+		|| body.replyDisplay && body.replyDisplay !== 'all'
+		|| body.publishAt || body.groupRef || body.albumIds?.length || body.sensitiveMedia)
+		setComposerAdvancedOpen(true)
+
+	const replyPolicy = document.getElementById('postReplyPolicy')
+	if (replyPolicy instanceof HTMLSelectElement && body.replyPolicy)
+		replyPolicy.value = body.replyPolicy
+	const replyDisplay = document.getElementById('postReplyDisplay')
+	if (replyDisplay instanceof HTMLSelectElement && body.replyDisplay)
+		replyDisplay.value = body.replyDisplay
+
+	if (body.locale) {
+		const localeEl = document.getElementById('postLocale')
+		if (localeEl instanceof HTMLInputElement) localeEl.value = String(body.locale)
+	}
+
+	if (body.publishAt) {
+		const publishAtEl = document.getElementById('postPublishAt')
+		if (publishAtEl instanceof HTMLInputElement) {
+			const d = new Date(Number(body.publishAt))
+			if (!Number.isNaN(d.getTime()))
+				publishAtEl.value = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+		}
+	}
+
+	if (Array.isArray(body.albumIds) && body.albumIds.length) {
+		await loadAlbumPickerOptions()
+		const albumSelect = document.getElementById('postAlbumSelect')
+		if (albumSelect instanceof HTMLSelectElement) {
+			const wanted = new Set(body.albumIds.map(String))
+			for (const opt of albumSelect.options)
+				opt.selected = wanted.has(opt.value)
+		}
+	}
+
+	if (body.quoteRef?.entityHash && body.quoteRef?.postId) {
+		state.pendingQuoteRef = {
+			entityHash: String(body.quoteRef.entityHash).toLowerCase(),
+			postId: String(body.quoteRef.postId),
+		}
+		await refreshQuotePreview()
+	}
+
+	if (body.groupRef?.groupId) {
+		await loadGroupPickerOptions()
+		const groupId = String(body.groupRef.groupId)
+		const channelId = String(body.groupRef.channelId || 'default')
+		setPendingGroupRef(groupId, channelId, groupRefLabel({ groupId, channelId }))
+		const groupSelect = document.getElementById('linkGroupSelect')
+		if (groupSelect instanceof HTMLSelectElement) {
+			const value = `${groupId}\t${channelId}`
+			if ([...groupSelect.options].some(opt => opt.value === value))
+				groupSelect.value = value
+		}
+	}
+
+	if (body.poll && Array.isArray(body.poll.options) && body.poll.options.length >= 2) {
+		state.pendingPoll = structuredClone(body.poll)
+		document.getElementById('pollComposerToggle')?.classList.add('active')
+		const pollOptions = document.getElementById('pollComposerOptions')
+		if (pollOptions instanceof HTMLTextAreaElement)
+			pollOptions.value = body.poll.options.join('\n')
+		const multi = document.getElementById('pollComposerMulti')
+		if (multi instanceof HTMLInputElement)
+			multi.checked = Boolean(body.poll.multi)
+		if (body.poll.deadline) {
+			const deadline = document.getElementById('pollComposerDeadline')
+			if (deadline instanceof HTMLInputElement) {
+				const d = new Date(body.poll.deadline)
+				if (!Number.isNaN(d.getTime()))
+					deadline.value = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}T${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+			}
+		}
+	}
+
+	if (Array.isArray(body.mediaRefs) && body.mediaRefs.length)
+		state.pendingMediaRefs = body.mediaRefs.map(ref => ({ ...ref }))
+	refreshMediaPreview()
+}
+
+/**
+ * 设置待关联的群/频道并更新预览。
+ * @param {string} groupId 群 id
+ * @param {string} channelId 频道 id
+ * @param {string} label 展示标签
+ * @returns {void}
+ */
+export function setPendingGroupRef(groupId, channelId, label) {
+	state.pendingGroupRef = {
+		groupId,
+		channelId: channelId || 'default',
+		label: label || groupRefLabel({ groupId, channelId }),
+	}
+	syncGroupRefInComposer(state.pendingGroupRef)
+	refreshGroupRefPreview()
+}

--- a/src/public/parts/shells/social/public/src/dwellTracker.mjs
+++ b/src/public/parts/shells/social/public/src/dwellTracker.mjs
@@ -1,0 +1,161 @@
+import { socialApi } from './lib/apiClient.mjs'
+/**
+ * Feed 停留时长采集（本地隐私信号，不联邦）。
+ */
+
+const DWELL_MIN_MS = 3000
+const FLUSH_INTERVAL_MS = 30_000
+const VISIBLE_RATIO = 0.5
+
+/** @type {{ author: string, postId: string, tags: string[], dwellMs: number, at: number }[]} */
+const buffer = []
+/** @type {Map<Element, { author: string, postId: string, tags: string[], startedAt: number }>} */
+const visible = new Map()
+/** @type {IntersectionObserver | null} */
+let observer = null
+/** @type {ReturnType<typeof setInterval> | null} */
+let flushTimer = null
+
+/**
+ * @param {HTMLElement} card 帖卡
+ * @returns {{ author: string, postId: string, tags: string[] } | null} 元数据
+ */
+function cardMeta(card) {
+	const author = String(card.dataset.authorEntity || '').trim().toLowerCase()
+	const postId = String(card.dataset.postId || '').trim().toLowerCase()
+	if (!author || !postId) return null
+	const text = (() => {
+		try {
+			return decodeURIComponent(card.dataset.postText || '')
+		}
+		catch {
+			return card.dataset.postText || ''
+		}
+	})()
+	const tags = [...String(text).matchAll(/#([\p{L}\p{N}_-]{2,32})/gu)].map(match => match[1].toLowerCase())
+	return { author, postId, tags }
+}
+
+/**
+ * @returns {void}
+ */
+function flushVisibleAges() {
+	const now = Date.now()
+	for (const [el, state] of visible) {
+		const dwellMs = now - state.startedAt
+		if (dwellMs >= DWELL_MIN_MS)
+			buffer.push({
+				author: state.author,
+				postId: state.postId,
+				tags: state.tags,
+				dwellMs,
+				at: now,
+			})
+		state.startedAt = now
+		if (!(el instanceof HTMLElement) || !el.isConnected)
+			visible.delete(el)
+	}
+}
+
+/**
+ * @returns {Promise<void>}
+ */
+async function flushBuffer() {
+	flushVisibleAges()
+	if (!buffer.length) return
+	const batch = buffer.splice(0, buffer.length)
+	await sendDwellBeacon(batch)
+}
+
+/**
+ * @param {HTMLElement} root feed 根
+ * @returns {() => void} 解绑
+ */
+export function bindDwellTracker(root) {
+	unbindDwellTracker()
+	if (!(root instanceof HTMLElement)) return () => {}
+	observer = new IntersectionObserver(entries => {
+		const now = Date.now()
+		for (const entry of entries) {
+			const el = entry.target
+			if (!(el instanceof HTMLElement)) continue
+			if (entry.isIntersecting && entry.intersectionRatio >= VISIBLE_RATIO) {
+				if (visible.has(el)) continue
+				const meta = cardMeta(el)
+				if (!meta) continue
+				visible.set(el, { ...meta, startedAt: now })
+			}
+			else if (visible.has(el)) {
+				const state = visible.get(el)
+				visible.delete(el)
+				const dwellMs = now - state.startedAt
+				if (dwellMs >= DWELL_MIN_MS)
+					buffer.push({
+						author: state.author,
+						postId: state.postId,
+						tags: state.tags,
+						dwellMs,
+						at: now,
+					})
+			}
+		}
+	}, { threshold: [0, VISIBLE_RATIO, 1] })
+
+	/**
+	 * @returns {void}
+	 */
+	function observeCards() {
+		for (const card of root.querySelectorAll('.post-card'))
+			observer.observe(card)
+	}
+	observeCards()
+	const mutation = new MutationObserver(() => observeCards())
+	mutation.observe(root, { childList: true, subtree: true })
+
+	flushTimer = setInterval(() => {
+		void flushBuffer()
+	}, FLUSH_INTERVAL_MS)
+
+	/**
+	 *
+	 */
+	const onVisibility = () => {
+		if (document.visibilityState === 'hidden')
+			void flushBuffer()
+	}
+	document.addEventListener('visibilitychange', onVisibility)
+	window.addEventListener('pagehide', onVisibility)
+
+	return () => {
+		mutation.disconnect()
+		document.removeEventListener('visibilitychange', onVisibility)
+		window.removeEventListener('pagehide', onVisibility)
+		unbindDwellTracker()
+	}
+}
+
+/**
+ * @returns {void}
+ */
+export function unbindDwellTracker() {
+	observer?.disconnect()
+	observer = null
+	if (flushTimer) clearInterval(flushTimer)
+	flushTimer = null
+	visible.clear()
+}
+
+/**
+ * @param {object[]} entries 停留条目
+ * @returns {Promise<void>}
+ */
+export async function sendDwellBeacon(entries) {
+	if (!entries?.length) return
+	const body = JSON.stringify({ entries })
+	const url = '/api/parts/shells:social/signals/dwell'
+	if (typeof navigator.sendBeacon === 'function') {
+		const blob = new Blob([body], { type: 'application/json' })
+		if (navigator.sendBeacon(url, blob)) return
+	}
+	await socialApi('/signals/dwell', { method: 'POST', body }).catch(() => null)
+}

--- a/src/public/parts/shells/social/public/src/exportHtml.mjs
+++ b/src/public/parts/shells/social/public/src/exportHtml.mjs
@@ -1,0 +1,60 @@
+/**
+ * Social 帖子 → 可离线独立 HTML 文档。
+ */
+import {
+	downloadHtmlDocument,
+	materializeStandaloneAttachments,
+	renderMarkdownAsStandaloneDocument,
+} from '/scripts/features/markdown/standaloneDocument.mjs'
+import { arrayBufferToBase64 } from '/scripts/lib/base64.mjs'
+import { mediaRefUrl } from '/parts/shells:chat/shared/evfsMedia.mjs'
+
+/**
+ * @param {object[] | undefined} mediaRefs 媒体引用
+ * @returns {Promise<object[]>} standalone 附件
+ */
+async function resolveMediaRefAttachments(mediaRefs) {
+	if (!mediaRefs?.length) return []
+	const files = []
+	for (const ref of mediaRefs) {
+		let url
+		try {
+			url = mediaRefUrl(ref)
+		}
+		catch {
+			continue
+		}
+		const res = await fetch(url, { credentials: 'include' })
+		if (!res.ok) continue
+		const mime = String(ref.mimeType || res.headers.get('Content-Type') || 'application/octet-stream')
+		files.push({
+			name: ref.name || ref.path?.split('/').pop() || 'media',
+			mime_type: mime,
+			buffer: arrayBufferToBase64(await res.arrayBuffer()),
+		})
+	}
+	return files
+}
+
+/**
+ * @param {{ text?: string, mediaRefs?: object[] }} content 帖子 content
+ * @returns {Promise<string>} 完整 HTML
+ */
+export async function generatePostStandaloneHtml(content = {}) {
+	const markdown = content.text || ''
+	const files = await materializeStandaloneAttachments(
+		await resolveMediaRefAttachments(content.mediaRefs),
+	)
+	return renderMarkdownAsStandaloneDocument(markdown, { files })
+}
+
+/**
+ * 下载帖子为独立 HTML。
+ * @param {{ text?: string, mediaRefs?: object[] }} content 帖子 content
+ * @param {string} [fileName] 文件名
+ * @returns {Promise<void>}
+ */
+export async function downloadPostHtml(content, fileName) {
+	const html = await generatePostStandaloneHtml(content)
+	downloadHtmlDocument(html, fileName || 'post-export.html')
+}

--- a/src/public/parts/shells/social/public/src/gate.mjs
+++ b/src/public/parts/shells/social/public/src/gate.mjs
@@ -1,0 +1,6 @@
+/** Social bootstrap 完成后的就绪 signal（事件 `fount:social-*`）。 */
+export const SOCIAL_GATE = {
+	id: 'social',
+	readyEvent: 'fount:social-ready',
+	errorEvent: 'fount:social-error',
+}

--- a/src/public/parts/shells/social/public/src/init.mjs
+++ b/src/public/parts/shells/social/public/src/init.mjs
@@ -1,0 +1,291 @@
+import { wireEmojiPickerButton } from '../../../../scripts/components/emojiPicker.mjs'
+import { createReadyGate } from '/scripts/test/ready_gate.mjs'
+import { loadAliases } from '/parts/shells:chat/shared/aliases.mjs'
+import { showToastI18n } from '../../../../scripts/features/toast.mjs'
+import { groupRefLabel } from '../shared/groupRef.mjs'
+
+import { handleMainClick } from './actions.mjs'
+import {
+	addComposerMedia,
+	initComposerVisibilityPicker,
+	loadAlbumPickerOptions,
+	loadGroupPickerOptions,
+	refreshGroupRefPreview,
+	setPendingGroupRef,
+	syncGroupRefInComposer,
+} from './composer.mjs'
+import { SOCIAL_GATE } from './gate.mjs'
+import { chatApi } from './lib/apiClient.mjs'
+import { renderAvatarHtml, rememberEntityHandle } from './lib/display.mjs'
+import { wireSocialProfileHover } from './lib/profileHover.mjs'
+import { bindMediaCarousel } from './mediaRender.mjs'
+import { attachMentionAutocomplete } from './mentionAutocomplete.mjs'
+import { bindContentReveal } from '/scripts/features/contentReveal/index.mjs'
+import { geti18n, primaryLocale } from '/scripts/i18n/index.mjs'
+import { applyIncomingNavigation, afterPublishPost, focusComposer, switchView } from './navigation.mjs'
+import { state } from './state.mjs'
+import { prependFeedItem, showFeedNewPostsBanner, updateFeedSearchChrome } from './views/feed.mjs'
+import { initLiveBroadcastView } from './views/live.mjs'
+import { bumpNotificationBadge, mergeIncomingNotification, updateNotificationBadge } from './views/notifications.mjs'
+import { confirmSaveModal, closeSaveModal } from './views/saved.mjs'
+import { initSearchView, loadSearchView } from './views/search.mjs'
+import { initTopicView } from './views/topic.mjs'
+import { handleVideoKeydown } from './views/video.mjs'
+
+const socialGate = createReadyGate(SOCIAL_GATE)
+
+const FEED_WS_TIMEOUT_MS = 30_000
+const FEED_WS_RECONNECT_MAX_MS = 30_000
+
+/**
+ * 处理 feed WebSocket 消息。
+ * @param {object | null} message 解析后的 WS 载荷
+ * @returns {void}
+ */
+function handleFeedWebSocketMessage(message) {
+	if (!message?.type || message.type === 'hello') return
+	if (message.type === 'post') {
+		if (message.item) {
+			void prependFeedItem(message.item).then(inserted => {
+				if (!inserted) showFeedNewPostsBanner()
+			})
+			return
+		}
+		showFeedNewPostsBanner()
+	}
+	else if (message.type === 'notification') {
+		if (!mergeIncomingNotification(message.notification))
+			bumpNotificationBadge()
+	}
+	else {
+		const feedVisible = !document.getElementById('feedView')?.classList.contains('hidden')
+		if (feedVisible && !state.activeFeedSearchQuery)
+			showFeedNewPostsBanner()
+	}
+}
+
+/**
+ * 建立 feed WebSocket（带断线重连）。
+ * @param {number} [attempt=0] 重连次数
+ * @returns {void}
+ */
+function connectFeedWebSocket(attempt = 0) {
+	const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/parts/shells:social/feed`
+	const ws = new WebSocket(url)
+	state.feedWs = ws
+	const timer = setTimeout(() => {
+		ws.close()
+	}, FEED_WS_TIMEOUT_MS)
+	ws.addEventListener('open', () => {
+		clearTimeout(timer)
+		state.feedWsAttempt = 0
+	}, { once: true })
+	ws.addEventListener('error', () => {
+		clearTimeout(timer)
+	}, { once: true })
+	ws.addEventListener('message', event => {
+		let message = null
+		try { message = JSON.parse(event.data) } catch { /* ignore */ }
+		handleFeedWebSocketMessage(message)
+	})
+	ws.addEventListener('close', () => {
+		if (state.feedWs !== ws) return
+		state.feedWs = null
+		const nextAttempt = (state.feedWsAttempt ?? attempt) + 1
+		state.feedWsAttempt = nextAttempt
+		const delay = Math.min(FEED_WS_RECONNECT_MAX_MS, 1000 * 2 ** Math.min(nextAttempt, 5))
+		setTimeout(() => connectFeedWebSocket(nextAttempt), delay)
+	})
+}
+
+/**
+ * 初始化 Social 前端：绑定事件、加载选项并建立 WebSocket feed 连接。
+ * @returns {Promise<void>}
+ */
+export async function bootstrap() {
+	socialGate.markPending()
+	try {
+		await loadAliases().catch(() => {})
+		document.getElementById('postButton')?.addEventListener('click', () => { void afterPublishPost() })
+		document.getElementById('composeNavButton')?.addEventListener('click', () => {
+			void focusComposer({ switchToFeed: true })
+		})
+		document.getElementById('composeFab')?.addEventListener('click', () => {
+			void focusComposer({ switchToFeed: true })
+		})
+		document.getElementById('feedSearchOpenButton')?.addEventListener('click', () => {
+			void loadSearchView()
+		})
+		const postText = document.getElementById('postText')
+		wireEmojiPickerButton(document.getElementById('emojiPickButton'), token => {
+			if (!(postText instanceof HTMLTextAreaElement)) return
+			const start = postText.selectionStart ?? postText.value.length
+			const end = postText.selectionEnd ?? start
+			postText.value = postText.value.slice(0, start) + token + postText.value.slice(end)
+			postText.selectionStart = postText.selectionEnd = start + token.length
+			postText.focus()
+		})
+		attachMentionAutocomplete(document.getElementById('postText'))
+		document.getElementById('mediaInput')?.addEventListener('change', async event => {
+			const input = event.target
+			if (!(input instanceof HTMLInputElement) || !input.files?.length) return
+			await addComposerMedia(input.files)
+			input.value = ''
+		})
+		const shellRoot = document.getElementById('shell')
+		shellRoot?.addEventListener('click', event => { void handleMainClick(event) })
+		bindContentReveal(shellRoot)
+		bindMediaCarousel(shellRoot)
+		shellRoot?.addEventListener('click', event => {
+			const { target } = event
+			if (!(target instanceof HTMLElement)) return
+			const cwReveal = target.closest('.content-warning-reveal')
+			if (cwReveal) {
+				const wrap = cwReveal.closest('.content-warning-wrap')
+				queueMicrotask(async () => {
+					const { playRevealedPostVideos } = await import('./lib/videoAutoplay.mjs')
+					playRevealedPostVideos(wrap?.querySelector('.content-warning-body') || wrap)
+				})
+				return
+			}
+			const sensitiveReveal = target.closest('.sensitive-media-reveal')
+			if (sensitiveReveal) {
+				const wrap = sensitiveReveal.closest('.sensitive-media-wrap')
+				queueMicrotask(async () => {
+					const { playRevealedPostVideos } = await import('./lib/videoAutoplay.mjs')
+					playRevealedPostVideos(wrap)
+				})
+			}
+		})
+		document.getElementById('saveModal')?.addEventListener('click', async event => {
+			const { target } = event
+			if (!(target instanceof HTMLElement)) return
+			if (target.closest('#saveConfirmButton'))
+				await confirmSaveModal()
+			if (target.closest('#saveCancelButton'))
+				closeSaveModal()
+		})
+		for (const button of document.querySelectorAll('.nav-btn[data-view]'))
+			button.addEventListener('click', () => { void switchView(button.dataset.view) })
+
+		const postLocale = document.getElementById('postLocale')
+		if (postLocale instanceof HTMLInputElement)
+			postLocale.value = primaryLocale()
+
+		initComposerVisibilityPicker()
+		await loadGroupPickerOptions()
+		await loadAlbumPickerOptions()
+		await updateNotificationBadge()
+
+		const viewer = await chatApi('/viewer')
+		state.viewerEntityHash = viewer.viewerEntityHash ?? null
+		state.viewerNodeHash = viewer.nodeHash ?? null
+		state.viewerDisplayName = viewer.profile?.name || null
+		state.viewerProfile = viewer.profile
+			? {
+				name: viewer.profile.name || null,
+				handle: viewer.profile.handle || null,
+				avatar: viewer.profile.avatar || null,
+				infoDefaults: viewer.profile.infoDefaults
+					? { avatar: viewer.profile.infoDefaults.avatar || '' }
+					: null,
+			}
+			: { name: state.viewerDisplayName }
+		if (state.viewerEntityHash)
+			rememberEntityHandle(state.viewerEntityHash, state.viewerProfile)
+		const avatarSlot = document.getElementById('viewerComposerAvatar')
+		if (avatarSlot && state.viewerEntityHash)
+			avatarSlot.innerHTML = renderAvatarHtml(state.viewerEntityHash, state.viewerProfile)
+
+		for (const [id, key] of Object.entries({
+			linkGroupSelect: 'social.a11y.linkGroupSelect',
+			postVisibility: 'social.a11y.postVisibility',
+			postLocale: 'social.a11y.postLang',
+			feedTrending: 'social.a11y.trendingHashtags',
+			saveFolderSelect: 'social.a11y.saveFolderSelect',
+			feedRefreshButton: 'social.feed.refresh',
+			feedSearchClearButton: 'social.search.clear',
+		})) {
+			const el = document.getElementById(id)
+			if (el) el.setAttribute('aria-label', geti18n(key))
+		}
+		const refreshButton = document.getElementById('feedRefreshButton')
+		if (refreshButton) {
+			const refreshLabel = geti18n('social.feed.refresh')
+			refreshButton.setAttribute('data-tip', refreshLabel)
+			refreshButton.setAttribute('title', refreshLabel)
+		}
+
+		document.getElementById('linkGroupSelect')?.addEventListener('change', event => {
+			const select = event.target
+			if (!(select instanceof HTMLSelectElement) || !select.value) {
+				state.pendingGroupRef = null
+				syncGroupRefInComposer(null)
+				refreshGroupRefPreview()
+				return
+			}
+			const [groupId, channelId] = select.value.split('\t')
+			if (!groupId) return
+			const label = select.selectedOptions[0]?.textContent
+			|| groupRefLabel({ groupId, channelId })
+			setPendingGroupRef(groupId, channelId, label)
+		})
+
+		// 初始化新视图
+		initSearchView()
+		initTopicView()
+		initLiveBroadcastView()
+		wireSocialProfileHover()
+
+		// 视频视图键盘导航
+		document.getElementById('videosView')?.addEventListener('keydown', handleVideoKeydown)
+		document.getElementById('videosViewBackButton')?.addEventListener('click', () => {
+			void switchView('feed')
+		})
+		document.getElementById('liveViewBackButton')?.addEventListener('click', () => {
+			void switchView('feed')
+		})
+
+		if (!await applyIncomingNavigation())
+			await switchView('feed')
+
+		window.addEventListener('hashchange', () => {
+			void applyIncomingNavigation()
+		})
+
+		document.getElementById('feedSearchInput')?.addEventListener('keydown', event => {
+			if (event.key === 'Enter') {
+				event.preventDefault()
+				const input = event.target
+				const q = input instanceof HTMLInputElement ? input.value.trim() : ''
+				void loadSearchView(q)
+			}
+		})
+
+		document.getElementById('feedSearchClearButton')?.addEventListener('click', () => {
+			const input = document.getElementById('feedSearchInput')
+			if (input instanceof HTMLInputElement) input.value = ''
+			const searchInput = document.querySelector('#searchView #searchViewInput')
+			if (searchInput instanceof HTMLInputElement) searchInput.value = ''
+			state.activeFeedSearchQuery = null
+			updateFeedSearchChrome()
+			void switchView('feed')
+		})
+
+		document.getElementById('feedSearchInput')?.addEventListener('input', event => {
+			const input = event.target
+			if (!(input instanceof HTMLInputElement)) return
+			document.getElementById('feedSearchClearButton')?.classList.toggle('hidden', !input.value.trim())
+		})
+
+		socialGate.markReady()
+		connectFeedWebSocket()
+	}
+	catch (error) {
+		socialGate.markFailed(error)
+		const err = error instanceof Error ? error : new Error(String(error))
+		console.error(err)
+		showToastI18n('social.bootstrapFailed', { error: err.message })
+		throw error
+	}
+}

--- a/src/public/parts/shells/social/public/src/lib/actionKey.mjs
+++ b/src/public/parts/shells/social/public/src/lib/actionKey.mjs
@@ -1,0 +1,34 @@
+/**
+ * 构建 `entityHash:postId` action key（entityHash 本身可含冒号）。
+ * @param {string} entityHash 作者 entityHash
+ * @param {string} postId 帖子 id
+ * @returns {string} 复合键
+ */
+export function formatActionKey(entityHash, postId) {
+	return `${entityHash}:${postId}`
+}
+
+/**
+ * 解析 `entityHash:postId` action key（entityHash 本身可含冒号）。
+ * @param {string} actionKey 复合键
+ * @returns {{ entityHash: string, postId: string } | null} 解析结果；无法识别为 `null`
+ */
+export function parseActionKey(actionKey) {
+	const sep = actionKey.lastIndexOf(':')
+	if (sep < 0) return null
+	return {
+		entityHash: actionKey.slice(0, sep),
+		postId: actionKey.slice(sep + 1),
+	}
+}
+
+/**
+ * 按 data 属性值查询 DOM（对 selector 中的特殊字符做 CSS.escape）。
+ * @param {string} attr 属性名（如 `data-repost-for`）
+ * @param {string} actionKey 属性值
+ * @param {ParentNode} [root=document] 查询根节点
+ * @returns {Element | null} 匹配元素或 `null`
+ */
+export function queryByActionKey(attr, actionKey, root = document) {
+	return root.querySelector(`[${attr}="${CSS.escape(actionKey)}"]`)
+}

--- a/src/public/parts/shells/social/public/src/lib/apiClient.mjs
+++ b/src/public/parts/shells/social/public/src/lib/apiClient.mjs
@@ -1,0 +1,55 @@
+/** Social shell HTTP 客户端。 */
+import { state } from '../state.mjs'
+
+/**
+ *
+ */
+export const SOCIAL_API = '/api/parts/shells:social'
+
+/**
+ *
+ */
+export const CHAT_API = '/api/parts/shells:chat'
+
+/**
+ * @param {string} base API 前缀
+ * @param {string} path 路径（含前导 `/`）
+ * @param {object} [options] fetch 选项
+ * @returns {Promise<any>} JSON
+ */
+async function api(base, path, options = {}) {
+	const response = await fetch(`${base}${path}`, {
+		credentials: 'include',
+		headers: { 'Content-Type': 'application/json', ...options.headers || {} },
+		...options,
+	})
+	if (!response.ok) throw new Error(await response.text())
+	return response.json()
+}
+
+/**
+ * 调用 Social shell 受保护 HTTP API 并返回 JSON。
+ * @param {string} path API 路径（含前导 `/`）
+ * @param {object} [options] fetch 选项
+ * @returns {Promise<any>} 解析后的 JSON
+ */
+export function socialApi(path, options = {}) {
+	return api(SOCIAL_API, path, options)
+}
+
+/**
+ * 调用 Chat shell 受保护 HTTP API（Social 复用 viewer / personal-lists / entities/search / translation-prefs）。
+ * @param {string} path API 路径（含前导 `/`）
+ * @param {object} [options] fetch 选项
+ * @returns {Promise<any>} 解析后的 JSON
+ */
+export function chatApi(path, options = {}) {
+	return api(CHAT_API, path, options)
+}
+
+/**
+ * @returns {string | null} 当前观看者（operator）entityHash
+ */
+export function viewerEntityHash() {
+	return state.viewerEntityHash
+}

--- a/src/public/parts/shells/social/public/src/lib/dialog.mjs
+++ b/src/public/parts/shells/social/public/src/lib/dialog.mjs
@@ -1,0 +1,74 @@
+import { pickFromDialog } from '/scripts/features/dialog.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+const CANCEL_OK = `
+		<button type="button" class="btn" data-dialog-cancel data-i18n="social.saved.cancel"></button>
+		<button type="button" class="btn btn-primary" data-dialog-resolve="ok" data-i18n="social.saved.confirm"></button>`
+const OK_ONLY = `
+		<button type="button" class="btn btn-primary" data-dialog-resolve="ok" data-i18n="social.saved.confirm"></button>`
+
+/**
+ * @param {string} title 对话框标题
+ * @param {string} [value=''] 初始输入
+ * @returns {Promise<string | null>} 用户输入；取消为 null
+ */
+export function promptText(title, value = '') {
+	return pickFromDialog('text_prompt_modal', {
+		title,
+		boxClass: '',
+		bodyHtml: `<input type="text" class="input input-bordered w-full" id="promptInput" value="${escapeHtml(value)}" />`,
+		actionsHtml: CANCEL_OK,
+	}, {
+		/**
+		 * @param {HTMLDialogElement} dialog 对话框元素
+		 * @returns {string | null} 用户输入（可为空表示清除）；取消为 null
+		 */
+		mapResult: dialog => {
+			const input = dialog.querySelector('#promptInput')
+			return input instanceof HTMLInputElement ? input.value.trim() : null
+		},
+	})
+}
+
+/**
+ * 多行文本输入（读者补充等）。
+ * @param {string} title 标题
+ * @param {string} [value=''] 初始值
+ * @returns {Promise<string | null>} 输入或取消
+ */
+export function promptTextArea(title, value = '') {
+	return pickFromDialog('text_prompt_modal', {
+		title,
+		boxClass: '',
+		bodyHtml: `<textarea class="textarea textarea-bordered w-full min-h-32" id="promptInput" maxlength="2000" rows="6">${escapeHtml(value)}</textarea>`,
+		actionsHtml: CANCEL_OK,
+	}, {
+		/**
+		 * @param {HTMLDialogElement} dialog 对话框
+		 * @returns {string | null} 输入
+		 */
+		mapResult: dialog => dialog.querySelector('#promptInput')?.value.trim() || null,
+	})
+}
+
+/**
+ * @param {string} text 只读正文
+ * @param {string} [title=''] 标题
+ * @returns {Promise<void>}
+ */
+export function showText(text, title = '') {
+	return pickFromDialog('text_prompt_modal', {
+		title,
+		boxClass: ' max-w-lg',
+		bodyHtml: `<pre class="whitespace-pre-wrap text-sm max-h-96 overflow-auto">${escapeHtml(text)}</pre>`,
+		actionsHtml: OK_ONLY,
+	})
+}
+
+/**
+ * @param {string} message 确认文案
+ * @returns {Promise<boolean>} 用户确认
+ */
+export async function confirmAction(message) {
+	return await pickFromDialog('confirm_modal', { message }) === 'ok'
+}

--- a/src/public/parts/shells/social/public/src/lib/display.mjs
+++ b/src/public/parts/shells/social/public/src/lib/display.mjs
@@ -1,0 +1,171 @@
+/**
+ *
+ */
+export {
+	entityAvatarUrl,
+	renderAvatarHtml,
+} from '/parts/shells:chat/shared/entityAvatar.mjs'
+
+import { aliasForEntity } from '/parts/shells:chat/shared/aliases.mjs'
+import { formatEntityAtId } from '/parts/shells:chat/shared/entityHash.mjs'
+import { resolveDisplayName } from '/parts/shells:chat/shared/nameResolve.mjs'
+import {
+	mountTrustedMarkdown,
+	renderTrustedMarkdownHtml,
+} from '/parts/shells:chat/shared/trustedMarkdown.mjs'
+import { isTrustedMarkdownAuthor } from '/parts/shells:chat/src/trustedAuthors.mjs'
+import { renderTemplateAsHtmlString } from '/scripts/features/template.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+import { formatSocialPostHref } from '../../shared/runUri.mjs'
+import { state } from '../state.mjs'
+
+import { viewerEntityHash } from './apiClient.mjs'
+
+/**
+ *
+ */
+export { formatEntityAtId }
+
+/** @type {Map<string, string>} entityHash → 具名 handle（会话内缓存） */
+const knownHandles = new Map()
+
+/**
+ * 记住实体具名 handle，供帖卡/回复等瘦摘要补全 at-id。
+ * @param {string} entityHash entity hash
+ * @param {{ handle?: string | null } | string | null | undefined} profileOrHandle 资料或 handle 字符串
+ * @returns {void}
+ */
+export function rememberEntityHandle(entityHash, profileOrHandle) {
+	const key = String(entityHash || '').trim().toLowerCase()
+	if (!key) return
+	const raw = typeof profileOrHandle === 'string'
+		? profileOrHandle
+		: profileOrHandle?.handle
+	const handle = String(raw || '').trim().replace(/^@+/u, '').toLowerCase()
+	if (handle) knownHandles.set(key, handle)
+}
+
+/**
+ * at-id 表述：有具名 handle 时 `@handle (@hash…)`，否则 `@hash…`。
+ * 优先 profile.handle，其次会话内缓存（资料页已加载、其它卡片已见过）。
+ * @param {string} entityHash entity hash
+ * @param {{ handle?: string | null } | null} [profile] 可选资料（取 handle）
+ * @returns {string} at-id
+ */
+export function entityHandle(entityHash, profile = null) {
+	const key = String(entityHash || '').trim().toLowerCase()
+	const handle = String(profile?.handle || '').trim() || knownHandles.get(key) || ''
+	if (handle) rememberEntityHandle(key, handle)
+	return formatEntityAtId(entityHash, { handle })
+}
+
+/**
+ * 返回作者展示名（别名 → profile.name → entityHash 短码）。
+ * @param {string} entityHash 作者 hash
+ * @param {object} [profile] 可选资料
+ * @returns {string} 展示名
+ */
+export function authorLabel(entityHash, profile) {
+	return resolveDisplayName({
+		entityHash,
+		alias: aliasForEntity(entityHash),
+		profileName: profile?.name,
+	})
+}
+
+/**
+ * Social 信任上下文（本人 / 本机 char / 声明的主人 / 信任表）。
+ * @returns {{ selfEntityHash: string | null, nodeHash: string | null, viewerOwnerEntityHash?: string | null }} 信任上下文
+ */
+function socialTrustCtx() {
+	return {
+		selfEntityHash: viewerEntityHash(),
+		nodeHash: state.viewerNodeHash,
+		viewerOwnerEntityHash: state.viewerProfile?.ownerEntityHash,
+	}
+}
+
+/**
+ * 判断作者是否应对 Markdown 走可信 pipeline。
+ * @param {string} pubKeyHash 作者 hash
+ * @param {{ ownerEntityHash?: string | null }} [_options] 兼容旧调用（所属主人不再影响 Markdown 信任）
+ * @returns {Promise<boolean>} 是否可信
+ */
+export async function isTrusted(pubKeyHash, _options = {}) {
+	return isTrustedMarkdownAuthor(pubKeyHash, socialTrustCtx())
+}
+
+/**
+ * 将 Markdown 源本机渲染为 HTML（默认/安全两档）。
+ * @param {string} markdown 原文
+ * @param {string} pubKeyHash 作者
+ * @param {{ ownerEntityHash?: string | null }} [_options] 兼容旧调用
+ * @returns {Promise<string>} HTML
+ */
+export async function renderTrustedPostMarkdown(markdown, pubKeyHash, _options = {}) {
+	return renderTrustedMarkdownHtml(markdown || '', pubKeyHash, socialTrustCtx())
+}
+
+/**
+ * 将 Markdown 源本机安全渲染进 DOM 宿主（勿对源做 escapeHtml）。
+ * @param {HTMLElement} host 宿主
+ * @param {string} markdown 原文
+ * @param {string} pubKeyHash 作者
+ * @param {{ ownerEntityHash?: string | null }} [_options] 兼容旧调用
+ * @returns {Promise<void>}
+ */
+export async function mountMarkdown(host, markdown, pubKeyHash, _options = {}) {
+	await mountTrustedMarkdown(host, markdown || '', pubKeyHash, socialTrustCtx())
+}
+
+/**
+ * 相对时间的 data-i18n 描述（或绝对时间纯文本）。
+ * @param {number} [ts] 毫秒时间戳
+ * @returns {{ i18n?: string, n?: number, text?: string }} 属性描述
+ */
+export function formatTimeAttrs(ts) {
+	const value = Number(ts) || Date.now()
+	const delta = Date.now() - value
+	if (delta < 60_000) return { i18n: 'social.time.justNow' }
+	if (delta < 3_600_000) return { i18n: 'social.time.minutesAgo', n: Math.floor(delta / 60_000) }
+	if (delta < 86_400_000) return { i18n: 'social.time.hoursAgo', n: Math.floor(delta / 3_600_000) }
+	return { text: new Date(value).toLocaleString() }
+}
+
+/**
+ * 相对时间 HTML（`data-i18n` + 参数，或绝对时间文本）。
+ * @param {number} [ts] 毫秒时间戳
+ * @param {string} [className] class
+ * @param {string} [tag='span'] 标签名
+ * @param {Record<string, string>} [extraAttrs] 额外属性（如 href）
+ * @returns {string} HTML
+ */
+export function formatTimeHtml(ts, className = 'post-meta', tag = 'span', extraAttrs = {}) {
+	const attrs = formatTimeAttrs(ts)
+	const extra = Object.entries(extraAttrs)
+		.map(([name, value]) => ` ${name}="${escapeHtml(value)}"`)
+		.join('')
+	const classAttr = className ? ` class="${escapeHtml(className)}"` : ''
+	if (attrs.text)
+		return `<${tag}${classAttr}${extra}>${escapeHtml(attrs.text)}</${tag}>`
+	const nAttr = attrs.n != null ? ` data-n="${attrs.n}"` : ''
+	return `<${tag}${classAttr}${extra} data-i18n="${attrs.i18n}"${nAttr}></${tag}>`
+}
+
+/**
+ * 渲染引用原帖块 HTML。
+ * @param {{ entityHash: string, postId: string, text?: string }} quoteRef 引用
+ * @returns {Promise<string>} HTML
+ */
+export async function renderQuoteBlockHtml(quoteRef) {
+	if (!quoteRef?.entityHash || !quoteRef?.postId) return ''
+	const snippetHtml = quoteRef.text
+		? `<p class="quote-snippet">${escapeHtml(quoteRef.text.slice(0, 200))}${quoteRef.text.length > 200 ? '…' : ''}</p>`
+		: ''
+	return renderTemplateAsHtmlString('quote_block', {
+		href: escapeHtml(formatSocialPostHref(quoteRef.entityHash, quoteRef.postId)),
+		snippetHtml,
+	})
+}
+

--- a/src/public/parts/shells/social/public/src/lib/emptyState.mjs
+++ b/src/public/parts/shells/social/public/src/lib/emptyState.mjs
@@ -1,0 +1,47 @@
+import { renderTemplate } from '/scripts/features/template.mjs'
+
+/**
+ * 构建带图标的空态节点。
+ * @param {object} options 选项
+ * @param {string} options.titleKey i18n 标题键
+ * @param {string} [options.iconClass] 图标 class（如 icon-bookmark）
+ * @param {string} [options.hintKey] i18n 提示键
+ * @param {string} [options.modClass] 修饰 class（含前导空格，如 ` empty-state--saved`）
+ * @param {string} [options.actionHtml] 底部操作 HTML
+ * @returns {Promise<HTMLElement>} 空态节点
+ */
+export async function buildEmptyState({ titleKey, iconClass = '', hintKey = '', modClass = '', actionHtml = '' }) {
+	return renderTemplate('empty_state', {
+		modClass,
+		titleKey,
+		iconHtml: iconClass
+			? `<span class="icon ${iconClass} empty-state-icon" aria-hidden="true"></span>`
+			: '',
+		hintHtml: hintKey
+			? `<p class="empty-state-hint" data-i18n="${hintKey}"></p>`
+			: '',
+		actionHtml,
+	})
+}
+
+/**
+ * @param {HTMLElement} container 容器
+ * @param {Parameters<typeof buildEmptyState>[0]} options 选项
+ * @returns {Promise<HTMLElement>} 空态节点
+ */
+export async function mountEmptyState(container, options) {
+	const node = await buildEmptyState(options)
+	container.replaceChildren(node)
+	return node
+}
+
+/**
+ * @param {HTMLElement} container 容器
+ * @param {Parameters<typeof buildEmptyState>[0]} options 选项
+ * @returns {Promise<HTMLElement>} 空态节点
+ */
+export async function appendEmptyState(container, options) {
+	const node = await buildEmptyState(options)
+	container.appendChild(node)
+	return node
+}

--- a/src/public/parts/shells/social/public/src/lib/engagementBar.mjs
+++ b/src/public/parts/shells/social/public/src/lib/engagementBar.mjs
@@ -1,0 +1,40 @@
+import { renderTemplateAsHtmlString } from '/scripts/features/template.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * 从 feed item / reply 组装互动栏模板数据。
+ * @param {object} item feed 条目（含 engagement 字段）
+ * @param {string} actionKey entityHash:postId
+ * @returns {object} engagement_bar 模板变量
+ */
+export function engagementBarTemplateData(item, actionKey) {
+	const liked = Boolean(item.viewerLiked)
+	const disliked = Boolean(item.viewerDisliked)
+	return {
+		actionKey,
+		likedClass: liked ? ' liked' : '',
+		dislikedClass: disliked ? ' disliked' : '',
+		likedFlag: liked ? '1' : '0',
+		dislikedFlag: disliked ? '1' : '0',
+		likeLabel: liked ? geti18n('social.actions.unlike') : geti18n('social.actions.like'),
+		dislikeLabel: disliked ? geti18n('social.actions.undislike') : geti18n('social.actions.dislike'),
+		replyLabel: geti18n('social.actions.replies'),
+		repostLabel: geti18n('social.actions.repost'),
+		saveLabel: geti18n('social.actions.save'),
+		shareLabel: geti18n('social.actions.share'),
+		likeCount: item.likeCount || 0,
+		dislikeCount: item.dislikeCount || 0,
+		repostCount: item.repostCount || 0,
+		replyCount: item.replyCount || 0,
+	}
+}
+
+/**
+ * 渲染统一互动栏（回复 / 转发 / 赞 / 踩 / 收藏 / 分享 + 转发面板）。
+ * @param {object} item feed 条目
+ * @param {string} actionKey entityHash:postId
+ * @returns {Promise<string>} HTML
+ */
+export function renderEngagementBarHtml(item, actionKey) {
+	return renderTemplateAsHtmlString('engagement_bar', engagementBarTemplateData(item, actionKey))
+}

--- a/src/public/parts/shells/social/public/src/lib/feedThreads.mjs
+++ b/src/public/parts/shells/social/public/src/lib/feedThreads.mjs
@@ -1,0 +1,107 @@
+/**
+ * 将同页自回复链合并为 thread 分组（正序）；非自回复保持原序单卡。
+ * @param {object[]} items feed 条目
+ * @returns {{ type: 'thread' | 'single', items: object[] }[]} 分组
+ */
+export function groupSelfReplyThreads(items) {
+	const list = items || []
+	/** @type {Map<string, object>} */
+	const byKey = new Map()
+	for (const item of list) {
+		if (item.kind === 'repost') continue
+		byKey.set(`${String(item.entityHash).toLowerCase()}:${item.postId}`, item)
+	}
+
+	/** @type {Map<string, object[]>} */
+	const childrenOf = new Map()
+	/** @type {Set<string>} */
+	const isChild = new Set()
+
+	for (const item of list) {
+		if (item.kind === 'repost') continue
+		const replyTo = item.replyContext || item.post?.content?.replyTo
+		if (!replyTo?.entityHash || !replyTo?.postId) continue
+		const parentAuthor = String(replyTo.entityHash).toLowerCase()
+		const self = String(item.entityHash).toLowerCase()
+		if (parentAuthor !== self) continue
+		const parentKey = `${parentAuthor}:${replyTo.postId}`
+		if (!byKey.has(parentKey)) continue
+		const childKey = `${self}:${item.postId}`
+		if (!childrenOf.has(parentKey)) childrenOf.set(parentKey, [])
+		childrenOf.get(parentKey).push(item)
+		isChild.add(childKey)
+	}
+
+	/** @type {Set<string>} */
+	const used = new Set()
+	/** @type {{ type: 'thread' | 'single', items: object[] }[]} */
+	const groups = []
+
+	for (const item of list) {
+		const key = item.kind === 'repost'
+			? `repost:${item.entityHash}:${item.postId}`
+			: `${String(item.entityHash).toLowerCase()}:${item.postId}`
+		if (used.has(key)) continue
+		if (item.kind === 'repost') {
+			used.add(key)
+			groups.push({ type: 'single', items: [item] })
+			continue
+		}
+		const postKey = `${String(item.entityHash).toLowerCase()}:${item.postId}`
+		if (isChild.has(postKey)) continue
+
+		const chain = [item]
+		used.add(postKey)
+		let current = item
+		while (true) {
+			const ck = `${String(current.entityHash).toLowerCase()}:${current.postId}`
+			const kids = (childrenOf.get(ck) || [])
+				.filter(child => !used.has(`${String(child.entityHash).toLowerCase()}:${child.postId}`))
+			kids.sort((a, b) => (Number(a.hlc?.wall) || 0) - (Number(b.hlc?.wall) || 0))
+			if (!kids.length) break
+			const next = kids[0]
+			chain.push(next)
+			used.add(`${String(next.entityHash).toLowerCase()}:${next.postId}`)
+			current = next
+		}
+		groups.push(chain.length > 1 ? { type: 'thread', items: chain } : { type: 'single', items: chain })
+	}
+
+	for (const item of list) {
+		if (item.kind === 'repost') continue
+		const postKey = `${String(item.entityHash).toLowerCase()}:${item.postId}`
+		if (used.has(postKey)) continue
+		used.add(postKey)
+		groups.push({ type: 'single', items: [item] })
+	}
+
+	return groups
+}
+
+/**
+ * 将分组渲染并追加到容器。
+ * @param {HTMLElement} container 列表容器
+ * @param {object[]} items feed 条目
+ * @param {(item: object) => Promise<HTMLElement | null>} buildCard 卡片构建
+ * @returns {Promise<void>}
+ */
+export async function appendFeedItemsWithThreads(container, items, buildCard) {
+	const groups = groupSelfReplyThreads(items)
+	for (const group of groups) {
+		if (group.type === 'single') {
+			const card = await buildCard(group.items[0])
+			if (card) container.appendChild(card)
+			continue
+		}
+		const thread = document.createElement('div')
+		thread.className = 'post-thread'
+		for (const item of group.items) {
+			const card = await buildCard(item)
+			if (!card) continue
+			card.classList.add('post-thread-item')
+			thread.appendChild(card)
+		}
+		if (thread.childElementCount)
+			container.appendChild(thread)
+	}
+}

--- a/src/public/parts/shells/social/public/src/lib/heartAnim.mjs
+++ b/src/public/parts/shells/social/public/src/lib/heartAnim.mjs
@@ -1,0 +1,44 @@
+/**
+ * 媒体区飘心 / 点赞反馈动画。
+ * @param {HTMLElement} host 宿主
+ * @param {object} [options] 选项
+ * @param {string} [options.emoji='👍'] 表情
+ * @param {number} [options.durationMs=800] 动画毫秒
+ * @param {string} [options.selector='.heart-anim'] 已有节点选择器
+ * @param {boolean} [options.createIfMissing=false] 无节点时是否创建
+ * @param {string} [options.createClass='heart-anim'] 新建 class
+ * @param {'reuse' | 'spawn'} [options.mode='reuse'] reuse 播放已有节点；spawn 临时节点后移除
+ * @returns {void}
+ */
+export function playHeartAnim(host, {
+	emoji = '👍',
+	durationMs = 800,
+	selector = '.heart-anim',
+	createIfMissing = false,
+	createClass = 'heart-anim',
+	mode = 'reuse',
+} = {}) {
+	if (mode === 'spawn') {
+		const heart = document.createElement('div')
+		heart.className = createClass
+		heart.textContent = emoji
+		heart.style.cssText = `position:absolute;left:50%;bottom:2rem;animation:heartFloat ${durationMs / 1000}s ease-out forwards;pointer-events:none;`
+		host.appendChild(heart)
+		setTimeout(() => heart.remove(), durationMs + 100)
+		return
+	}
+	let anim = host.querySelector(selector)
+	if (!(anim instanceof HTMLElement)) {
+		if (!createIfMissing) return
+		anim = document.createElement('div')
+		anim.className = createClass
+		anim.setAttribute('aria-hidden', 'true')
+		host.appendChild(anim)
+	}
+	anim.classList.remove('hidden')
+	anim.textContent = emoji
+	anim.style.animation = 'none'
+	void anim.offsetWidth
+	anim.style.animation = `heartFloat ${durationMs / 1000}s ease-out forwards`
+	setTimeout(() => anim.classList.add('hidden'), durationMs + 100)
+}

--- a/src/public/parts/shells/social/public/src/lib/pollUi.mjs
+++ b/src/public/parts/shells/social/public/src/lib/pollUi.mjs
@@ -1,0 +1,58 @@
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+import { socialApi } from './apiClient.mjs'
+
+/**
+ * @param {object} poll poll 态
+ * @param {string} actionKey 帖子 action key
+ * @returns {string} poll HTML
+ */
+export function renderPollHtml(poll, actionKey) {
+	if (!poll?.options?.length) return ''
+	const [entityHash, postId] = actionKey.split(':')
+	const closed = poll.closed === true
+	const tally = poll.tally || {}
+	const total = Object.values(tally).reduce((sum, n) => sum + Number(n), 0) || 0
+	const viewerChoices = new Set(poll.viewerChoices || [])
+	const optionsHtml = poll.options.map((label, index) => {
+		const count = Number(tally[String(index)] || 0)
+		const pct = total ? Math.round((count / total) * 100) : 0
+		const selected = viewerChoices.has(index) ? ' poll-option-selected' : ''
+		const disabled = closed || poll.viewerChoices?.length ? ' disabled' : ''
+		return `<button type="button" class="poll-option${selected}" data-poll-vote="${escapeHtml(actionKey)}" data-poll-choice="${index}"${disabled}>
+			<span class="poll-option-label">${escapeHtml(label)}</span>
+			<span class="poll-option-bar"><span class="poll-option-fill" style="width:${pct}%"></span></span>
+			<span class="poll-option-meta">${count}${total ? ` (${pct}%)` : ''}</span>
+		</button>`
+	}).join('')
+	const status = closed
+		? '<span data-i18n="social.poll.closed"></span>'
+		: poll.deadline
+			? `<span data-i18n="social.poll.deadline" data-deadline="${escapeHtml(poll.deadline)}"></span>`
+			: ''
+	return `<div class="post-poll" data-poll-for="${escapeHtml(actionKey)}">
+		<div class="post-poll-status">${status}</div>
+		<div class="poll-options">${optionsHtml}</div>
+	</div>`
+}
+
+/**
+ * @param {HTMLElement} target 点击目标
+ * @returns {Promise<boolean>} 是否已处理
+ */
+export async function handlePollVoteClick(target) {
+	const button = target.closest('[data-poll-vote]')
+	if (!(button instanceof HTMLElement) || button.disabled) return false
+	const actionKey = button.dataset.pollVote
+	const choice = Number(button.dataset.pollChoice)
+	if (!actionKey || !Number.isInteger(choice)) return false
+	const [entityHash, postId] = actionKey.split(':')
+	if (!entityHash || !postId) return false
+	await socialApi(`/posts/${encodeURIComponent(entityHash)}/${encodeURIComponent(postId)}/poll-vote`, {
+		method: 'POST',
+		body: JSON.stringify({ choices: [choice] }),
+	})
+	const { refreshVisiblePosts } = await import('../navigation.mjs')
+	await refreshVisiblePosts()
+	return true
+}

--- a/src/public/parts/shells/social/public/src/lib/profileHover.mjs
+++ b/src/public/parts/shells/social/public/src/lib/profileHover.mjs
@@ -1,0 +1,57 @@
+/**
+ * Social 作者名/头像悬停：复用 chat 共享人物卡（含 tags）。
+ */
+import { isEntityHash128 } from '/parts/shells:chat/shared/entityHash.mjs'
+import { wireEntityProfileHover } from '/parts/shells:chat/shared/entityProfileHoverCard.mjs'
+
+import { state } from '../state.mjs'
+
+import { viewerEntityHash } from './apiClient.mjs'
+
+const PROFILE_HOVER_SELECTOR = [
+	'a.author-name',
+	'a.author-avatar-link',
+	'a.reply-avatar-link',
+	'a.author-handle',
+	'a.suggested-account-name',
+	'a.explore-account-avatar-link',
+].join(', ')
+
+/**
+ * 从 Social profile 链接解析 entityHash。
+ * @param {string} href 链接
+ * @returns {string | null} 128 hex 或 null
+ */
+export function entityHashFromProfileHref(href) {
+	try {
+		const url = new URL(String(href || ''), location.origin)
+		const hash = url.hash.replace(/^#/, '')
+		const match = /^profile;([0-9a-f]{128})/i.exec(hash)
+		return match ? match[1].toLowerCase() : null
+	}
+	catch {
+		return null
+	}
+}
+
+/**
+ * 注册 feed / replies / explore 等作者锚点的悬停资料卡。
+ * @returns {void}
+ */
+export function wireSocialProfileHover() {
+	wireEntityProfileHover(PROFILE_HOVER_SELECTOR, (el) => {
+		const entityHash = entityHashFromProfileHref(el.getAttribute('href') || '')
+		if (!isEntityHash128(entityHash)) return null
+		const label = el.textContent?.trim()
+		return {
+			cacheKey: entityHash,
+			entityHash,
+			displayName: label && label !== '@' ? label : undefined,
+			paintOptions: {
+				selfEntityHash: viewerEntityHash(),
+				nodeHash: state.viewerNodeHash,
+				viewerOwnerEntityHash: state.viewerProfile?.ownerEntityHash,
+			},
+		}
+	})
+}

--- a/src/public/parts/shells/social/public/src/lib/replies.mjs
+++ b/src/public/parts/shells/social/public/src/lib/replies.mjs
@@ -1,0 +1,21 @@
+import { socialApi } from './apiClient.mjs'
+import { primaryLocale } from '/scripts/i18n/index.mjs'
+
+/**
+ * 提交对指定帖子的公开回复。
+ * @param {string} entityHash 目标作者
+ * @param {string} postId 帖子
+ * @param {string} text 回复正文
+ * @returns {Promise<void>}
+ */
+export async function submitReply(entityHash, postId, text) {
+	await socialApi('/posts', {
+		method: 'POST',
+		body: JSON.stringify({
+			text,
+			replyTo: { entityHash, postId },
+			visibility: 'public',
+			locale: document.getElementById('postLocale')?.value.trim() || primaryLocale(),
+		}),
+	})
+}

--- a/src/public/parts/shells/social/public/src/lib/snapCursorFeed.mjs
+++ b/src/public/parts/shells/social/public/src/lib/snapCursorFeed.mjs
@@ -1,0 +1,89 @@
+/**
+ * 竖滑 feed 的 cursor 分页 + 循环重放状态机（video / live 共用）。
+ */
+
+/**
+ * @param {object} options 选项
+ * @param {(cursor: string | null) => Promise<{ items?: object[], nextCursor?: string | null } | null>} options.fetchPage 拉取一页
+ * @param {(container: HTMLElement, items: object[]) => void} options.appendSlides 追加 slides
+ * @param {(container: HTMLElement, index: number) => boolean} [options.canReplay] 无 cursor 时是否允许循环重放
+ * @param {() => boolean} [options.shouldSkip] 跳过加载（如 nearby 大厅）
+ * @returns {{
+ *   reset: () => void,
+ *   seed: (items: object[], nextCursor: string | null) => void,
+ *   getShownItems: () => object[],
+ *   maybeLoadMore: (container: HTMLElement, index: number) => Promise<void>,
+ * }} 分页控制器
+ */
+export function createSnapCursorFeed({ fetchPage, appendSlides, canReplay, shouldSkip }) {
+	/** @type {string | null} */
+	let cursor = null
+	/** @type {object[]} */
+	let shownItems = []
+	let pageLoading = false
+
+	return {
+		/** @returns {void} */
+		reset() {
+			cursor = null
+			shownItems = []
+			pageLoading = false
+		},
+		/**
+		 * @param {object[]} items 首屏条目
+		 * @param {string | null} nextCursor 下一页游标
+		 * @returns {void}
+		 */
+		seed(items, nextCursor) {
+			shownItems = [...items]
+			cursor = nextCursor || null
+		},
+		/**
+		 * @param {HTMLElement} container 容器
+		 * @param {object[]} items 条目
+		 * @returns {void}
+		 */
+		append(container, items) {
+			appendSlides(container, items)
+		},
+		/** @returns {object[]} 已展示条目 */
+		getShownItems: () => shownItems,
+		/**
+		 * @param {HTMLElement} container snap 容器
+		 * @param {number} index 当前索引
+		 * @returns {Promise<void>}
+		 */
+		async maybeLoadMore(container, index) {
+			if (pageLoading || shouldSkip?.()) return
+			if (container.children.length - index - 1 > 2) return
+
+			if (cursor) {
+				pageLoading = true
+				try {
+					const data = await fetchPage(cursor)
+					if (!data) return
+					const items = data.items || []
+					cursor = data.nextCursor || null
+					if (items.length) {
+						shownItems.push(...items)
+						appendSlides(container, items)
+					}
+				}
+				finally {
+					pageLoading = false
+				}
+				return
+			}
+
+			if (!shownItems.length) return
+			if (canReplay && !canReplay(container, index)) return
+			pageLoading = true
+			try {
+				appendSlides(container, shownItems)
+			}
+			finally {
+				pageLoading = false
+			}
+		},
+	}
+}

--- a/src/public/parts/shells/social/public/src/lib/socialWrite.mjs
+++ b/src/public/parts/shells/social/public/src/lib/socialWrite.mjs
@@ -1,0 +1,207 @@
+import { showToastI18n } from '../../../../../scripts/features/toast.mjs'
+
+/**
+ * 执行写操作并在失败时 toast。
+ * @param {string} actionKey i18n 后缀（social.actions.{actionKey}Failed）
+ * @param {() => Promise<void>} fn 写操作
+ * @returns {Promise<void>}
+ */
+export async function runWrite(actionKey, fn) {
+	try {
+		await fn()
+	}
+	catch (error) {
+		const err = error instanceof Error ? error : new Error(String(error))
+		showToastI18n('error', `social.actions.${actionKey}Failed`, { error: err.message })
+		throw error
+	}
+}
+
+/**
+ * @param {HTMLElement} button 按钮
+ * @param {string} key dataset 键 liked|disliked
+ * @param {string} className 激活 class
+ * @param {boolean} next 目标状态
+ * @returns {{ [key: string]: string | number }} 回滚快照
+ */
+function applyReactionOptimistic(button, key, className, next) {
+	const countEl = button.querySelector('.action-count')
+	const snapshot = { [key]: button.dataset[key] || '0', count: Number(countEl?.textContent) || 0 }
+	button.dataset[key] = next ? '1' : '0'
+	button.classList.toggle(className, next)
+	if (countEl) countEl.textContent = String(Math.max(0, /** @type {number} */ snapshot.count + (next ? 1 : -1)))
+	return snapshot
+}
+
+/**
+ * @param {HTMLElement} button 按钮
+ * @param {string} key dataset 键
+ * @param {string} className 激活 class
+ * @param {{ [key: string]: string | number }} snapshot 回滚快照
+ * @returns {void}
+ */
+function rollbackReaction(button, key, className, snapshot) {
+	const countEl = button.querySelector('.action-count')
+	button.dataset[key] = String(snapshot[key])
+	button.classList.toggle(className, snapshot[key] === '1')
+	if (countEl) countEl.textContent = String(snapshot.count)
+}
+
+/**
+ * @param {HTMLElement} cardRoot 帖卡
+ * @param {string} selector 按钮选择器
+ * @param {string} key dataset 键
+ * @param {string} className 激活 class
+ * @returns {void}
+ */
+function clearReactionOnCard(cardRoot, selector, key, className) {
+	const button = cardRoot.querySelector(selector)
+	if (!(button instanceof HTMLElement) || button.dataset[key] !== '1') return
+	const countEl = button.querySelector('.action-count')
+	button.dataset[key] = '0'
+	button.classList.remove(className)
+	if (countEl) countEl.textContent = String(Math.max(0, (Number(countEl.textContent) || 0) - 1))
+}
+
+/**
+ * @param {HTMLElement} button like 按钮
+ * @param {boolean} liked 目标 liked 状态
+ * @returns {{ liked: string, count: number }} 回滚快照
+ */
+export function applyLikeButtonOptimistic(button, liked) {
+	return /** @type {{ liked: string, count: number }} */ applyReactionOptimistic(button, 'liked', 'liked', liked)
+}
+
+/**
+ * @param {HTMLElement} button like 按钮
+ * @param {{ liked: string, count: number }} snapshot 回滚快照
+ * @returns {void}
+ */
+export function rollbackLikeButton(button, snapshot) {
+	rollbackReaction(button, 'liked', 'liked', snapshot)
+}
+
+/**
+ * @param {HTMLElement} button dislike 按钮
+ * @param {boolean} disliked 目标 disliked 状态
+ * @returns {{ disliked: string, count: number }} 回滚快照
+ */
+export function applyDislikeButtonOptimistic(button, disliked) {
+	return /** @type {{ disliked: string, count: number }} */ applyReactionOptimistic(button, 'disliked', 'disliked', disliked)
+}
+
+/**
+ * @param {HTMLElement} button dislike 按钮
+ * @param {{ disliked: string, count: number }} snapshot 回滚快照
+ * @returns {void}
+ */
+export function rollbackDislikeButton(button, snapshot) {
+	rollbackReaction(button, 'disliked', 'disliked', snapshot)
+}
+
+/**
+ * @param {HTMLElement} cardRoot 帖卡
+ * @returns {void}
+ */
+export function clearLikeOnCard(cardRoot) {
+	clearReactionOnCard(cardRoot, '[data-like]', 'liked', 'liked')
+}
+
+/**
+ * @param {HTMLElement} cardRoot 帖卡
+ * @returns {void}
+ */
+export function clearDislikeOnCard(cardRoot) {
+	clearReactionOnCard(cardRoot, '[data-dislike]', 'disliked', 'disliked')
+}
+
+/**
+ * @param {HTMLElement} cardRoot 帖子卡根节点
+ * @param {number} delta repost 计数增量
+ * @returns {number} 原计数
+ */
+export function bumpRepostCount(cardRoot, delta) {
+	const repostBtn = cardRoot.querySelector('[data-repost] .action-count')
+	if (!repostBtn) return 0
+	const prev = Number(repostBtn.textContent) || 0
+	repostBtn.textContent = String(Math.max(0, prev + delta))
+	return prev
+}
+
+/**
+ * 从 feed 循环重放源剔除指定帖子。
+ * @param {{ feedShownItems?: object[] | null }} state 应用 state
+ * @param {string} postId 帖子 id
+ * @returns {object[]} 被剔除的条目（用于回滚）
+ */
+export function purgeFeedShownPost(state, postId) {
+	const id = String(postId || '')
+	if (!state.feedShownItems?.length || !id) return []
+	const kept = []
+	const removed = []
+	for (const item of state.feedShownItems)
+		if (item.postId === id) removed.push(item)
+		else kept.push(item)
+	state.feedShownItems = kept.length ? kept : null
+	return removed
+}
+
+/**
+ * 从 feed 循环重放源剔除指定作者的帖子。
+ * @param {{ feedShownItems?: object[] | null }} state 应用 state
+ * @param {string} entityHash 作者 entityHash
+ * @returns {object[]} 被剔除的条目（用于回滚）
+ */
+export function purgeFeedShownAuthor(state, entityHash) {
+	const norm = String(entityHash || '').trim().toLowerCase()
+	if (!state.feedShownItems?.length || !norm) return []
+	const kept = []
+	const removed = []
+	for (const item of state.feedShownItems)
+		if (String(item.entityHash || '').trim().toLowerCase() === norm) removed.push(item)
+		else kept.push(item)
+	state.feedShownItems = kept.length ? kept : null
+	return removed
+}
+
+/**
+ * 把 purge 掉的条目塞回 feedShownItems。
+ * @param {{ feedShownItems?: object[] | null }} state 应用 state
+ * @param {object[]} items 先前剔除的条目
+ * @returns {void}
+ */
+export function restoreFeedShownItems(state, items) {
+	if (!items?.length) return
+	state.feedShownItems = [...state.feedShownItems || [], ...items]
+}
+
+/**
+ * 乐观移除指定作者的全部帖子卡片。
+ * @param {string} entityHash 作者 entityHash
+ * @returns {HTMLElement[]} 被移除的节点（用于回滚）
+ */
+export function removePostsByAuthor(entityHash) {
+	const norm = String(entityHash || '').trim().toLowerCase()
+	/** @type {HTMLElement[]} */
+	const removed = []
+	for (const card of document.querySelectorAll('.post-card[data-author-entity]')) {
+		if (!(card instanceof HTMLElement)) continue
+		if (String(card.dataset.authorEntity || '').trim().toLowerCase() !== norm) continue
+		removed.push(card)
+		card.remove()
+	}
+	return removed
+}
+
+/**
+ * 回滚 removePostsByAuthor 移除的卡片。
+ * @param {HTMLElement[]} cards 被移除的卡片
+ * @param {HTMLElement | null} anchor 插入锚点（缺省追加到 feedList）
+ * @returns {void}
+ */
+export function restoreRemovedPosts(cards, anchor = null) {
+	const list = anchor || document.getElementById('feedList') || document.getElementById('profilePostsPanel')
+	if (!list) return
+	for (const card of cards)
+		list.appendChild(card)
+}

--- a/src/public/parts/shells/social/public/src/lib/suggestedAccounts.mjs
+++ b/src/public/parts/shells/social/public/src/lib/suggestedAccounts.mjs
@@ -1,0 +1,23 @@
+import { formatSocialProfileHref } from '../../shared/runUri.mjs'
+
+import { entityHandle, renderAvatarHtml } from './display.mjs'
+import { appendTemplate } from '/scripts/features/template.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+/**
+ * 渲染推荐关注行到容器（feed / explore 侧栏共用）。
+ * @param {HTMLElement} list 列表容器
+ * @param {object[]} accounts 账户行
+ * @returns {Promise<void>}
+ */
+export async function renderSuggestedAccountRows(list, accounts) {
+	list.replaceChildren()
+	for (const account of accounts)
+		await appendTemplate(list, 'explore_suggested', {
+			profileHref: escapeHtml(formatSocialProfileHref(account.entityHash)),
+			entityHash: escapeHtml(account.entityHash),
+			name: escapeHtml(account.name),
+			handle: escapeHtml(entityHandle(account.entityHash, account)),
+			avatarHtml: renderAvatarHtml(account.entityHash, { name: account.name }),
+		})
+}

--- a/src/public/parts/shells/social/public/src/lib/verticalSnap.mjs
+++ b/src/public/parts/shells/social/public/src/lib/verticalSnap.mjs
@@ -1,0 +1,36 @@
+/**
+ * 竖向全屏 scroll-snap 容器绑定工具。
+ */
+
+/**
+ * @param {HTMLElement} container snap 容器
+ * @param {object} [options] 回调选项
+ * @param {(index: number, el: HTMLElement) => void} [options.onEnter] 进入回调（可见度 ≥ 60%）
+ * @param {(index: number, el: HTMLElement) => void} [options.onLeave] 离开回调
+ * @returns {{ disconnect: () => void, observe: (el: HTMLElement) => void }} 观察控制
+ */
+export function bindVerticalSnap(container, { onEnter, onLeave } = {}) {
+	const observer = new IntersectionObserver(entries => {
+		for (const entry of entries) {
+			const el = entry.target
+			const index = [...container.children].indexOf(el)
+			if (entry.isIntersecting)
+				onEnter?.(index, el)
+			else
+				onLeave?.(index, el)
+		}
+	}, { root: container, threshold: 0.6 })
+
+	for (const child of container.children)
+		observer.observe(child)
+
+	return {
+		/** @returns {void} */
+		disconnect: () => observer.disconnect(),
+		/**
+		 * @param {HTMLElement} el 新 slide
+		 * @returns {void}
+		 */
+		observe: el => observer.observe(el),
+	}
+}

--- a/src/public/parts/shells/social/public/src/lib/videoAutoplay.mjs
+++ b/src/public/parts/shells/social/public/src/lib/videoAutoplay.mjs
@@ -1,0 +1,74 @@
+/**
+ * Feed / 详情帖内视频：进入视野静音循环播放，离开暂停。
+ */
+
+/** @type {IntersectionObserver | null} */
+let feedVideoObserver = null
+
+/**
+ * @returns {IntersectionObserver} 共享 IO
+ */
+function getFeedVideoObserver() {
+	if (feedVideoObserver) return feedVideoObserver
+	feedVideoObserver = new IntersectionObserver(entries => {
+		for (const entry of entries) {
+			const video = entry.target
+			if (!(video instanceof HTMLVideoElement)) continue
+			if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+				if (video.closest('[data-cw-collapsed="1"], [data-sensitive-collapsed="1"]')) continue
+				video.muted = true
+				video.play().catch(() => {})
+			}
+			else
+				video.pause()
+		}
+	}, { threshold: [0, 0.5, 0.75] })
+	return feedVideoObserver
+}
+
+/**
+ * 观察容器内帖子视频（可重复调用，幂等观察）。
+ * @param {ParentNode | null | undefined} root 容器
+ * @returns {void}
+ */
+export function bindFeedVideoAutoplay(root) {
+	if (!root) return
+	const observer = getFeedVideoObserver()
+	for (const video of root.querySelectorAll('video.post-media-video')) {
+		if (!(video instanceof HTMLVideoElement)) continue
+		video.muted = true
+		video.loop = true
+		video.playsInline = true
+		observer.observe(video)
+	}
+}
+
+/**
+ * 对刚展开的 CW / 敏感遮罩内视频立即播放。
+ * @param {Element | null | undefined} wrap 展开后的 wrap
+ * @returns {void}
+ */
+export function playRevealedPostVideos(wrap) {
+	if (!(wrap instanceof Element)) return
+	for (const video of wrap.querySelectorAll('video.post-media-video')) {
+		if (!(video instanceof HTMLVideoElement)) continue
+		video.muted = true
+		video.loop = true
+		video.playsInline = true
+		getFeedVideoObserver().observe(video)
+		video.play().catch(() => {})
+	}
+}
+
+/**
+ * 暂停页面上所有帖子/短视频播放器。
+ * @param {ParentNode | null | undefined} [scope=document] 作用域
+ * @returns {void}
+ */
+export function pauseAllVideos(scope = document) {
+	if (!scope) return
+	for (const video of scope.querySelectorAll('video.post-media-video, video.video-player')) 
+		if (video instanceof HTMLVideoElement)
+			video.pause()
+	
+}

--- a/src/public/parts/shells/social/public/src/media.mjs
+++ b/src/public/parts/shells/social/public/src/media.mjs
@@ -1,0 +1,33 @@
+/**
+ * Social 媒体附件：EVFS 存储（中立层上传）。
+ */
+import { uploadEvfsAttachment } from '/parts/shells:chat/shared/evfsMedia.mjs'
+
+const SOCIAL_ATTACHMENT_PREFIX = 'shells/social/attachments'
+
+/**
+ * 上传本地媒体文件并返回 mediaRefs 条目。
+ * @param {FileList | File[]} files 本地文件
+ * @returns {Promise<object[]>} mediaRefs 条目
+ */
+export async function uploadMedia(files) {
+	/** @type {object[]} */
+	const refs = []
+	for (const file of files) {
+		const uploaded = await uploadEvfsAttachment(file, SOCIAL_ATTACHMENT_PREFIX)
+		const kind = file.type.startsWith('image/')
+			? 'image'
+			: file.type.startsWith('video/')
+				? 'video'
+				: 'file'
+		refs.push({
+			entityHash: uploaded.entityHash,
+			path: uploaded.path,
+			url: uploaded.url,
+			kind,
+			name: file.name,
+			mimeType: file.type || 'application/octet-stream',
+		})
+	}
+	return refs
+}

--- a/src/public/parts/shells/social/public/src/mediaRender.mjs
+++ b/src/public/parts/shells/social/public/src/mediaRender.mjs
@@ -1,0 +1,254 @@
+/**
+ * Social 媒体渲染（与上传解耦）：轮播、alt、敏感遮罩、lightbox。
+ */
+import { wrapSensitiveMediaHtml } from '/scripts/features/contentReveal/index.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { mediaRefUrl } from '/parts/shells:chat/shared/evfsMedia.mjs'
+
+/**
+ * @param {object} ref 媒体引用
+ * @param {number} index 序号
+ * @returns {string} 单项 HTML；非法 url 返回空串
+ */
+function renderMediaItem(ref, index) {
+	let url
+	try {
+		url = mediaRefUrl(ref)
+	}
+	catch {
+		return ''
+	}
+	const mimeType = ref.mimeType || ''
+	const kind = ref.kind || (mimeType.startsWith('video/') ? 'video' : 'image')
+	const alt = escapeHtml(String(ref.alt || ref.name || ''))
+	if (kind === 'image')
+		return `<button type="button" class="post-media-slide" data-media-index="${index}" data-media-lightbox="${escapeHtml(url)}" data-media-alt="${alt}">
+			<img src="${escapeHtml(url)}" alt="${alt}" loading="lazy" class="post-media-item" />
+		</button>`
+	if (kind === 'video')
+		return `<div class="post-media-slide" data-media-index="${index}" data-media-video>
+			<video src="${escapeHtml(url)}" muted loop playsinline preload="metadata" class="post-media-item post-media-video"></video>
+		</div>`
+	return `<a href="${escapeHtml(url)}" class="post-media-slide post-media-file link-btn" download>${escapeHtml(ref.name || 'file')}</a>`
+}
+
+/**
+ * 将 mediaRefs 渲染为帖子内嵌媒体 HTML（多图横向轮播）。
+ * @param {object[] | string[]} mediaRefs 媒体引用
+ * @param {{ sensitive?: boolean, warningLabel?: string, revealLabel?: string, warningI18n?: string, revealI18n?: string }} [options] 敏感遮罩选项
+ * @returns {string} HTML
+ */
+export function renderMediaHtml(mediaRefs, options = {}) {
+	if (!mediaRefs?.length) return ''
+	const rendered = mediaRefs.map((ref, index) => renderMediaItem(ref, index)).filter(Boolean)
+	if (!rendered.length) return ''
+	const items = rendered.join('')
+	const dots = rendered.length > 1
+		? `<div class="post-media-dots" aria-hidden="true">${rendered.map((_, index) =>
+			`<span class="post-media-dot${index === 0 ? ' active' : ''}" data-media-dot="${index}"></span>`).join('')}</div>`
+		: ''
+	const nav = rendered.length > 1
+		? `<button type="button" class="post-media-nav post-media-prev" data-media-nav="-1" aria-label="prev">‹</button>
+			<button type="button" class="post-media-nav post-media-next" data-media-nav="1" aria-label="next">›</button>`
+		: ''
+	let html = `<div class="post-media ${rendered.length > 1 ? 'post-media-carousel' : ''}" data-media-count="${rendered.length}">
+		<div class="post-media-track">${items}</div>
+		${nav}
+		${dots}
+	</div>`
+	if (options.sensitive)
+		html = wrapSensitiveMediaHtml(html, {
+			warningLabel: options.warningLabel || '',
+			revealLabel: options.revealLabel || 'Reveal',
+			warningI18n: options.warningI18n,
+			revealI18n: options.revealI18n,
+		})
+	return html
+}
+
+/**
+ * 绑定轮播轨道滚动与圆点同步（委托事件可重复调用，幂等靠 closest）。
+ * @param {HTMLElement} root 卡片或 feed 根
+ * @returns {void}
+ */
+export function bindMediaCarousel(root) {
+	if (!(root instanceof HTMLElement) || root.dataset.mediaCarouselBound === '1') return
+	root.dataset.mediaCarouselBound = '1'
+	root.addEventListener('click', event => {
+		const nav = event.target instanceof Element ? event.target.closest('[data-media-nav]') : null
+		if (nav instanceof HTMLElement) {
+			const carousel = nav.closest('.post-media-carousel')
+			const track = carousel?.querySelector('.post-media-track')
+			if (!(track instanceof HTMLElement)) return
+			const delta = Number(nav.dataset.mediaNav) || 0
+			const width = track.clientWidth || 1
+			track.scrollBy({ left: delta * width, behavior: 'smooth' })
+			return
+		}
+		const videoSlide = event.target instanceof Element ? event.target.closest('[data-media-video]') : null
+		if (videoSlide instanceof HTMLElement) {
+			if (videoSlide.closest('.post-detail-card')) return
+			const media = videoSlide.closest('.post-media')
+			const card = videoSlide.closest('.post-card')
+			const entityHash = media?.dataset.mediaEntity || card?.dataset.mediaEntity || card?.dataset.authorEntity
+			const postId = media?.dataset.mediaPostId || card?.dataset.mediaPostId || card?.dataset.postId
+			if (entityHash && postId) {
+				event.preventDefault()
+				event.stopPropagation()
+				location.hash = `videos;${entityHash};${postId}`
+			}
+			return
+		}
+		const lightboxBtn = event.target instanceof Element ? event.target.closest('[data-media-lightbox]') : null
+		if (lightboxBtn instanceof HTMLElement && lightboxBtn.dataset.mediaLightbox)
+			openMediaLightbox(lightboxBtn.closest('.post-media'), Number(lightboxBtn.dataset.mediaIndex) || 0)
+	})
+	root.addEventListener('scroll', event => {
+		const track = event.target
+		if (!(track instanceof HTMLElement) || !track.classList.contains('post-media-track')) return
+		const carousel = track.closest('.post-media')
+		if (!carousel) return
+		const width = track.clientWidth || 1
+		const index = Math.round(track.scrollLeft / width)
+		for (const dot of carousel.querySelectorAll('.post-media-dot'))
+			dot.classList.toggle('active', Number(dot.dataset.mediaDot) === index)
+	}, true)
+}
+
+/**
+ * @param {Element | null} mediaRoot 媒体根
+ * @param {number} startIndex 起始索引
+ * @returns {void}
+ */
+export function openMediaLightbox(mediaRoot, startIndex = 0) {
+	if (!(mediaRoot instanceof HTMLElement)) return
+	const slides = [...mediaRoot.querySelectorAll('[data-media-lightbox]')]
+	if (!slides.length) return
+	let index = Math.max(0, Math.min(startIndex, slides.length - 1))
+	const dialog = document.createElement('dialog')
+	dialog.className = 'modal media-lightbox-modal'
+	dialog.innerHTML = `
+		<div class="modal-box media-lightbox-box">
+			<button type="button" class="btn btn-sm btn-circle btn-ghost media-lightbox-close" data-lightbox-close aria-label="close">✕</button>
+			<img class="media-lightbox-img" alt="" />
+			<p class="media-lightbox-alt"></p>
+			<div class="media-lightbox-nav">
+				<button type="button" class="btn btn-ghost" data-lightbox-nav="-1">‹</button>
+				<span class="media-lightbox-counter"></span>
+				<button type="button" class="btn btn-ghost" data-lightbox-nav="1">›</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop"><button>close</button></form>
+	`
+	document.body.appendChild(dialog)
+	const img = dialog.querySelector('.media-lightbox-img')
+	const altEl = dialog.querySelector('.media-lightbox-alt')
+	const counter = dialog.querySelector('.media-lightbox-counter')
+	/**
+	 * @returns {void}
+	 */
+	function paint() {
+		const slide = slides[index]
+		const url = slide.dataset.mediaLightbox || ''
+		const alt = slide.dataset.mediaAlt || ''
+		if (img instanceof HTMLImageElement) {
+			img.src = url
+			img.alt = alt
+		}
+		if (altEl) altEl.textContent = alt
+		if (counter) counter.textContent = `${index + 1} / ${slides.length}`
+	}
+	paint()
+	dialog.addEventListener('click', event => {
+		const close = event.target instanceof Element ? event.target.closest('[data-lightbox-close]') : null
+		if (close) {
+			dialog.close()
+			return
+		}
+		const nav = event.target instanceof Element ? event.target.closest('[data-lightbox-nav]') : null
+		if (!(nav instanceof HTMLElement)) return
+		index = (index + Number(nav.dataset.lightboxNav || 0) + slides.length) % slides.length
+		paint()
+	})
+	dialog.addEventListener('keydown', event => {
+		if (event.key === 'ArrowLeft') {
+			index = (index - 1 + slides.length) % slides.length
+			paint()
+		}
+		else if (event.key === 'ArrowRight') {
+			index = (index + 1) % slides.length
+			paint()
+		}
+	})
+	dialog.addEventListener('close', () => dialog.remove(), { once: true })
+	dialog.showModal()
+}
+
+/**
+ * 渲染 composer 待发布媒体预览区（含 alt 输入与图片编辑入口）。
+ * @param {HTMLElement} container 预览区
+ * @param {object[]} refs 待发布媒体
+ * @param {() => void} onChange 变更回调
+ * @param {{ onEditImage?: (index: number, ref: object) => void | Promise<void>, editLabel?: string }} [options] 选项
+ * @returns {void}
+ */
+export function renderMediaPreview(container, refs, onChange, options = {}) {
+	container.innerHTML = ''
+	if (!refs.length) {
+		container.classList.add('hidden')
+		return
+	}
+	container.classList.remove('hidden')
+	for (const [index, ref] of refs.entries()) {
+		const chip = document.createElement('div')
+		chip.className = 'media-chip media-chip-editable'
+		const url = ref.objectUrl || mediaRefUrl(ref)
+		if (ref.kind === 'image') {
+			const img = document.createElement('img')
+			img.src = url
+			img.alt = ref.alt || ref.name || ''
+			chip.appendChild(img)
+			if (options.onEditImage) {
+				const edit = document.createElement('button')
+				edit.type = 'button'
+				edit.className = 'media-chip-edit'
+				edit.textContent = options.editLabel || 'Edit'
+				edit.addEventListener('click', () => {
+					void options.onEditImage?.(index, ref)
+				})
+				chip.appendChild(edit)
+			}
+		}
+		else if (ref.kind === 'video') {
+			const video = document.createElement('video')
+			video.src = url
+			video.muted = true
+			chip.appendChild(video)
+		}
+		else
+			chip.textContent = ref.name || ref.path?.split('/').pop() || 'file'
+
+		const altInput = document.createElement('input')
+		altInput.type = 'text'
+		altInput.className = 'media-chip-alt input input-bordered input-xs'
+		altInput.maxLength = 1500
+		altInput.dataset.i18n = 'social.composer.media'
+		altInput.value = ref.alt || ''
+		altInput.addEventListener('input', () => {
+			ref.alt = altInput.value.trim()
+		})
+		chip.appendChild(altInput)
+
+		const remove = document.createElement('button')
+		remove.type = 'button'
+		remove.className = 'media-chip-remove'
+		remove.textContent = '×'
+		remove.addEventListener('click', () => {
+			if (ref.objectUrl) URL.revokeObjectURL(ref.objectUrl)
+			refs.splice(index, 1)
+			onChange()
+		})
+		chip.appendChild(remove)
+		container.appendChild(chip)
+	}
+}

--- a/src/public/parts/shells/social/public/src/mentionAutocomplete.mjs
+++ b/src/public/parts/shells/social/public/src/mentionAutocomplete.mjs
@@ -1,0 +1,176 @@
+/**
+ * @ 提及 autocomplete（输入 @ 后弹出候选）。
+ */
+
+import { formatEntityMentionToken } from '/parts/shells:chat/shared/inlineTokenSyntax.mjs'
+import { aliasForEntity } from '/parts/shells:chat/shared/aliases.mjs'
+import { formatEntityAtId, formatHashShort } from '/parts/shells:chat/shared/entityHash.mjs'
+import { sanitizePermissiveHtml } from '/scripts/lib/sanitizeHtml.mjs'
+
+const API = '/api/parts/shells:social/mentions/suggest'
+
+/**
+ * 为发帖框挂载 @ 提及 autocomplete。
+ * @param {HTMLTextAreaElement} textarea 发帖框
+ * @returns {() => void} 卸载监听
+ */
+export function attachMentionAutocomplete(textarea) {
+	const panel = document.createElement('div')
+	panel.className = 'mention-panel hidden'
+	panel.setAttribute('role', 'listbox')
+	textarea.parentElement?.appendChild(panel)
+
+	/** @type {object[]} */
+	let suggestions = []
+	let activeIndex = 0
+	/** @type {{ start: number, end: number } | null} */
+	let mentionRange = null
+
+	/**
+	 * 隐藏 @ 提及候选面板并重置状态。
+	 * @returns {void}
+	 */
+	function hide() {
+		panel.classList.add('hidden')
+		panel.innerHTML = ''
+		suggestions = []
+		mentionRange = null
+	}
+
+	/**
+	 * 渲染 @ 提及候选列表。
+	 * @param {object[]} rows 候选
+	 * @returns {void}
+	 */
+	function render(rows) {
+		suggestions = rows
+		activeIndex = 0
+		panel.innerHTML = ''
+		if (!rows.length) {
+			hide()
+			return
+		}
+		for (const [index, row] of rows.entries()) {
+			const button = document.createElement('button')
+			button.type = 'button'
+			button.className = `mention-option${index === 0 ? ' active' : ''}`
+			button.dataset.index = String(index)
+			button.innerHTML = `
+				<strong>${sanitizePermissiveHtml(aliasForEntity(row.entityHash) || row.displayName || formatHashShort(row.entityHash, { headLen: 8, tailLen: 0, ellipsis: false }))}</strong>
+				<small>${sanitizePermissiveHtml(formatEntityAtId(row.entityHash, { handle: row.handle }))}</small>
+			`
+			panel.appendChild(button)
+		}
+		panel.classList.remove('hidden')
+	}
+
+	/**
+	 * 从 API 拉取 @ 提及候选。
+	 * @param {string} query 过滤词
+	 * @returns {Promise<void>}
+	 */
+	async function fetchSuggestions(query) {
+		const response = await fetch(`${API}?q=${encodeURIComponent(query)}&limit=12`, { credentials: 'include' })
+		if (!response.ok) {
+			hide()
+			return
+		}
+		const data = await response.json()
+		render(data.suggestions || [])
+	}
+
+	/**
+	 * 解析光标处正在输入的 @ 片段。
+	 * @returns {{ query: string, start: number, end: number } | null} 当前 @ 片段
+	 */
+	function currentMention() {
+		const pos = textarea.selectionStart
+		const before = textarea.value.slice(0, pos)
+		const match = before.match(/@(?:\[([^\]]*))?$/u)
+		if (!match) return null
+		return {
+			query: match[1] ?? '',
+			start: pos - match[0].length,
+			end: pos,
+		}
+	}
+
+	/**
+	 * 将选中的 @ 提及候选插入发帖框。
+	 * @param {object} row 选中候选
+	 * @returns {void}
+	 */
+	function apply(row) {
+		if (!mentionRange) return
+		const mention = formatEntityMentionToken(row.entityHash)
+		textarea.value = textarea.value.slice(0, mentionRange.start)
+			+ mention
+			+ textarea.value.slice(mentionRange.end)
+		const caret = mentionRange.start + mention.length
+		textarea.setSelectionRange(caret, caret)
+		textarea.focus()
+		hide()
+	}
+
+	/**
+	 * 处理 @ 提及面板的键盘导航与选中。
+	 * @param {KeyboardEvent} event 键盘
+	 * @returns {void}
+	 */
+	function onKeydown(event) {
+		if (panel.classList.contains('hidden') || !suggestions.length) return
+		if (event.key === 'ArrowDown') {
+			event.preventDefault()
+			activeIndex = (activeIndex + 1) % suggestions.length
+		}
+		else if (event.key === 'ArrowUp') {
+			event.preventDefault()
+			activeIndex = (activeIndex - 1 + suggestions.length) % suggestions.length
+		}
+		else if (event.key === 'Enter' || event.key === 'Tab') {
+			event.preventDefault()
+			apply(suggestions[activeIndex])
+			return
+		}
+		else if (event.key === 'Escape') {
+			hide()
+			return
+		}
+		else return
+
+		for (const button of panel.querySelectorAll('.mention-option'))
+			button.classList.toggle('active', Number(button.dataset.index) === activeIndex)
+	}
+
+	/**
+	 * 输入变化时更新 @ 提及候选。
+	 * @returns {void}
+	 */
+	function onInput() {
+		const mention = currentMention()
+		if (!mention) {
+			hide()
+			return
+		}
+		mentionRange = { start: mention.start, end: mention.end }
+		fetchSuggestions(mention.query).catch(() => hide())
+	}
+
+	panel.addEventListener('mousedown', event => {
+		const button = event.target instanceof HTMLElement ? event.target.closest('.mention-option') : null
+		if (!button) return
+		event.preventDefault()
+		const row = suggestions[Number(button.dataset.index)]
+		if (row) apply(row)
+	})
+
+	textarea.addEventListener('input', onInput)
+	textarea.addEventListener('keydown', onKeydown)
+	textarea.addEventListener('blur', () => setTimeout(hide, 150))
+
+	return () => {
+		textarea.removeEventListener('input', onInput)
+		textarea.removeEventListener('keydown', onKeydown)
+		panel.remove()
+	}
+}

--- a/src/public/parts/shells/social/public/src/navigation.mjs
+++ b/src/public/parts/shells/social/public/src/navigation.mjs
@@ -1,0 +1,218 @@
+import { parseEntityHash } from 'https://esm.sh/@steve02081504/fount-p2p/core/entity_id'
+import { isHex64 } from 'https://esm.sh/@steve02081504/fount-p2p/core/hexIds'
+
+import { parseSocialRunUri } from '../shared/runUri.mjs'
+
+import { publishPost } from './composer.mjs'
+import { state } from './state.mjs'
+import { activateView, currentMainView, MAIN_NAV_VIEWS } from './viewChrome.mjs'
+import { loadDrafts } from './views/drafts.mjs'
+import { loadExplore } from './views/explore.mjs'
+import { loadFeed, updateFeedSearchChrome } from './views/feed.mjs'
+import { loadLiveView } from './views/live.mjs'
+import { loadNotifications } from './views/notifications.mjs'
+import { loadPostDetail } from './views/postDetail.mjs'
+import { loadProfile, loadProfileFor, refreshProfilePosts } from './views/profile.mjs'
+import { loadSaved } from './views/saved.mjs'
+import { loadSearchView } from './views/search.mjs'
+import { loadSettings } from './views/settings.mjs'
+import { loadTopicView } from './views/topic.mjs'
+import { loadVideoView } from './views/video.mjs'
+
+/**
+ * 打开分享帖时主动连分享者 / 作者节点（跳过本机）。
+ * @param {string} entityHash 作者 entityHash
+ * @param {string} [sharerNodeHash] 分享者 nodeHash
+ * @returns {void}
+ */
+function connectNodesFromShare(entityHash, sharerNodeHash) {
+	const targets = new Set()
+	if (isHex64(sharerNodeHash)) targets.add(String(sharerNodeHash).toLowerCase())
+	const parsed = parseEntityHash(entityHash)
+	if (parsed?.nodeHash) targets.add(String(parsed.nodeHash).toLowerCase())
+	const self = String(state.viewerNodeHash || '').toLowerCase()
+	for (const targetNodeHash of targets) {
+		if (!targetNodeHash || targetNodeHash === self) continue
+		void fetch('/api/p2p/federation/connect-node', {
+			method: 'POST',
+			credentials: 'include',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ targetNodeHash }),
+		}).catch(() => {})
+	}
+}
+
+/**
+ * 将主导航视图同步到 location.hash（replace，避免历史堆叠）。
+ * @param {string} view 视图名
+ * @returns {void}
+ */
+function syncHashForMainView(view) {
+	if (!MAIN_NAV_VIEWS.includes(view)) return
+	const next = `#${view}`
+	if (location.hash === next) return
+	history.replaceState(null, '', `${location.pathname}${location.search}${next}`)
+}
+
+/**
+ * 刷新当前可见视图中的帖子列表。
+ * @returns {Promise<void>}
+ */
+export async function refreshVisiblePosts() {
+	const feedVisible = !document.getElementById('feedView')?.classList.contains('hidden')
+	const profileVisible = !document.getElementById('profileView')?.classList.contains('hidden')
+	const postVisible = !document.getElementById('postDetailView')?.classList.contains('hidden')
+	if (feedVisible)
+		if (state.activeFeedSearchQuery) {
+			const { loadSearchView } = await import('./views/search.mjs')
+			await loadSearchView(state.activeFeedSearchQuery)
+		}
+		else {
+			state.feedCursor = null
+			await loadFeed(false)
+		}
+
+	if (profileVisible && state.profileEntityHash) {
+		await refreshProfilePosts()
+		const albumsPanel = document.getElementById('profileAlbumsPanel')
+		if (albumsPanel && !albumsPanel.classList.contains('hidden')) {
+			const { renderProfileAlbums } = await import('./views/albums.mjs')
+			await renderProfileAlbums(state.profileEntityHash, albumsPanel)
+		}
+	}
+	if (postVisible && state.postDetailEntityHash && state.postDetailPostId)
+		await loadPostDetail(state.postDetailEntityHash, state.postDetailPostId)
+}
+
+/**
+ * 切换主导航视图并加载对应数据。
+ * @param {string} view 视图名
+ * @param {{ skipHash?: boolean, focusEntityHash?: string, focusPostId?: string }} [options] skipHash 时不写 URL；videos 可带焦点帖
+ * @returns {Promise<void>}
+ */
+export async function switchView(view, options = {}) {
+	activateView(view)
+	if (!options.skipHash)
+		syncHashForMainView(view)
+	if (view === 'feed') {
+		if (state.activeFeedSearchQuery) {
+			state.activeFeedSearchQuery = null
+			const searchInput = document.getElementById('feedSearchInput')
+			if (searchInput instanceof HTMLInputElement) searchInput.value = ''
+		}
+		state.feedCursor = null
+		await loadFeed(false)
+		updateFeedSearchChrome()
+	}
+	if (view === 'notifications') {
+		state.notificationsCursor = null
+		await loadNotifications(false)
+	}
+	if (view === 'explore') await loadExplore()
+	if (view === 'saved') await loadSaved()
+	if (view === 'drafts') await loadDrafts()
+	if (view === 'settings') await loadSettings()
+	if (view === 'profile') await loadProfile()
+	if (view === 'videos')
+		await loadVideoView({
+			focusEntityHash: options.focusEntityHash,
+			focusPostId: options.focusPostId,
+		})
+	if (view === 'live') await loadLiveView()
+}
+
+/**
+ * 解析 URL/hash 深链并导航到对应视图。
+ * @returns {Promise<boolean>} 是否已处理导航
+ */
+export async function applyIncomingNavigation() {
+	const rawHash = window.location.hash.replace(/^#/, '')
+
+	// 冒号分隔的自定义深链格式
+	if (rawHash.startsWith('topic:')) {
+		const tag = decodeURIComponent(rawHash.slice('topic:'.length))
+		await loadTopicView(tag)
+		return true
+	}
+	if (rawHash.startsWith('search:')) {
+		const q = decodeURIComponent(rawHash.slice('search:'.length))
+		await loadSearchView(q)
+		return true
+	}
+	if (rawHash.startsWith('live:')) {
+		const rest = rawHash.slice('live:'.length)
+		const colonIdx = rest.indexOf(':')
+		const entityHash = colonIdx >= 0 ? rest.slice(0, colonIdx) : rest
+		const liveId = colonIdx >= 0 ? rest.slice(colonIdx + 1) : ''
+		activateView('live')
+		await loadLiveView(entityHash, liveId)
+		return true
+	}
+
+	// 短视频深链：#videos;entityHash;postId
+	if (rawHash.startsWith('videos;')) {
+		const parts = rawHash.split(';')
+		const focusEntityHash = (parts[1] || '').toLowerCase()
+		const focusPostId = parts[2] || ''
+		activateView('videos')
+		await loadVideoView({ focusEntityHash, focusPostId })
+		return true
+	}
+
+	// 主导航 tab：#feed / #videos / …
+	if (MAIN_NAV_VIEWS.includes(rawHash)) {
+		if (currentMainView() === rawHash) return true
+		await switchView(rawHash, { skipHash: true })
+		return true
+	}
+
+	// 分号分隔的原有深链格式
+	const urlQ = new URLSearchParams(location.search).get('q')?.trim()
+	const hashParsed = parseSocialRunUri(rawHash)
+	if (hashParsed?.subcommand === 'search' && hashParsed.searchQuery) {
+		const tag = hashParsed.searchQuery.trim()
+		await loadSearchView(tag.startsWith('#') ? tag : `#${tag}`)
+		return true
+	}
+	if (urlQ) {
+		await loadSearchView(urlQ)
+		return true
+	}
+	if (hashParsed?.subcommand === 'post' && hashParsed.entityHash && hashParsed.postId) {
+		connectNodesFromShare(hashParsed.entityHash, hashParsed.sharerNodeHash)
+		await loadPostDetail(hashParsed.entityHash.toLowerCase(), hashParsed.postId)
+		return true
+	}
+	if (hashParsed?.entityHash && hashParsed.subcommand === 'profile') {
+		activateView('profile')
+		document.getElementById('composer')?.classList.add('hidden')
+		await loadProfileFor(hashParsed.entityHash.toLowerCase(), hashParsed.postId || null)
+		return true
+	}
+	return false
+}
+
+/**
+ * 滚动到 composer 并聚焦输入框。
+ * @param {{ switchToFeed?: boolean }} [options] 为 true 时 composer 隐藏则先切到 feed
+ * @returns {Promise<void>}
+ */
+export async function focusComposer({ switchToFeed = false } = {}) {
+	if (switchToFeed) await switchView('feed')
+	document.getElementById('composer')?.scrollIntoView({ behavior: 'smooth' })
+	document.getElementById('postText')?.focus()
+}
+
+/**
+ * 发帖成功后刷新 feed 并清空搜索状态。
+ * @returns {Promise<void>}
+ */
+export async function afterPublishPost() {
+	await publishPost()
+	state.activeFeedSearchQuery = null
+	const searchInput = document.getElementById('feedSearchInput')
+	if (searchInput instanceof HTMLInputElement) searchInput.value = ''
+	state.feedCursor = null
+	await loadFeed(false)
+	updateFeedSearchChrome()
+}

--- a/src/public/parts/shells/social/public/src/postCard.mjs
+++ b/src/public/parts/shells/social/public/src/postCard.mjs
@@ -1,0 +1,442 @@
+import { wrapContentWarningHtml } from '/scripts/features/contentReveal/index.mjs'
+import { renderTemplate, renderTemplateAsHtmlString } from '../../../../scripts/features/template.mjs'
+import { renderGroupRefBlockHtml } from '../shared/groupRef.mjs'
+import { formatSocialPostHref, formatSocialProfileHref } from '../shared/runUri.mjs'
+
+import { formatActionKey } from './lib/actionKey.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { viewerEntityHash } from './lib/apiClient.mjs'
+import {
+	authorLabel,
+	entityHandle,
+	formatTimeAttrs,
+	rememberEntityHandle,
+	renderAvatarHtml,
+	renderTrustedPostMarkdown,
+	renderQuoteBlockHtml,
+} from './lib/display.mjs'
+import { renderEngagementBarHtml } from './lib/engagementBar.mjs'
+import { playHeartAnim } from './lib/heartAnim.mjs'
+import { renderPollHtml } from './lib/pollUi.mjs'
+import { renderMediaHtml } from './mediaRender.mjs'
+
+/**
+ * @param {object} liveRef 直播引用
+ * @returns {Promise<string>} HTML
+ */
+async function renderLiveRefHtml(liveRef) {
+	const entityHash = String(liveRef.entityHash || '').toLowerCase()
+	const liveId = String(liveRef.liveId || '').toLowerCase()
+	const ended = liveRef.status === 'ended'
+	const href = escapeHtml(`#live:${entityHash}:${liveId}`)
+	const avatarHtml = renderAvatarHtml(entityHash, null, 'live-ref-avatar')
+	if (ended) {
+		const viewers = Number(liveRef.totalViewers) || 0
+		const likes = Number(liveRef.totalLikes) || 0
+		const durationMs = Number(liveRef.duration) || 0
+		const secs = Math.max(0, Math.round(durationMs / 1000))
+		const mm = String(Math.floor(secs / 60)).padStart(2, '0')
+		const ss = String(secs % 60).padStart(2, '0')
+		return renderTemplateAsHtmlString('live_ref', {
+			href,
+			avatarHtml,
+			endedClass: ' live-ref-card--ended',
+			badgeHtml: '<span class="live-ref-badge" data-i18n="social.live.postEnded"></span>',
+			footerHtml: `<span class="live-ref-stats" data-i18n="social.live.postEndedStats" data-viewers="${viewers}" data-likes="${likes}" data-duration="${mm}:${ss}"></span>`,
+		})
+	}
+	return renderTemplateAsHtmlString('live_ref', {
+		href,
+		avatarHtml,
+		endedClass: '',
+		badgeHtml: '<span class="live-ref-badge">LIVE</span>',
+		footerHtml: '<span class="live-ref-cta" data-i18n="social.live.postWatch"></span>',
+	})
+}
+
+/**
+ * 将单条 feed 条目渲染为帖子卡片 DOM。
+ * @param {object} item feed 条目
+ * @param {{ openDetail?: boolean }} [options] openDetail 默认 true；详情页自身传 false
+ * @returns {Promise<HTMLElement>} 帖子卡片
+ */
+export async function buildPostCard(item, options = {}) {
+	const isRepost = item.kind === 'repost'
+	const actionEntity = item.targetEntityHash || item.entityHash
+	const actionPostId = item.targetPostId || item.postId
+	const actionKey = formatActionKey(actionEntity, actionPostId)
+	const originalAuthor = isRepost ? item.targetEntityHash : item.entityHash
+	rememberEntityHandle(item.entityHash, item.authorProfile)
+	if (isRepost) rememberEntityHandle(originalAuthor, item.targetAuthorProfile)
+	if (item.replyContext)
+		rememberEntityHandle(item.replyContext.entityHash, item.replyContext.authorProfile)
+	const decryptFailed = item.post?.decryptView?.failed
+	const text = item.post?.content?.text || ''
+	const contentAuthor = isRepost ? originalAuthor : item.entityHash
+	const markdownBody = decryptFailed
+		? '<em data-i18n="social.feed.decryptFailed"></em>'
+		: await renderTrustedPostMarkdown(text || (decryptFailed ? '' : ''), contentAuthor, {
+			ownerEntityHash: item.ownerEntityHash || item.authorProfile?.ownerEntityHash
+				|| (isRepost ? item.targetAuthorProfile?.ownerEntityHash : null),
+		})
+	const contentWarning = item.post?.content?.contentWarning?.trim()
+	const sensitiveMedia = item.post?.content?.sensitiveMedia === true
+		|| Boolean(contentWarning)
+	const mediaHtmlRaw = decryptFailed
+		? ''
+		: renderMediaHtml(item.post?.content?.mediaRefs, {
+			sensitive: sensitiveMedia && !contentWarning,
+			warningI18n: 'social.feed.sensitiveMedia',
+			revealI18n: 'social.feed.revealContent',
+		})
+	const quoteRef = item.post?.content?.quoteRef
+	const quoteHtml = quoteRef && !decryptFailed
+		? await renderQuoteBlockHtml({ ...quoteRef, text: quoteRef.text || '' })
+		: ''
+	const replyContext = item.replyContext
+	const replyContextHtml = replyContext && !decryptFailed
+		? await renderTemplateAsHtmlString('reply_context', {
+			href: escapeHtml(formatSocialPostHref(replyContext.entityHash, replyContext.postId)),
+			author: escapeHtml(entityHandle(replyContext.entityHash, replyContext.authorProfile)),
+			snippetHtml: replyContext.text
+				? `<span class="reply-context-snippet">${escapeHtml(String(replyContext.text).slice(0, 120))}</span>`
+				: '',
+		})
+		: ''
+	const groupRef = item.post?.content?.groupRef
+	const groupRefHtml = groupRef && !decryptFailed
+		? renderGroupRefBlockHtml(groupRef)
+		: ''
+	const pollHtml = item.poll && !decryptFailed
+		? renderPollHtml(item.poll, actionKey)
+		: ''
+	const liveRef = item.post?.content?.liveRef
+	const liveRefHtml = liveRef && !decryptFailed
+		? await renderLiveRefHtml(liveRef)
+		: ''
+	let contentBlock = `${pollHtml}${mediaHtmlRaw}${liveRefHtml}<div class="body markdown-body">${markdownBody}</div>`
+	if (contentWarning && !decryptFailed)
+		contentBlock = wrapContentWarningHtml(contentBlock, {
+			warningLabel: contentWarning,
+			revealI18n: 'social.feed.revealContent',
+		})
+
+	const viewer = viewerEntityHash()
+	const isOwn = viewer && item.entityHash === viewer && !isRepost
+	const itemOwner = String(item.ownerEntityHash || item.authorProfile?.ownerEntityHash || '').trim().toLowerCase()
+	const isManagedPost = !isRepost && !isOwn
+		&& !!viewer
+		&& !!itemOwner
+		&& itemOwner === String(viewer).toLowerCase()
+	const canManage = isOwn || isManagedPost
+	const canDelete = canManage
+	const label = authorLabel(item.entityHash, item.authorProfile)
+	const { visibilityDisplay } = await import('./visibilityPicker.mjs')
+	const vis = visibilityDisplay(item.post?.content?.visibility, item.post?.content?.minFollowMs)
+	const visibilityCode = vis.code
+	const albumChips = (item.albums || []).length
+		? `<div class="post-album-chips">${item.albums.map(album =>
+			`<button type="button" class="post-album-chip" data-album-open="${escapeHtml(item.entityHash)}" data-album-id="${escapeHtml(album.albumId)}">${escapeHtml(album.name)}</button>`,
+		).join('')}</div>`
+		: ''
+	const engagementBarHtml = await renderEngagementBarHtml(item, actionKey)
+	const repostBanner = isRepost
+		? await renderTemplateAsHtmlString('repost_banner', { author: escapeHtml(label) })
+		: ''
+	const repostCommentHtml = isRepost && item.repostComment
+		? `<div class="body markdown-body repost-comment">${await renderTrustedPostMarkdown(item.repostComment, item.entityHash, {
+			ownerEntityHash: item.ownerEntityHash || item.authorProfile?.ownerEntityHash,
+		})}</div>`
+		: ''
+	const embeddedWrapStart = isRepost ? '<div class="embedded-post">' : ''
+	const embeddedWrapEnd = isRepost ? '</div>' : ''
+	const headerAvatarEntity = isRepost ? originalAuthor : item.entityHash
+	const headerAvatarProfile = isRepost ? item.targetAuthorProfile : item.authorProfile
+	const headerHandleEntity = isRepost ? originalAuthor : item.entityHash
+	const headerAuthor = escapeHtml(isRepost
+		? authorLabel(originalAuthor, item.targetAuthorProfile)
+		: label)
+	const headerLink = escapeHtml(isRepost
+		? formatSocialProfileHref(originalAuthor)
+		: formatSocialProfileHref(item.entityHash))
+	const authorHandle = escapeHtml(entityHandle(headerHandleEntity, headerAvatarProfile))
+	const timeAttrs = formatTimeAttrs(item.post?.hlc?.wall)
+	const postTimeAttrs = timeAttrs.i18n
+		? ` data-i18n="${timeAttrs.i18n}"${timeAttrs.n != null ? ` data-n="${timeAttrs.n}"` : ''}`
+		: ''
+	const postTimeText = timeAttrs.text ? escapeHtml(timeAttrs.text) : ''
+	const postDetailHref = escapeHtml(formatSocialPostHref(actionEntity, actionPostId))
+	const editedBadge = item.post?.edited
+		? '<span class="post-edited-badge" data-i18n="social.post.edited"></span>'
+		: ''
+	const treatAsOwn = canManage
+	const blockButton = treatAsOwn
+		? ''
+		: `<button type="button" class="danger-item" data-block="${item.entityHash}"><span class="icon icon-block" aria-hidden="true"></span><span data-i18n="social.actions.block"></span></button>`
+	const hideButton = treatAsOwn
+		? ''
+		: `<button type="button" data-hide="${item.entityHash}"><span class="icon icon-hide" aria-hidden="true"></span><span data-i18n="social.actions.hide"></span></button>`
+	const muteButton = treatAsOwn
+		? ''
+		: `<button type="button" data-mute="${item.entityHash}"><span class="icon icon-mute" aria-hidden="true"></span><span data-i18n="social.actions.mute"></span></button>`
+	const deleteButton = canDelete
+		? `<button type="button" class="danger-item" data-delete="${item.postId}" data-delete-entity="${item.entityHash}"><span class="icon icon-delete" aria-hidden="true"></span><span data-i18n="social.actions.delete"></span></button>`
+		: ''
+	const editButton = canManage
+		? `<button type="button" data-edit="${actionKey}"><span class="icon icon-edit" aria-hidden="true"></span><span data-i18n="social.actions.edit"></span></button>`
+		: ''
+	const editHistoryButton = canManage && item.post?.revisions?.length
+		? `<button type="button" data-edit-history="${actionKey}"><span class="icon icon-history" aria-hidden="true"></span><span data-i18n="social.post.editHistory"></span></button>`
+		: ''
+
+	const topNote = item.communityNote?.topNote
+	const communityNoteHtml = topNote
+		? await renderTemplateAsHtmlString('community_note', {
+			actionKey,
+			noteId: escapeHtml(topNote.noteEventId),
+			text: escapeHtml(topNote.text || ''),
+			helpfulCount: topNote.helpfulCount || 0,
+			unhelpfulCount: topNote.unhelpfulCount || 0,
+			noteCount: item.communityNote.noteCount || 1,
+		})
+		: item.communityNote?.noteCount
+			? await renderTemplateAsHtmlString('community_note_collapsed', {
+				actionKey,
+				noteCount: item.communityNote.noteCount,
+			})
+			: ''
+
+	const { geti18n } = await import('/scripts/i18n/index.mjs')
+	const visLabel = geti18n(vis.labelKey)
+	const card = await renderTemplate('post_card', {
+		postId: item.postId,
+		postTextEncoded: encodeURIComponent(decryptFailed ? '' : text),
+		visibilityCode,
+		repostBanner,
+		repostCommentHtml,
+		embeddedWrapStart,
+		embeddedWrapEnd,
+		headerAvatarHtml: renderAvatarHtml(headerAvatarEntity, headerAvatarProfile),
+		headerAuthor,
+		headerLink,
+		authorHandle,
+		postTimeAttrs,
+		postTimeText,
+		editedBadge,
+		visibilityIcon: `<span class="icon icon-${vis.icon} post-visibility-icon" title="${escapeHtml(visLabel)}" aria-label="${escapeHtml(visLabel)}"></span>`,
+		quoteHtml,
+		replyContextHtml,
+		groupRefHtml,
+		contentBlock,
+		albumChips,
+		communityNoteHtml,
+		engagementBarHtml,
+		actionKey,
+		postDetailHref,
+		entityHash: item.entityHash,
+		blockButton,
+		hideButton,
+		muteButton,
+		editButton,
+		editHistoryButton,
+		deleteButton,
+	})
+	const el = /** @type {HTMLElement} */ card
+	el.dataset.mediaEntity = actionEntity
+	el.dataset.mediaPostId = actionPostId
+	const mediaRoot = el.querySelector('.post-media')
+	if (mediaRoot instanceof HTMLElement) {
+		mediaRoot.dataset.mediaEntity = actionEntity
+		mediaRoot.dataset.mediaPostId = actionPostId
+	}
+	if (options.openDetail !== false) {
+		bindPostCardOpen(el, `post;${actionEntity};${actionPostId}`)
+		// 时间线：长代码块默认收起；过长正文折叠，避免点 summary 进详情
+		collapseFeedCodeBlocks(el)
+		bindBodyFold(el)
+	}
+	else {
+		el.style.cursor = 'default'
+		bindPostDetailMediaLike(el, actionEntity, actionPostId)
+	}
+	return el
+}
+
+const POST_CARD_OPEN_EXCLUDE = 'a, button, input, textarea, select, label, summary, .poll, .post-media, .live-ref-card, .post-actions, .repost-panel, .replies, .post-more-menu, .content-warning-reveal, .sensitive-media-reveal, .body-expand'
+const LONG_PRESS_MS = 400
+const MEDIA_DBLCLICK_MS = 350
+/** 时间线正文折叠阈值（约 12～14 行） */
+const BODY_FOLD_MAX_PX = 280
+
+/**
+ * 时间线内将 markdown 长代码 `<details>` 默认收起（详情页保持原文展开）。
+ * @param {HTMLElement} card 帖卡
+ * @returns {void}
+ */
+function collapseFeedCodeBlocks(card) {
+	for (const details of card.querySelectorAll('details.markdown-code-block'))
+		if (details instanceof HTMLDetailsElement) details.open = false
+}
+
+/**
+ * 过长正文折叠：测量高度，超出则加「展开/收起」；CW 未揭示时延后测量。
+ * @param {HTMLElement} card 帖卡
+ * @returns {void}
+ */
+function bindBodyFold(card) {
+	for (const body of card.querySelectorAll('.body.markdown-body')) {
+		if (!(body instanceof HTMLElement) || body.dataset.bodyFoldBound === '1') continue
+		body.dataset.bodyFoldBound = '1'
+		scheduleBodyFold(body)
+	}
+}
+
+/**
+ * @param {HTMLElement} body 正文节点
+ * @returns {void}
+ */
+function scheduleBodyFold(body) {
+	/**
+	 *
+	 */
+	const apply = () => {
+		if (body.classList.contains('body-foldable')) return
+		const cwBody = body.closest('.content-warning-body')
+		if (cwBody instanceof HTMLElement && cwBody.classList.contains('hidden')) {
+			const observer = new MutationObserver(() => {
+				if (cwBody.classList.contains('hidden')) return
+				observer.disconnect()
+				requestAnimationFrame(apply)
+			})
+			observer.observe(cwBody, { attributes: true, attributeFilter: ['class'] })
+			return
+		}
+		if (body.scrollHeight <= BODY_FOLD_MAX_PX + 24) return
+		body.classList.add('body-foldable')
+		const button = document.createElement('button')
+		button.type = 'button'
+		button.className = 'body-expand'
+		button.dataset.i18n = 'social.feed.showMore'
+		button.addEventListener('click', event => {
+			event.preventDefault()
+			event.stopPropagation()
+			const expanded = body.classList.toggle('body-expanded')
+			button.dataset.i18n = expanded ? 'social.feed.showLess' : 'social.feed.showMore'
+		})
+		body.insertAdjacentElement('afterend', button)
+	}
+	requestAnimationFrame(() => requestAnimationFrame(apply))
+}
+
+/**
+ * 详情页：双击多媒体点赞；单击视频进短视频页。
+ * @param {HTMLElement} card 帖卡
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {void}
+ */
+function bindPostDetailMediaLike(card, entityHash, postId) {
+	const media = card.querySelector('.post-media')
+	if (!(media instanceof HTMLElement) || media.dataset.dblLikeBound === '1') return
+	media.dataset.dblLikeBound = '1'
+	let lastTap = 0
+	media.addEventListener('pointerup', async event => {
+		if (!(event.target instanceof Element)) return
+		if (event.target.closest('[data-media-nav], .post-media-dot')) return
+		const now = Date.now()
+		const hitVideo = Boolean(event.target.closest('[data-media-video]'))
+		if (now - lastTap < MEDIA_DBLCLICK_MS) {
+			lastTap = 0
+			event.preventDefault()
+			event.stopPropagation()
+			const likeButton = card.querySelector('[data-like]')
+			if (!(likeButton instanceof HTMLElement)) return
+			if (likeButton.dataset.liked === '1') {
+				showPostMediaHeart(media)
+				return
+			}
+			const { applyLikeButtonOptimistic, rollbackLikeButton, runWrite } = await import('./lib/socialWrite.mjs')
+			const { socialApi } = await import('./lib/apiClient.mjs')
+			const snapshot = applyLikeButtonOptimistic(likeButton, true)
+			showPostMediaHeart(media)
+			try {
+				await runWrite('like', () => socialApi(`/posts/${entityHash}/${postId}/like`, {
+					method: 'POST',
+					body: JSON.stringify({ like: true }),
+				}))
+			}
+			catch {
+				rollbackLikeButton(likeButton, snapshot)
+			}
+			return
+		}
+		lastTap = now
+		if (!hitVideo) return
+		setTimeout(() => {
+			if (lastTap !== now) return
+			location.hash = `videos;${entityHash};${postId}`
+		}, MEDIA_DBLCLICK_MS + 10)
+	})
+}
+
+/**
+ * @param {HTMLElement} media 媒体根
+ * @returns {void}
+ */
+function showPostMediaHeart(media) {
+	playHeartAnim(media, {
+		emoji: '👍',
+		durationMs: 800,
+		selector: '.post-media-heart',
+		createIfMissing: true,
+		createClass: 'post-media-heart heart-anim',
+	})
+}
+
+/**
+ * 无按钮/链接的空白区短按进详情；长按/滑动/划词不进页。
+ * 头像、handle、时间等已是进帖链接，由浏览器原生导航。
+ * @param {HTMLElement} card 帖卡
+ * @param {string} hash 目标 hash（不含 #）
+ * @returns {void}
+ */
+function bindPostCardOpen(card, hash) {
+	let longPress = false
+	let timer = 0
+	let startX = 0
+	let startY = 0
+	/**
+	 *
+	 */
+	const clearPressTimer = () => {
+		if (timer) {
+			clearTimeout(timer)
+			timer = 0
+		}
+	}
+	card.addEventListener('pointerdown', event => {
+		if (event.button !== 0 || !(event.target instanceof Element)) return
+		if (event.target.closest(POST_CARD_OPEN_EXCLUDE)) return
+		longPress = false
+		startX = event.clientX
+		startY = event.clientY
+		clearPressTimer()
+		timer = setTimeout(() => {
+			longPress = true
+			timer = 0
+		}, LONG_PRESS_MS)
+	})
+	card.addEventListener('pointerup', clearPressTimer)
+	card.addEventListener('pointercancel', clearPressTimer)
+	card.addEventListener('click', event => {
+		if (!(event.target instanceof Element)) return
+		if (event.target.closest(POST_CARD_OPEN_EXCLUDE)) return
+		if (longPress) {
+			longPress = false
+			return
+		}
+		if (Math.hypot(event.clientX - startX, event.clientY - startY) > 12) return
+		if (getSelection()?.toString()) return
+		location.hash = hash
+	})
+}

--- a/src/public/parts/shells/social/public/src/state.mjs
+++ b/src/public/parts/shells/social/public/src/state.mjs
@@ -1,0 +1,39 @@
+/** Social 前端共享可变状态。 */
+export const state = {
+	viewerEntityHash: null,
+	/** 本机 P2P nodeHash（分享链附带） */
+	viewerNodeHash: null,
+	viewerDisplayName: null,
+	/** @type {{ name?: string, avatar?: string, infoDefaults?: { avatar?: string } } | null} */
+	viewerProfile: null,
+	feedCursor: null,
+	/** @type {object[] | null} 已展示的 feed 原始条目（循环重放源） */
+	feedShownItems: null,
+	/** @type {{ cursor: string, items: object[], nextCursor: string | null } | null} */
+	feedPrefetch: null,
+	/** @type {Promise<void> | null} */
+	feedPrefetchInFlight: null,
+	profileEntityHash: null,
+	/** @type {object | null} 当前资料页 socialMeta（设置弹窗用） */
+	profileSocialMeta: null,
+	profilePostsCursor: null,
+	notificationsCursor: null,
+	postDetailEntityHash: null,
+	postDetailPostId: null,
+	pendingMediaRefs: [],
+	pendingQuoteRef: null,
+	pendingGroupRef: null,
+	pendingPoll: null,
+	/** @type {string | null} 正在编辑的草稿 id */
+	activeDraftId: null,
+	feedRanking: 'latest',
+	exploreMediaOnly: false,
+	savedFoldersCache: {},
+	pendingSave: null,
+	activeFeedSearchQuery: null,
+	/** 服务端通知已读水位（毫秒） */
+	notificationsSeenAt: null,
+	lastNotificationUnreadCount: 0,
+	/** 收件箱 Tab：`all` | `mention` | `reply` | `like` | `follow` | `repost` */
+	notificationsFilter: 'all',
+}

--- a/src/public/parts/shells/social/public/src/templates/album_edit_dialog.html
+++ b/src/public/parts/shells/social/public/src/templates/album_edit_dialog.html
@@ -1,0 +1,19 @@
+<div class="modal-box album-edit-dialog">
+	<h3 class="font-bold text-lg">${title}</h3>
+	<label class="form-control">
+		<span class="label-text" data-i18n="social.albums.name"></span>
+		<input type="text" class="input input-bordered" data-album-name value="${name}" />
+	</label>
+	<label class="form-control">
+		<span class="label-text" data-i18n="social.albums.description"></span>
+		<textarea class="textarea textarea-bordered" data-album-description rows="2">${description}</textarea>
+	</label>
+	<div class="form-control">
+		<span class="label-text" data-i18n="social.visibility.label"></span>
+		${visibilityPickerHtml}
+	</div>
+	<div class="modal-action">
+		<form method="dialog"><button class="btn btn-ghost" data-i18n="social.albums.cancel"></button></form>
+		<button type="button" class="btn btn-primary" data-album-submit>${submitLabel}</button>
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/blocklist_action.html
+++ b/src/public/parts/shells/social/public/src/templates/blocklist_action.html
@@ -1,0 +1,1 @@
+<button type="button" class="profile-action-btn" data-${action}="${value}" data-i18n="${labelKey}"></button>

--- a/src/public/parts/shells/social/public/src/templates/blocklist_heading.html
+++ b/src/public/parts/shells/social/public/src/templates/blocklist_heading.html
@@ -1,0 +1,1 @@
+<h3 class="section-title" data-i18n="${titleKey}"></h3>

--- a/src/public/parts/shells/social/public/src/templates/blocklist_row.html
+++ b/src/public/parts/shells/social/public/src/templates/blocklist_row.html
@@ -1,0 +1,5 @@
+<div class="blocklist-row">
+	<span class="blocklist-kind" data-i18n="${scopeKey}"></span>
+	<code class="entity-hash">${value}</code>
+	${actionHtml}
+</div>

--- a/src/public/parts/shells/social/public/src/templates/community_note.html
+++ b/src/public/parts/shells/social/public/src/templates/community_note.html
@@ -1,0 +1,9 @@
+<div class="community-note" data-note-for="${actionKey}">
+	<div class="community-note-label" data-i18n="social.notes.label"></div>
+	<p class="community-note-text">${text}</p>
+	<div class="community-note-actions">
+		<button type="button" class="btn btn-ghost btn-xs" data-note-vote="${actionKey}" data-note-id="${noteId}" data-helpful="1"><span data-i18n="social.notes.helpful"></span> (${helpfulCount})</button>
+		<button type="button" class="btn btn-ghost btn-xs" data-note-vote="${actionKey}" data-note-id="${noteId}" data-helpful="0"><span data-i18n="social.notes.unhelpful"></span> (${unhelpfulCount})</button>
+		<button type="button" class="btn btn-ghost btn-xs" data-note-more="${actionKey}" data-i18n="social.notes.more" data-n="${noteCount}"></button>
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/community_note_collapsed.html
+++ b/src/public/parts/shells/social/public/src/templates/community_note_collapsed.html
@@ -1,0 +1,3 @@
+<div class="community-note community-note-collapsed">
+	<button type="button" class="btn btn-ghost btn-xs" data-note-more="${actionKey}" data-i18n="social.notes.more" data-n="${noteCount}"></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/confirm_modal.html
+++ b/src/public/parts/shells/social/public/src/templates/confirm_modal.html
@@ -1,0 +1,7 @@
+<div class="modal-box">
+	<p class="py-4">${escapeHtml(message)}</p>
+	<div class="modal-action">
+		<button type="button" class="btn" data-dialog-cancel data-i18n="social.saved.cancel"></button>
+		<button type="button" class="btn btn-error" data-dialog-resolve="ok" data-i18n="social.saved.confirm"></button>
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/empty_state.html
+++ b/src/public/parts/shells/social/public/src/templates/empty_state.html
@@ -1,0 +1,6 @@
+<div class="empty-state${modClass}">
+	${iconHtml}
+	<p class="empty-state-title" data-i18n="${titleKey}"></p>
+	${hintHtml}
+	${actionHtml}
+</div>

--- a/src/public/parts/shells/social/public/src/templates/engagement_bar.html
+++ b/src/public/parts/shells/social/public/src/templates/engagement_bar.html
@@ -1,0 +1,28 @@
+<div class="post-actions">
+	<button type="button" class="action-btn action-btn-reply replies-btn" data-replies="${actionKey}" aria-label="${replyLabel}">
+		<span class="icon icon-reply" aria-hidden="true"></span>
+		<span class="action-count">${replyCount}</span>
+	</button>
+	<button type="button" class="action-btn action-btn-repost repost-btn" data-repost="${actionKey}" aria-label="${repostLabel}">
+		<span class="icon icon-repost" aria-hidden="true"></span>
+		<span class="action-count">${repostCount}</span>
+	</button>
+	<button type="button" class="action-btn action-btn-like like-btn${likedClass}" data-like="${actionKey}" data-liked="${likedFlag}" aria-label="${likeLabel}">
+		<span class="icon icon-like" aria-hidden="true"></span>
+		<span class="action-count">${likeCount}</span>
+	</button>
+	<button type="button" class="action-btn action-btn-dislike dislike-btn${dislikedClass}" data-dislike="${actionKey}" data-disliked="${dislikedFlag}" aria-label="${dislikeLabel}">
+		<span class="icon icon-dislike" aria-hidden="true"></span>
+		<span class="action-count">${dislikeCount}</span>
+	</button>
+	<button type="button" class="action-btn action-btn-save" data-save="${actionKey}" aria-label="${saveLabel}">
+		<span class="icon icon-bookmark" aria-hidden="true"></span>
+	</button>
+	<button type="button" class="action-btn action-btn-share" data-share="${actionKey}" aria-label="${shareLabel}">
+		<span class="icon icon-share" aria-hidden="true"></span>
+	</button>
+</div>
+<div class="repost-panel hidden" data-repost-for="${actionKey}">
+	<textarea rows="2" data-i18n="social.repost"></textarea>
+	<button type="button" data-submit-repost="${actionKey}"><span data-i18n="social.repost.submit"></span></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/explore_account.html
+++ b/src/public/parts/shells/social/public/src/templates/explore_account.html
@@ -1,0 +1,9 @@
+<article class="explore-account">
+	<a href="${profileHref}" class="explore-account-avatar-link">${avatarHtml}</a>
+	<div class="explore-account-body">
+		<a href="${profileHref}" class="suggested-account-name">${name}</a>
+		<span class="suggested-account-handle">${handle}</span>
+		${bioHtml}
+	</div>
+	<button type="button" class="suggested-follow-btn" data-follow="${entityHash}" data-i18n="social.actions.follow"></button>
+</article>

--- a/src/public/parts/shells/social/public/src/templates/explore_post.html
+++ b/src/public/parts/shells/social/public/src/templates/explore_post.html
@@ -1,0 +1,14 @@
+<article class="explore-post-card">
+	<header class="explore-post-header">
+		<a href="${authorHref}" class="explore-post-avatar-link">${avatarHtml}</a>
+		<div class="explore-post-author">
+			<a href="${authorHref}" class="author-name">${name}</a>
+			<a href="${authorHref}" class="author-handle">${handle}</a>
+			${timeHtml}
+		</div>
+	</header>
+	<a href="${href}" class="explore-post-body">
+		${snippetHtml}
+		${thumbsHtml}
+	</a>
+</article>

--- a/src/public/parts/shells/social/public/src/templates/explore_suggested.html
+++ b/src/public/parts/shells/social/public/src/templates/explore_suggested.html
@@ -1,0 +1,8 @@
+<div class="suggested-account">
+	${avatarHtml}
+	<div class="suggested-account-info">
+		<a href="${profileHref}" class="suggested-account-name">${name}</a>
+		<span class="suggested-account-handle">${handle}</span>
+	</div>
+	<button type="button" class="suggested-follow-btn" data-follow="${entityHash}" data-i18n="social.actions.follow"></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/feed_entity_search.html
+++ b/src/public/parts/shells/social/public/src/templates/feed_entity_search.html
@@ -1,0 +1,11 @@
+<div class="suggested-account feed-search-entity">
+	<div class="suggested-account-info">
+		<a href="${profileHref}" class="suggested-account-name">${label}</a>
+		<span class="suggested-account-handle">${handle}</span>
+		<span class="text-xs opacity-50" data-i18n="social.search.trustScore" data-score="${score}"></span>
+	</div>
+	<div class="flex gap-1 flex-wrap justify-end">
+		<button type="button" class="suggested-follow-btn" data-follow="${entityHash}" data-is-following="${isFollowing}" data-i18n="${followI18n}"></button>
+		<button type="button" class="btn btn-ghost btn-xs" data-set-alias="${entityHash}" data-i18n="social.search.pinAlias"></button>
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/group_ref_preview.html
+++ b/src/public/parts/shells/social/public/src/templates/group_ref_preview.html
@@ -1,0 +1,5 @@
+<div class="group-ref-preview-inner">
+	<span data-i18n="social.groupRef.linking"></span>
+	<div class="group-ref-preview-body"></div>
+	<button type="button" class="clear-group-ref-btn link-btn" data-i18n="social.groupRef.clear"></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/live_ref.html
+++ b/src/public/parts/shells/social/public/src/templates/live_ref.html
@@ -1,0 +1,5 @@
+<a class="live-ref-card${endedClass}" href="${href}">
+	${badgeHtml}
+	${avatarHtml}
+	${footerHtml}
+</a>

--- a/src/public/parts/shells/social/public/src/templates/post_card.html
+++ b/src/public/parts/shells/social/public/src/templates/post_card.html
@@ -1,0 +1,49 @@
+<article class="post-card" data-post-id="${postId}" data-author-entity="${entityHash}" data-post-text="${postTextEncoded}" data-visibility="${visibilityCode}">
+	${repostBanner}
+	${repostCommentHtml}
+	${embeddedWrapStart}
+	<header class="post-header">
+		<div class="post-header-row">
+			<a href="${postDetailHref}" class="author-avatar-link">${headerAvatarHtml}</a>
+			<div class="post-author">
+				<div class="post-author-line">
+					<a href="${headerLink}" class="author-name">${headerAuthor}</a>
+					<a href="${postDetailHref}" class="author-handle">${authorHandle}</a>
+					<span class="post-meta-sep">·</span>
+					<a href="${postDetailHref}" class="post-meta post-time-link"${postTimeAttrs}>${postTimeText}</a>
+					${editedBadge}
+					${visibilityIcon}
+				</div>
+			</div>
+			<div class="post-more-dropdown">
+				<button type="button" class="action-btn action-btn-more" data-more-toggle="${actionKey}" data-i18n="social.actions.more">
+					<span class="icon icon-more" aria-hidden="true"></span>
+				</button>
+				<div class="post-more-menu hidden" data-more-menu="${actionKey}">
+					<button type="button" data-quote="${actionKey}"><span class="icon icon-quote" aria-hidden="true"></span><span data-i18n="social.actions.quote"></span></button>
+					<button type="button" data-copy-link="${actionKey}"><span class="icon icon-link" aria-hidden="true"></span><span data-i18n="social.actions.copyLink"></span></button>
+					<button type="button" data-download-html="${actionKey}"><span class="icon icon-download" aria-hidden="true"></span><span data-i18n="social.actions.downloadHtml"></span></button>
+					<button type="button" data-share="${actionKey}"><span class="icon icon-share" aria-hidden="true"></span><span data-i18n="social.actions.share"></span></button>
+					<button type="button" data-add-note="${actionKey}"><span class="icon icon-note" aria-hidden="true"></span><span data-i18n="social.notes.add"></span></button>
+					<button type="button" data-translate="${actionKey}"><span class="icon icon-translate" aria-hidden="true"></span><span data-i18n="social.actions.translate"></span></button>
+					<button type="button" data-dm="${entityHash}"><span class="icon icon-direct-message" aria-hidden="true"></span><span data-i18n="social.actions.dm"></span></button>
+					${blockButton}
+					${hideButton}
+					${muteButton}
+					${editButton}
+					${editHistoryButton}
+					${deleteButton}
+				</div>
+			</div>
+		</div>
+	</header>
+	${replyContextHtml}
+	${quoteHtml}
+	${groupRefHtml}
+	${contentBlock}
+	${albumChips}
+	${communityNoteHtml}
+	${embeddedWrapEnd}
+	${engagementBarHtml}
+	<div class="replies hidden" data-replies-for="${actionKey}"></div>
+</article>

--- a/src/public/parts/shells/social/public/src/templates/profile_header_actions_other.html
+++ b/src/public/parts/shells/social/public/src/templates/profile_header_actions_other.html
@@ -1,0 +1,4 @@
+<button type="button" class="profile-action-btn ${primaryClass}" data-follow="${entityHash}" data-is-following="${isFollowing}" data-i18n="${followKey}"></button>
+<button type="button" class="profile-action-btn" data-care="${entityHash}" data-is-cared="${isCared}" data-i18n="${careKey}"></button>
+<button type="button" class="profile-action-btn" data-dm="${entityHash}" data-i18n="social.actions.dm"></button>
+<button type="button" class="profile-action-btn" data-set-alias="${entityHash}" data-i18n="social.actions.setAlias"></button>

--- a/src/public/parts/shells/social/public/src/templates/profile_header_actions_self.html
+++ b/src/public/parts/shells/social/public/src/templates/profile_header_actions_self.html
@@ -1,0 +1,4 @@
+<button type="button" class="profile-action-btn primary" data-profile-edit data-i18n="social.profile.edit">编辑资料</button>
+<button type="button" class="profile-action-btn profile-settings-btn" data-profile-settings data-i18n="social.profile.settingsBtn">
+	<span class="icon icon-settings" aria-hidden="true"></span>
+</button>

--- a/src/public/parts/shells/social/public/src/templates/profile_relationship_list.html
+++ b/src/public/parts/shells/social/public/src/templates/profile_relationship_list.html
@@ -1,0 +1,8 @@
+<div class="modal-box profile-relationship-dialog">
+	<form method="dialog">
+		<button type="submit" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" data-i18n="social.dialog.close"></button>
+	</form>
+	<h3 class="font-bold text-lg" data-i18n="${titleKey}"></h3>
+	<div id="profileRelationshipList" class="profile-relationship-list"></div>
+</div>
+<form method="dialog" class="modal-backdrop"><button data-i18n="social.dialog.close">close</button></form>

--- a/src/public/parts/shells/social/public/src/templates/profile_view.html
+++ b/src/public/parts/shells/social/public/src/templates/profile_view.html
@@ -1,0 +1,30 @@
+<div class="profile-entity-card-host" id="profileEntityCardHost"></div>
+<div class="profile-header">
+	<div class="profile-header-actions">
+		${headerActions}
+	</div>
+	<div class="profile-stats" role="group" data-i18n="social.profile.statsGroup">
+		<button type="button" class="profile-stat" data-profile-stat="posts">
+			<strong>${postCount}</strong>
+			<span data-i18n="social.profile.statsPosts"></span>
+		</button>
+		<button type="button" class="profile-stat" data-profile-stat="following" data-entity-hash="${entityHash}">
+			<strong>${followingCount}</strong>
+			<span data-i18n="social.profile.statsFollowing"></span>
+		</button>
+		<button type="button" class="profile-stat" data-profile-stat="followers" data-entity-hash="${entityHash}">
+			<strong>${followerCount}</strong>
+			<span data-i18n="social.profile.statsFollowers"></span>
+		</button>
+	</div>
+	<div class="profile-tabs tabs tabs-bordered" role="tablist" data-i18n="social.profile.tabsLabel">
+		<button type="button" class="profile-tab tab tab-active active" role="tab" aria-selected="true" data-profile-tab="posts" data-i18n="social.profile.tabPosts"></button>
+		<button type="button" class="profile-tab tab" role="tab" aria-selected="false" data-profile-tab="albums" data-i18n="social.profile.tabAlbums"></button>
+		<button type="button" class="profile-tab tab" role="tab" aria-selected="false" data-profile-tab="likes" data-i18n="social.profile.tabLikes"></button>
+		<button type="button" class="profile-tab tab" role="tab" aria-selected="false" data-profile-tab="cabinets" data-i18n="social.profile.tabCabinets"></button>
+	</div>
+</div>
+<div id="profilePostsPanel" class="profile-tab-panel" role="tabpanel" data-profile-panel="posts"></div>
+<div id="profileAlbumsPanel" class="profile-tab-panel hidden" role="tabpanel" data-profile-panel="albums"></div>
+<div id="profileLikesPanel" class="profile-tab-panel hidden" role="tabpanel" data-profile-panel="likes"></div>
+<div id="profileCabinetsPanel" class="profile-tab-panel hidden" role="tabpanel" data-profile-panel="cabinets"></div>

--- a/src/public/parts/shells/social/public/src/templates/quote_block.html
+++ b/src/public/parts/shells/social/public/src/templates/quote_block.html
@@ -1,0 +1,4 @@
+<blockquote class="quote-block">
+	<a href="${href}" class="link-btn quote-link" data-i18n="social.quote.viewOriginal"></a>
+	${snippetHtml}
+</blockquote>

--- a/src/public/parts/shells/social/public/src/templates/quote_preview.html
+++ b/src/public/parts/shells/social/public/src/templates/quote_preview.html
@@ -1,0 +1,5 @@
+<div class="quote-preview-inner">
+	<span data-i18n="social.quote.quoting"></span>
+	<div class="quote-preview-body"></div>
+	<button type="button" class="clear-quote-btn link-btn" data-i18n="social.quote.clear"></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/relationship_row.html
+++ b/src/public/parts/shells/social/public/src/templates/relationship_row.html
@@ -1,0 +1,7 @@
+<a class="following-link" href="${href}">
+	${avatarHtml}
+	<span>
+		<strong>${name}</strong>
+		<span class="profile-handle">${handle}</span>
+	</span>
+</a>

--- a/src/public/parts/shells/social/public/src/templates/reply_composer.html
+++ b/src/public/parts/shells/social/public/src/templates/reply_composer.html
@@ -1,0 +1,9 @@
+<div class="reply-composer">
+	${avatarSlot}
+	<div class="reply-composer-body">
+		<textarea rows="1" data-i18n="social.replies"></textarea>
+		<div class="reply-composer-actions">
+			<button type="button" class="reply-composer-submit" data-submit-reply="${actionKey}" data-i18n="social.replies.submit"></button>
+		</div>
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/reply_context.html
+++ b/src/public/parts/shells/social/public/src/templates/reply_context.html
@@ -1,0 +1,4 @@
+<a class="reply-context" href="${href}">
+	<span class="reply-context-label" data-i18n="social.reply.context" data-author="${author}"></span>
+	${snippetHtml}
+</a>

--- a/src/public/parts/shells/social/public/src/templates/repost_banner.html
+++ b/src/public/parts/shells/social/public/src/templates/repost_banner.html
@@ -1,0 +1,1 @@
+<div class="repost-banner"><span class="icon icon-repost" aria-hidden="true"></span><span data-i18n="social.feed.repostedBy" data-author="${author}"></span></div>

--- a/src/public/parts/shells/social/public/src/templates/settings_muted_keywords.html
+++ b/src/public/parts/shells/social/public/src/templates/settings_muted_keywords.html
@@ -1,0 +1,13 @@
+<section class="settings-card card">
+	<h3 class="settings-card-title" data-i18n="social.settings.mutedKeywordsTitle"></h3>
+	<p class="settings-hint" data-i18n="social.settings.mutedKeywordsHint"></p>
+	<form id="mutedKeywordForm" class="muted-keyword-form">
+		<input type="text" id="mutedKeywordInput" maxlength="64" data-i18n="social.settings.mutedKeywords" />
+		<label class="muted-keyword-match-tags">
+			<input type="checkbox" id="mutedKeywordMatchTags" checked />
+			<span data-i18n="social.settings.mutedKeywordsMatchTags"></span>
+		</label>
+		<button type="submit" class="btn btn-primary btn-sm" data-i18n="social.settings.mutedKeywordsAdd"></button>
+	</form>
+	<div class="muted-keyword-chips" id="mutedKeywordChips"></div>
+</section>

--- a/src/public/parts/shells/social/public/src/templates/settings_safety.html
+++ b/src/public/parts/shells/social/public/src/templates/settings_safety.html
@@ -1,0 +1,5 @@
+<section class="settings-card card">
+	<h3 class="settings-card-title" data-i18n="social.settings.safetyTitle"></h3>
+	<p class="settings-hint" data-i18n="social.settings.safetyHint"></p>
+	<div id="blocklistSection" class="profile-settings-blocklist"></div>
+</section>

--- a/src/public/parts/shells/social/public/src/templates/settings_taste.html
+++ b/src/public/parts/shells/social/public/src/templates/settings_taste.html
@@ -1,0 +1,16 @@
+<section class="settings-card card">
+	<h3 class="settings-card-title" data-i18n="social.settings.tasteTitle"></h3>
+	<p class="settings-hint" data-i18n="social.settings.tasteHint"></p>
+	<label class="settings-toggle">
+		<input type="checkbox" id="tastePublishPreferences" ${prefsCheckedAttr} />
+		<span data-i18n="social.taste.privacyPublishPreferences"></span>
+	</label>
+	<p class="settings-hint" data-i18n="social.taste.privacyPublishPreferencesHint"></p>
+	<label class="settings-toggle">
+		<input type="checkbox" id="tastePublishReactions" ${reactionsCheckedAttr} />
+		<span data-i18n="social.taste.privacyPublishReactions"></span>
+	</label>
+	<p class="settings-hint" data-i18n="social.taste.privacyPublishReactionsHint"></p>
+	<button type="button" id="tasteRebuildButton" class="btn btn-primary btn-sm" data-i18n="social.taste.rebuild"></button>
+	<div class="taste-list" data-taste-list></div>
+</section>

--- a/src/public/parts/shells/social/public/src/templates/settings_taste_row.html
+++ b/src/public/parts/shells/social/public/src/templates/settings_taste_row.html
@@ -1,0 +1,11 @@
+<article class="taste-row card">
+	<div class="taste-row-main">
+		<strong class="taste-label">${label}</strong>
+		<span class="taste-hash">${tagHashShort}</span>
+		<span class="taste-weight" data-i18n="social.taste.weight" data-weight="${weight}"></span>
+	</div>
+	<form class="taste-rename-form" data-tag-hash="${tagHash}">
+		<input type="text" maxlength="64" data-i18n="social.taste.name" value="${labelValue}" />
+		<button type="submit" class="btn btn-ghost btn-xs" data-i18n="social.taste.save"></button>
+	</form>
+</article>

--- a/src/public/parts/shells/social/public/src/templates/settings_toggle_card.html
+++ b/src/public/parts/shells/social/public/src/templates/settings_toggle_card.html
@@ -1,0 +1,8 @@
+<section class="settings-card card">
+	<h3 class="settings-card-title" data-i18n="${titleKey}"></h3>
+	<p class="settings-hint" data-i18n="${hintKey}"></p>
+	<label class="settings-toggle">
+		<input type="checkbox" id="${inputId}" ${checkedAttr} />
+		<span data-i18n="${labelKey}"></span>
+	</label>
+</section>

--- a/src/public/parts/shells/social/public/src/templates/text_prompt_modal.html
+++ b/src/public/parts/shells/social/public/src/templates/text_prompt_modal.html
@@ -1,0 +1,7 @@
+<div class="modal-box${boxClass}">
+	<h3 class="font-bold text-lg mb-4">${escapeHtml(title)}</h3>
+	${bodyHtml}
+	<div class="modal-action">
+		${actionsHtml}
+	</div>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/translate_block.html
+++ b/src/public/parts/shells/social/public/src/templates/translate_block.html
@@ -1,0 +1,3 @@
+<div class="translation-block">
+	<strong data-i18n="social.translate.label"></strong> ${translated}
+</div>

--- a/src/public/parts/shells/social/public/src/templates/trending_header.html
+++ b/src/public/parts/shells/social/public/src/templates/trending_header.html
@@ -1,0 +1,5 @@
+<h2 class="aside-card-title" data-i18n="social.trending.title"></h2>
+<div class="trending-scope-tabs" role="tablist">
+	<button type="button" class="btn btn-ghost btn-xs ${localActive}" data-trending-scope="local" data-i18n="social.trending.scopeLocal"></button>
+	<button type="button" class="btn btn-ghost btn-xs ${nearbyActive}" data-trending-scope="nearby" data-i18n="social.trending.scopeNearby"></button>
+</div>

--- a/src/public/parts/shells/social/public/src/templates/video_replies_header.html
+++ b/src/public/parts/shells/social/public/src/templates/video_replies_header.html
@@ -1,0 +1,6 @@
+<div class="video-replies-header">
+	<span class="video-replies-title" data-i18n="social.actions.replies"></span>
+	<button type="button" class="video-replies-close" data-close-replies data-i18n="social.video.closeReplies">
+		<span class="icon icon-close" aria-hidden="true"></span>
+	</button>
+</div>

--- a/src/public/parts/shells/social/public/src/viewChrome.mjs
+++ b/src/public/parts/shells/social/public/src/viewChrome.mjs
@@ -1,0 +1,43 @@
+import { pauseAllVideos } from './lib/videoAutoplay.mjs'
+
+/** 可写入 location.hash 的主导航视图 */
+export const MAIN_NAV_VIEWS = [
+	'feed', 'explore', 'notifications', 'saved', 'drafts', 'profile', 'videos', 'live', 'settings',
+]
+
+/** 二级视图 → 保留高亮的主导航 */
+const OVERLAY_PARENT = {
+	settings: 'profile',
+	search: 'feed',
+	topic: 'explore',
+	postDetail: 'feed',
+	liveBroadcast: 'live',
+}
+
+/** @type {string | null} 当前激活的主导航视图名 */
+let activeMainView = null
+
+/**
+ * @returns {string | null} 当前主导航视图
+ */
+export function currentMainView() {
+	return activeMainView
+}
+
+/**
+ * 切换主导航视图的高亮与可见性。
+ * @param {string} view 视图名（feed / explore / profile / …）
+ * @returns {void}
+ */
+export function activateView(view) {
+	activeMainView = view
+	const highlight = OVERLAY_PARENT[view] || view
+	for (const button of document.querySelectorAll('.nav-btn'))
+		button.classList.toggle('active', button.dataset.view === highlight)
+	for (const section of document.querySelectorAll('.view')) {
+		const show = section.id === `${view}View`
+		section.classList.toggle('hidden', !show)
+		if (!show) pauseAllVideos(section)
+	}
+	document.getElementById('composer')?.classList.toggle('hidden', view !== 'feed')
+}

--- a/src/public/parts/shells/social/public/src/views/albums.mjs
+++ b/src/public/parts/shells/social/public/src/views/albums.mjs
@@ -1,0 +1,205 @@
+import { socialApi, viewerEntityHash } from '../lib/apiClient.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { bindVisibilityPicker, readVisibilityPicker, renderVisibilityPickerHtml } from '../visibilityPicker.mjs'
+import { openDialogFromTemplate } from '/scripts/features/dialog.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { mediaRefUrl } from '/parts/shells:chat/shared/evfsMedia.mjs'
+
+/**
+ * @param {object | null} coverMediaRef 封面
+ * @param {string} displayName 相册名
+ * @returns {string} 封面 HTML
+ */
+function renderAlbumCoverHtml(coverMediaRef, displayName) {
+	if (coverMediaRef) 
+		try {
+			const url = mediaRefUrl(coverMediaRef)
+			const alt = escapeHtml(String(coverMediaRef.alt || displayName || ''))
+			return `<div class="album-card-cover"><img class="album-card-cover-img" src="${escapeHtml(url)}" alt="${alt}" loading="lazy" /></div>`
+		}
+		catch { /* fall through */ }
+	
+	return `<div class="album-card-cover album-card-cover-fallback">${escapeHtml(displayName)}</div>`
+}
+
+/**
+ * 渲染资料页相册网格。
+ * @param {string} entityHash owner
+ * @param {HTMLElement} container 容器
+ * @returns {Promise<void>}
+ */
+export async function renderProfileAlbums(entityHash, container) {
+	const data = await socialApi(`/albums/${entityHash}`)
+	const albums = data.albums || []
+	const isSelf = viewerEntityHash() === entityHash
+	container.replaceChildren()
+	if (isSelf) {
+		const toolbar = document.createElement('div')
+		toolbar.className = 'album-toolbar'
+		toolbar.innerHTML = `<button type="button" class="btn btn-primary btn-sm" data-album-create>${escapeHtml(geti18n('social.albums.create'))}</button>`
+		toolbar.querySelector('[data-album-create]')?.addEventListener('click', () => {
+			void openCreateAlbumDialog(() => renderProfileAlbums(entityHash, container))
+		})
+		container.appendChild(toolbar)
+	}
+	if (!albums.length) {
+		const empty = document.createElement('div')
+		empty.className = 'empty'
+		empty.textContent = geti18n('social.albums.empty')
+		container.appendChild(empty)
+		return
+	}
+	const grid = document.createElement('div')
+	grid.className = 'album-grid'
+	for (const album of albums) {
+		const card = document.createElement('button')
+		card.type = 'button'
+		card.className = 'album-card'
+		card.dataset.albumOpen = entityHash
+		card.dataset.albumId = album.albumId
+		const displayName = album.virtual ? geti18n('social.albums.defaultName') : album.name
+		const visKey = album.visibility === 'followers_since' ? 'followers7d' : album.visibility || 'public'
+		card.innerHTML = `
+			${renderAlbumCoverHtml(album.coverMediaRef, displayName)}
+			<div class="album-card-meta">
+				<strong>${escapeHtml(displayName)}</strong>
+				<span class="muted">${album.postCount || 0} · ${escapeHtml(geti18n(`social.visibility.${visKey}`))}</span>
+			</div>
+		`
+		card.addEventListener('click', () => {
+			void openAlbumDetail(entityHash, album.albumId, container)
+		})
+		grid.appendChild(card)
+	}
+	container.appendChild(grid)
+}
+
+/**
+ * 打开相册详情（成员帖列表）。
+ * @param {string} entityHash owner
+ * @param {string} albumId 相册
+ * @param {HTMLElement} [backContainer] 返回时刷新的容器
+ * @returns {Promise<void>}
+ */
+export async function openAlbumDetail(entityHash, albumId, backContainer = null) {
+	const detail = await socialApi(`/albums/${entityHash}/${albumId}`)
+	const album = detail.album
+	const items = detail.items || []
+	const isSelf = viewerEntityHash() === entityHash
+	const panel = backContainer || document.getElementById('profileAlbumsPanel')
+	if (!panel) return
+	panel.replaceChildren()
+	const header = document.createElement('div')
+	header.className = 'album-detail-header'
+	header.innerHTML = `
+		<button type="button" class="btn btn-ghost btn-sm" data-album-back>${escapeHtml(geti18n('social.albums.back'))}</button>
+		<h3>${escapeHtml(album.virtual ? geti18n('social.albums.defaultName') : album.name)}</h3>
+		<p class="muted">${escapeHtml(album.description || '')}</p>
+		${isSelf && !album.virtual ? `
+			<div class="album-detail-actions">
+				<button type="button" class="btn btn-ghost btn-sm" data-album-edit>${escapeHtml(geti18n('social.albums.edit'))}</button>
+				<button type="button" class="btn btn-ghost btn-sm" data-album-delete-links>${escapeHtml(geti18n('social.albums.deleteLinks'))}</button>
+				<button type="button" class="btn btn-error btn-sm" data-album-delete-posts>${escapeHtml(geti18n('social.albums.deleteWithPosts'))}</button>
+			</div>
+		` : ''}
+	`
+	header.querySelector('[data-album-back]')?.addEventListener('click', () => {
+		void renderProfileAlbums(entityHash, panel)
+	})
+	header.querySelector('[data-album-edit]')?.addEventListener('click', () => {
+		void openEditAlbumDialog(album, () => openAlbumDetail(entityHash, albumId, panel))
+	})
+	header.querySelector('[data-album-delete-links]')?.addEventListener('click', async () => {
+		await socialApi(`/albums/${albumId}?deletePosts=0`, { method: 'DELETE' })
+		await renderProfileAlbums(entityHash, panel)
+	})
+	header.querySelector('[data-album-delete-posts]')?.addEventListener('click', async () => {
+		await socialApi(`/albums/${albumId}?deletePosts=1`, { method: 'DELETE' })
+		await renderProfileAlbums(entityHash, panel)
+	})
+	panel.appendChild(header)
+	if (!items.length) {
+		const empty = document.createElement('div')
+		empty.className = 'empty'
+		empty.textContent = geti18n('social.albums.emptyPosts')
+		panel.appendChild(empty)
+		return
+	}
+	const list = document.createElement('div')
+	list.className = 'album-posts'
+	for (const item of items)
+		list.appendChild(await buildPostCard(item))
+	panel.appendChild(list)
+}
+
+/**
+ * @param {() => Promise<void>} onDone 完成回调
+ * @returns {Promise<void>}
+ */
+async function openCreateAlbumDialog(onDone) {
+	const dialog = await openDialogFromTemplate('album_edit_dialog', {
+		title: geti18n('social.albums.create'),
+		name: '',
+		description: '',
+		visibilityPickerHtml: renderVisibilityPickerHtml({ idPrefix: 'albumCreate', selected: 'public' }),
+		submitLabel: geti18n('social.albums.create'),
+	})
+	bindVisibilityPicker(dialog)
+	dialog.querySelector('[data-album-submit]')?.addEventListener('click', async () => {
+		const name = /** @type {HTMLInputElement} */dialog.querySelector('[data-album-name]')?.value?.trim()
+		const description = /** @type {HTMLTextAreaElement} */dialog.querySelector('[data-album-description]')?.value?.trim() || ''
+		if (!name) return
+		await socialApi('/albums', {
+			method: 'POST',
+			body: JSON.stringify({
+				name,
+				description,
+				...readVisibilityPicker(dialog),
+			}),
+		})
+		dialog.close()
+		await onDone()
+	})
+}
+
+/**
+ * @param {object} album 相册
+ * @param {() => Promise<void>} onDone 完成回调
+ * @returns {Promise<void>}
+ */
+async function openEditAlbumDialog(album, onDone) {
+	let selected = album.visibility || 'public'
+	if (selected === 'followers_since') {
+		const day = 24 * 60 * 60 * 1000
+		selected = (album.minFollowMs || 0) >= 30 * day ? 'followers_30d' : 'followers_7d'
+	}
+	const dialog = await openDialogFromTemplate('album_edit_dialog', {
+		title: geti18n('social.albums.edit'),
+		name: album.name || '',
+		description: album.description || '',
+		visibilityPickerHtml: renderVisibilityPickerHtml({
+			idPrefix: 'albumEdit',
+			selected,
+			allow: (album.allow || []).join(' '),
+			except: (album.except || []).join(' '),
+		}),
+		submitLabel: geti18n('social.albums.save'),
+	})
+	bindVisibilityPicker(dialog)
+	dialog.querySelector('[data-album-submit]')?.addEventListener('click', async () => {
+		const name = /** @type {HTMLInputElement} */dialog.querySelector('[data-album-name]')?.value?.trim()
+		const description = /** @type {HTMLTextAreaElement} */dialog.querySelector('[data-album-description]')?.value?.trim() || ''
+		if (!name) return
+		await socialApi(`/albums/${album.albumId}/update`, {
+			method: 'POST',
+			body: JSON.stringify({
+				name,
+				description,
+				...readVisibilityPicker(dialog),
+			}),
+		})
+		dialog.close()
+		await onDone()
+	})
+}

--- a/src/public/parts/shells/social/public/src/views/drafts.mjs
+++ b/src/public/parts/shells/social/public/src/views/drafts.mjs
@@ -1,0 +1,56 @@
+import { showToastI18n } from '../../../../../scripts/features/toast.mjs'
+import { escapeHtml } from '../../../../../scripts/lib/escapeHtml.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { formatTimeHtml } from '../lib/display.mjs'
+import { buildEmptyState } from '../lib/emptyState.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/**
+ * 渲染草稿箱列表。
+ * @returns {Promise<void>}
+ */
+export async function loadDrafts() {
+	const panel = document.getElementById('draftsPanel')
+	if (!panel) return
+	const data = await socialApi('/drafts')
+	const drafts = Array.isArray(data.drafts) ? data.drafts : []
+	if (!drafts.length) {
+		panel.replaceChildren(await buildEmptyState({
+			modClass: ' empty-state--saved empty-state--compact',
+			titleKey: 'social.empty.drafts',
+			hintKey: 'social.drafts.emptyHint',
+		}))
+		return
+	}
+	panel.innerHTML = `<div class="drafts-list">${drafts.map(row => {
+		const preview = String(row.preview || '').trim() || geti18n('social.drafts.untitled')
+		return `
+			<article class="draft-row" data-draft-id="${escapeHtml(row.draftId)}">
+				<button type="button" class="draft-row-main" data-open-draft="${escapeHtml(row.draftId)}">
+					<p class="draft-row-preview">${escapeHtml(preview)}</p>
+					${formatTimeHtml(row.updatedAt, 'draft-row-meta')}
+				</button>
+				<button type="button" class="draft-row-action" data-delete-draft="${escapeHtml(row.draftId)}" aria-label="${escapeHtml(geti18n('social.drafts.delete'))}">
+					<span class="icon icon-delete" aria-hidden="true"></span>
+				</button>
+			</article>
+		`
+	}).join('')}</div>`
+}
+
+/**
+ * 删除草稿并刷新列表。
+ * @param {string} draftId id
+ * @returns {Promise<void>}
+ */
+export async function removeDraft(draftId) {
+	try {
+		await socialApi(`/drafts/${encodeURIComponent(draftId)}`, { method: 'DELETE' })
+		await loadDrafts()
+		showToastI18n('success', 'social.drafts.deleted')
+	}
+	catch (error) {
+		const err = error instanceof Error ? error : new Error(String(error))
+		showToastI18n('error', 'social.drafts.deleteFailed', { error: err.message })
+	}
+}

--- a/src/public/parts/shells/social/public/src/views/explore.mjs
+++ b/src/public/parts/shells/social/public/src/views/explore.mjs
@@ -1,0 +1,150 @@
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { mediaRefUrl } from '/parts/shells:chat/shared/evfsMedia.mjs'
+import { formatSocialPostHref, formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { authorLabel, entityHandle, formatTimeHtml, mountMarkdown, renderAvatarHtml } from '../lib/display.mjs'
+import { mountEmptyState } from '../lib/emptyState.mjs'
+import { renderSuggestedAccountRows } from '../lib/suggestedAccounts.mjs'
+import { appendTemplate, renderTemplate } from '/scripts/features/template.mjs'
+import { state } from '../state.mjs'
+
+let exploreToolbarBound = false
+
+/**
+ * 绑定探索页工具栏（幂等）。
+ * @returns {void}
+ */
+function bindExploreToolbar() {
+	if (exploreToolbarBound) return
+	const input = document.getElementById('exploreMediaOnly')
+	if (!(input instanceof HTMLInputElement)) return
+	exploreToolbarBound = true
+	input.addEventListener('change', () => {
+		state.exploreMediaOnly = input.checked
+		void loadExplore()
+	})
+}
+
+/**
+ * 渲染探索帖媒体缩略条。
+ * @param {object[]} mediaThumbs 媒体引用
+ * @returns {string} HTML
+ */
+function renderExploreThumbs(mediaThumbs) {
+	if (!mediaThumbs?.length) return ''
+	const cells = []
+	for (const ref of mediaThumbs.slice(0, 4)) {
+		let url = ''
+		try { url = mediaRefUrl(ref) }
+		catch { continue }
+		const mimeType = ref.mimeType || ''
+		const isVideo = (ref.kind || '').startsWith('video') || mimeType.startsWith('video/')
+		cells.push(isVideo
+			? '<div class="explore-thumb explore-thumb-video" aria-hidden="true"><span class="icon icon-media"></span></div>'
+			: `<div class="explore-thumb"><img src="${escapeHtml(url)}" alt="" loading="lazy" /></div>`)
+	}
+	if (!cells.length) return ''
+	return `<div class="explore-thumbs" data-count="${cells.length}">${cells.join('')}</div>`
+}
+
+/**
+ * 加载并渲染探索页账户与帖子推荐。
+ * @returns {Promise<void>}
+ */
+export async function loadExplore() {
+	bindExploreToolbar()
+	const mediaInput = document.getElementById('exploreMediaOnly')
+	if (mediaInput instanceof HTMLInputElement)
+		mediaInput.checked = state.exploreMediaOnly
+
+	const mediaQuery = state.exploreMediaOnly ? '&mediaOnly=true' : ''
+	const [accounts, posts] = await Promise.all([
+		socialApi('/explore?limit=20'),
+		socialApi(`/explore/posts?limit=20${mediaQuery}`),
+	])
+
+	const accountList = document.getElementById('exploreAccountList')
+	const postList = document.getElementById('explorePostList')
+	if (!accountList || !postList) return
+
+	const accountRows = (accounts.accounts || []).filter(
+		row => row.entityHash !== state.viewerEntityHash,
+	)
+	accountList.replaceChildren()
+	if (!accountRows.length)
+		await mountEmptyState(accountList, {
+			titleKey: 'social.empty.exploreAccounts',
+			iconClass: 'icon-user',
+			modClass: ' empty-state--explore',
+		})
+	else
+		for (const account of accountRows) {
+			const profileHref = escapeHtml(formatSocialProfileHref(account.entityHash))
+			const row = await renderTemplate('explore_account', {
+				profileHref,
+				entityHash: escapeHtml(account.entityHash),
+				name: escapeHtml(account.name),
+				handle: escapeHtml(entityHandle(account.entityHash, account)),
+				avatarHtml: renderAvatarHtml(account.entityHash, { name: account.name, avatar: account.avatarUrl }, 'explore-account-avatar'),
+				bioHtml: account.bio ? '<div class="explore-account-bio" data-explore-bio></div>' : '',
+			})
+			const bioHost = row.querySelector('[data-explore-bio]')
+			if (bioHost instanceof HTMLElement && account.bio)
+				await mountMarkdown(bioHost, account.bio, account.entityHash)
+			accountList.appendChild(row)
+		}
+
+	const postRows = posts.posts || []
+	postList.replaceChildren()
+	if (!postRows.length) {
+		await mountEmptyState(postList, {
+			titleKey: 'social.empty.explorePosts',
+			iconClass: 'icon-explore',
+			modClass: ' empty-state--explore',
+		})
+		return
+	}
+
+	for (const post of postRows) {
+		const href = escapeHtml(formatSocialPostHref(post.entityHash, post.postId))
+		const authorHref = escapeHtml(formatSocialProfileHref(post.entityHash))
+		const snippet = post.textSnippet || (post.mediaThumbs?.length
+			? '' // filled via data-i18n below when empty text
+			: '')
+		const name = authorLabel(post.entityHash, post.authorProfile)
+		const handle = entityHandle(post.entityHash, post.authorProfile)
+		const timeHtml = formatTimeHtml(post.hlc?.wall)
+		const snippetHtml = post.textSnippet
+			? `<p class="explore-snippet">${escapeHtml(post.textSnippet)}</p>`
+			: post.mediaThumbs?.length
+				? '<p class="explore-snippet" data-i18n="social.profile.mediaOnly"></p>'
+				: ''
+		await appendTemplate(postList, 'explore_post', {
+			href,
+			authorHref,
+			name: escapeHtml(name),
+			handle: escapeHtml(handle),
+			timeHtml,
+			avatarHtml: renderAvatarHtml(post.entityHash, post.authorProfile || { name }, 'explore-post-avatar'),
+			snippetHtml,
+			thumbsHtml: renderExploreThumbs(post.mediaThumbs),
+		})
+	}
+
+	const exploreSuggestedHost = document.getElementById('exploreSuggested')
+	const exploreSuggestedList = document.getElementById('exploreSuggestedList')
+	if (exploreSuggestedHost && exploreSuggestedList) {
+		const suggested = accountRows.slice(0, 5)
+		if (!suggested.length) {
+			exploreSuggestedHost.classList.add('hidden')
+			exploreSuggestedList.replaceChildren()
+		}
+		else {
+			exploreSuggestedHost.classList.remove('hidden')
+			await renderSuggestedAccountRows(exploreSuggestedList, suggested)
+		}
+	}
+
+	const { loadTrendingHashtags } = await import('./feed.mjs')
+	await loadTrendingHashtags('local', 'exploreTrending')
+}

--- a/src/public/parts/shells/social/public/src/views/feed.mjs
+++ b/src/public/parts/shells/social/public/src/views/feed.mjs
@@ -1,0 +1,338 @@
+import { formatSocialTopicHref, formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { bindDwellTracker } from '../dwellTracker.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { entityHandle } from '../lib/display.mjs'
+import { mountEmptyState } from '../lib/emptyState.mjs'
+import { appendFeedItemsWithThreads } from '../lib/feedThreads.mjs'
+import { renderSuggestedAccountRows } from '../lib/suggestedAccounts.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { state } from '../state.mjs'
+import { renderTemplate } from '/scripts/features/template.mjs'
+import { bindInfiniteScroll, disconnectInfiniteScroll, ensureScrollSentinel } from '/scripts/infiniteScroll.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+/** @type {(() => void) | null} */
+let unbindDwell = null
+
+/**
+ * 更新 feed 侧栏搜索清除按钮可见性。
+ * @returns {void}
+ */
+export function updateFeedSearchChrome() {
+	const clearButton = document.getElementById('feedSearchClearButton')
+	const hasSearch = !!state.activeFeedSearchQuery
+	clearButton?.classList.toggle('hidden', !hasSearch)
+}
+
+/**
+ * 循环重放仅在用户已真实下滚且内容高于视口时允许，避免短 feed 首屏自动复制。
+ * @returns {boolean} 是否允许重放
+ */
+function canReplayFeed() {
+	const list = document.getElementById('feedList')
+	if (!list?.children.length) return false
+	const scrolled = (window.scrollY || document.documentElement.scrollTop) > 0
+	if (!scrolled) return false
+	return document.documentElement.scrollHeight > window.innerHeight
+}
+
+/**
+ * 绑定 feed 无限滚动。
+ * @returns {void}
+ */
+export function bindFeedInfiniteScroll() {
+	const list = document.getElementById('feedList')
+	if (!list || state.activeFeedSearchQuery) {
+		disconnectInfiniteScroll()
+		return
+	}
+	const sentinel = ensureScrollSentinel(list, 'feedScrollSentinel')
+	bindInfiniteScroll({
+		sentinel,
+		rootMargin: '480px 0px',
+		/** @returns {boolean} 有下一页或可循环重放 */
+		hasMore: () => !!state.feedCursor
+			|| (!!state.feedShownItems?.length && canReplayFeed()),
+		/** @returns {Promise<void>} 追加下一页或循环重放 */
+		onLoad: () => loadFeed(true),
+	})
+}
+
+/**
+ * 后台预取下一页（结果缓存在 state.feedPrefetch）。
+ * @returns {void}
+ */
+function scheduleFeedPrefetch() {
+	const cursor = state.feedCursor
+	if (!cursor || state.activeFeedSearchQuery) return
+	if (state.feedPrefetch?.cursor === cursor) return
+	if (state.feedPrefetchInFlight) return
+	const gen = feedGeneration
+	state.feedPrefetchInFlight = (async () => {
+		const data = await socialApi(
+			`/feed?limit=30${feedRankingQuery()}&cursor=${encodeURIComponent(cursor)}`,
+		).catch(() => null)
+		if (feedGeneration !== gen) return
+		if (!data || state.feedCursor !== cursor) return
+		state.feedPrefetch = {
+			cursor,
+			items: data.items || [],
+			nextCursor: data.nextCursor || null,
+		}
+	})().finally(() => {
+		state.feedPrefetchInFlight = null
+	})
+}
+
+/**
+ * 循环重放已展示条目。
+ * @returns {Promise<void>}
+ */
+async function replayFeedItems() {
+	const items = state.feedShownItems
+	if (!items?.length) return
+	const list = document.getElementById('feedList')
+	if (!list) return
+	const divider = document.createElement('div')
+	divider.className = 'feed-replay-divider text-center text-sm opacity-50 py-3'
+	divider.dataset.i18n = 'social.feed.replayDivider'
+	list.appendChild(divider)
+	await appendFeedItemsWithThreads(list, items, item => buildPostCard(item).catch(() => null))
+	// 只把哨兵挪到尾部，不重绑 observer——否则哨兵仍在视口内时会立刻再触发形成死循环
+	ensureScrollSentinel(list, 'feedScrollSentinel')
+}
+
+/**
+ * 加载并渲染右栏推荐关注账户。
+ * @returns {Promise<void>}
+ */
+export async function loadSuggestedAccounts() {
+	const aside = document.getElementById('asideSuggested')
+	const list = document.getElementById('asideSuggestedList')
+	if (!aside || !list) return
+	const data = await socialApi('/explore?limit=5').catch(() => ({ accounts: [] }))
+	const accounts = (data.accounts || []).filter(
+		row => row.entityHash !== state.viewerEntityHash,
+	)
+	if (!accounts.length) {
+		aside.classList.add('hidden')
+		list.replaceChildren()
+		return
+	}
+	aside.classList.remove('hidden')
+	await renderSuggestedAccountRows(list, accounts)
+}
+
+/**
+ * 加载并渲染热门话题标签。
+ * @param {'local' | 'nearby'} [scope='local'] 范围
+ * @param {string} [containerId='feedTrending'] 容器 id
+ * @returns {Promise<void>}
+ */
+export async function loadTrendingHashtags(scope = 'local', containerId = 'feedTrending') {
+	const aside = document.getElementById(containerId)
+	if (!aside) return
+	const currentScope = scope === 'nearby' ? 'nearby' : 'local'
+	aside.dataset.trendingScope = currentScope
+	const data = await socialApi(`/hashtags/trending?limit=12&scope=${currentScope}`).catch(() => ({ tags: [] }))
+	const tags = data.tags || []
+	aside.classList.remove('hidden')
+	aside.replaceChildren()
+	aside.appendChild(await renderTemplate('trending_header', {
+		localActive: currentScope === 'local' ? 'active' : '',
+		nearbyActive: currentScope === 'nearby' ? 'active' : '',
+	}))
+	const list = document.createElement('div')
+	list.className = 'trending-tags'
+	if (!tags.length)
+		await mountEmptyState(list, { titleKey: 'social.trending.empty', modClass: ' empty-state--hint' })
+	else
+		for (const row of tags) {
+			const link = document.createElement('a')
+			link.className = 'trending-tag link-btn'
+			link.href = formatSocialTopicHref(row.tag)
+			link.textContent = `#${row.tag}`
+			const count = document.createElement('span')
+			count.className = 'trending-count'
+			count.textContent = String(row.count)
+			link.appendChild(count)
+			link.dataset.n = String(row.count)
+			link.dataset.i18n = 'social.trending.postCount'
+			list.appendChild(link)
+		}
+
+	aside.appendChild(list)
+	aside.querySelectorAll('[data-trending-scope]').forEach(btn => {
+		btn.addEventListener('click', () => {
+			const next = btn.getAttribute('data-trending-scope') === 'nearby' ? 'nearby' : 'local'
+			void loadTrendingHashtags(next, containerId)
+		})
+	})
+}
+
+/**
+ * 在 feed 顶部插入单条帖子卡片（WS 真增量）。
+ * @param {object} item feed 条目
+ * @returns {Promise<boolean>} 是否成功插入
+ */
+export async function prependFeedItem(item) {
+	if (state.activeFeedSearchQuery) return false
+	if (state.feedCursor) return false
+	const feedView = document.getElementById('feedView')
+	if (!feedView || feedView.classList.contains('hidden')) return false
+	const list = document.getElementById('feedList')
+	if (!list) return false
+	document.getElementById('feedNewPostsBanner')?.remove()
+	const card = await buildPostCard(item).catch(() => null)
+	if (!card) return false
+	const empty = list.querySelector('.feed-empty')
+	if (empty) list.replaceChildren(card)
+	else list.prepend(card)
+	return true
+}
+
+/**
+ * @returns {string} feed ranking query 片段
+ */
+function feedRankingQuery() {
+	return state.feedRanking === 'for_you' ? '&ranking=for_you' : ''
+}
+
+/**
+ * 更新 feed 排序 tab 高亮。
+ * @returns {void}
+ */
+export function updateFeedRankingTabs() {
+	for (const tab of document.querySelectorAll('[data-feed-ranking]')) {
+		if (!(tab instanceof HTMLElement)) continue
+		const active = tab.dataset.feedRanking === state.feedRanking
+		tab.classList.toggle('active', active)
+		tab.setAttribute('aria-selected', active ? 'true' : 'false')
+		tab.setAttribute('role', 'tab')
+	}
+}
+
+/**
+ * 切换 feed 排序并重新加载。
+ * @param {string} ranking latest | for_you
+ * @returns {Promise<void>}
+ */
+export async function setFeedRanking(ranking) {
+	state.feedRanking = ranking === 'for_you' ? 'for_you' : 'latest'
+	state.feedCursor = null
+	state.feedPrefetch = null
+	state.feedShownItems = null
+	updateFeedRankingTabs()
+	await loadFeed(false)
+}
+
+/**
+ * 显示「有新帖」横幅（深分页 / 非首屏 fallback）。
+ * @returns {void}
+ */
+export function showFeedNewPostsBanner() {
+	const feedView = document.getElementById('feedView')
+	if (!feedView || feedView.classList.contains('hidden')) return
+	if (state.activeFeedSearchQuery) return
+	if (document.getElementById('feedNewPostsBanner')) return
+	const banner = document.createElement('button')
+	banner.type = 'button'
+	banner.id = 'feedNewPostsBanner'
+	banner.className = 'feed-new-posts-banner btn btn-primary btn-sm'
+	banner.dataset.i18n = 'social.feed.newPosts'
+	banner.addEventListener('click', () => {
+		banner.remove()
+		void loadFeed(false)
+	})
+	document.getElementById('feedList')?.before(banner)
+}
+
+let feedGeneration = 0
+
+/**
+ * 加载首页 feed（分页）。
+ * @param {boolean} [append=false] 追加
+ * @returns {Promise<void>}
+ */
+export async function loadFeed(append = false) {
+	if (state.activeFeedSearchQuery) return
+	const list = document.getElementById('feedList')
+	if (!list) return
+
+	if (append && !state.feedCursor) {
+		await replayFeedItems()
+		return
+	}
+
+	const gen = ++feedGeneration
+	let items
+	let nextCursor
+
+	const cached = append && state.feedPrefetch
+		&& state.feedPrefetch.cursor === state.feedCursor
+		? state.feedPrefetch
+		: null
+	if (cached) {
+		items = cached.items
+		nextCursor = cached.nextCursor
+		state.feedPrefetch = null
+	}
+	else {
+		const cursorQuery = append && state.feedCursor
+			? `&cursor=${encodeURIComponent(state.feedCursor)}`
+			: ''
+		const data = await socialApi(`/feed?limit=30${feedRankingQuery()}${cursorQuery}`)
+		if (feedGeneration !== gen) return
+		items = data.items || []
+		nextCursor = data.nextCursor || null
+	}
+	if (feedGeneration !== gen) return
+
+	state.feedCursor = nextCursor || null
+	if (!append) {
+		state.feedShownItems = [...items]
+		state.feedPrefetch = null
+	}
+	else if (items.length)
+		state.feedShownItems = [...state.feedShownItems || [], ...items]
+
+	if (!append && !items.length) {
+		await mountEmptyState(list, { titleKey: 'social.empty.feed', modClass: ' empty-state--plain' })
+		state.feedShownItems = null
+	}
+	else if (!append) {
+		list.replaceChildren()
+		await appendFeedItemsWithThreads(list, items, item => buildPostCard(item).catch(() => null))
+		if (feedGeneration !== gen) return
+		updateFeedRankingTabs()
+	}
+	else
+		await appendFeedItemsWithThreads(list, items, item => buildPostCard(item).catch(() => null))
+
+	bindFeedInfiniteScroll()
+	scheduleFeedPrefetch()
+	if (unbindDwell) unbindDwell()
+	unbindDwell = bindDwellTracker(list)
+	const { bindFeedVideoAutoplay } = await import('../lib/videoAutoplay.mjs')
+	bindFeedVideoAutoplay(list)
+	void loadTrendingHashtags()
+	void loadSuggestedAccounts()
+}
+
+/**
+ * @param {object} entity 搜索命中实体
+ * @returns {Promise<HTMLElement>} 卡片
+ */
+export async function buildEntitySearchCard(entity) {
+	const handle = entityHandle(entity.entityHash, entity)
+	const label = entity.alias || entity.name || handle
+	return renderTemplate('feed_entity_search', {
+		profileHref: escapeHtml(formatSocialProfileHref(entity.entityHash)),
+		label: escapeHtml(label),
+		handle: escapeHtml(handle),
+		score: Number(entity.nodeScore || 0).toFixed(2),
+		entityHash: escapeHtml(entity.entityHash),
+		isFollowing: entity.following ? 'true' : 'false',
+		followI18n: entity.following ? 'social.actions.following' : 'social.actions.follow',
+	})
+}

--- a/src/public/parts/shells/social/public/src/views/live.mjs
+++ b/src/public/parts/shells/social/public/src/views/live.mjs
@@ -1,0 +1,641 @@
+import { buildSocialLiveAvWsUrl } from '../../shared/liveAvWsUrl.mjs'
+import { chatApi, socialApi } from '../lib/apiClient.mjs'
+import { entityAvatarUrl, renderAvatarHtml } from '../lib/display.mjs'
+import { playHeartAnim } from '../lib/heartAnim.mjs'
+import { createSnapCursorFeed } from '../lib/snapCursorFeed.mjs'
+import { bindVerticalSnap } from '../lib/verticalSnap.mjs'
+import { activateView } from '../viewChrome.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { joinAvRelayRoom } from '/parts/shells:chat/shared/avRelayClient.mjs'
+import { mountVoiceRing } from '/parts/shells:chat/shared/voiceRing.mjs'
+import { themeColorForEntity } from '/parts/shells:chat/shared/themeColor.mjs'
+import { setElementI18n } from '/scripts/i18n/index.mjs'
+
+/** @type {{ disconnect: () => void, observe: (el: HTMLElement) => void } | null} */
+let snapBind = null
+/** @type {string} */
+let liveScope = 'local'
+/** @type {number} */
+let currentLiveIndex = -1
+
+/** @type {ReturnType<typeof createSnapCursorFeed>} */
+const liveFeed = createSnapCursorFeed({
+	/**
+	 * @param {string | null} cursor 游标
+	 * @returns {Promise<object | null>} 分页结果
+	 */
+	fetchPage: cursor => socialApi(
+		`/live/feed?limit=20&scope=${encodeURIComponent(liveScope)}&cursor=${encodeURIComponent(cursor || '')}`,
+	).catch(() => null),
+	/**
+	 * @param {HTMLElement} container 容器
+	 * @param {object[]} items 条目
+	 * @returns {void} 无返回
+	 */
+	appendSlides: (container, items) => {
+		for (const item of items) {
+			const slide = buildLiveSlide(item)
+			container.appendChild(slide)
+			snapBind?.observe(slide)
+		}
+	},
+	/** @returns {boolean} nearby 大厅时跳过竖滑分页 */
+	shouldSkip: () => liveScope === 'nearby',
+})
+
+/**
+ * 每个 slide 的连接态：信令 WS + AV session。
+ * @typedef {{ signalWs: WebSocket | null, avSession: { close: () => void, setMode?: (m: string) => void, getMode?: () => string } | null }} LiveSlideConn
+ */
+/** @type {WeakMap<HTMLElement, { destroy?: () => void }>} */
+const voiceRingMounts = new WeakMap()
+
+/**
+ * @param {string} entityHash 实体
+ * @returns {Promise<object | null>} profile
+ */
+async function fetchEntityProfile(entityHash) {
+	try {
+		const data = await chatApi(`/entities/${encodeURIComponent(entityHash)}`)
+		return data?.profile || data || null
+	}
+	catch { return null }
+}
+
+/**
+ * @param {HTMLElement} host 宿主
+ * @param {string} entityHash 主播
+ * @param {() => number[]} getLevels 电平
+ * @returns {Promise<void>}
+ */
+async function mountLiveVoiceRing(host, entityHash, getLevels) {
+	voiceRingMounts.get(host)?.destroy?.()
+	const profile = await fetchEntityProfile(entityHash)
+	host.classList.remove('hidden')
+	const mount = mountVoiceRing({
+		container: host,
+		avatarUrl: entityAvatarUrl(entityHash, profile),
+		avatarSeed: entityHash,
+		avatarLabel: profile?.name || entityHash,
+		themeColor: themeColorForEntity(profile, entityHash),
+		getLevels,
+	})
+	voiceRingMounts.set(host, mount)
+}
+
+/** @type {WeakMap<HTMLElement, LiveSlideConn>} */
+const slideConnections = new WeakMap()
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {void}
+ */
+function closeSlideConn(slide) {
+	const conn = slideConnections.get(slide)
+	if (!conn) return
+	conn.signalWs?.close()
+	conn.avSession?.close()
+	slideConnections.delete(slide)
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {LiveSlideConn} 连接态
+ */
+function getOrCreateConn(slide) {
+	let conn = slideConnections.get(slide)
+	if (!conn) {
+		conn = { signalWs: null, avSession: null }
+		slideConnections.set(slide, conn)
+	}
+	return conn
+}
+
+/**
+ * @param {string} [targetEntityHash] 定位主播
+ * @param {string} [targetLiveId] 定位直播
+ * @returns {Promise<void>}
+ */
+export async function loadLiveView(targetEntityHash, targetLiveId) {
+	const container = document.getElementById('liveSnapContainer')
+	if (!container) return
+
+	for (const child of [...container.children])
+		if (child instanceof HTMLElement) closeSlideConn(child)
+	snapBind?.disconnect()
+	snapBind = null
+	container.replaceChildren()
+	liveFeed.reset()
+	currentLiveIndex = -1
+
+	ensureLiveScopeTabs()
+
+	const data = await socialApi(
+		`/live/feed?limit=20&scope=${encodeURIComponent(liveScope)}`,
+	).catch(() => ({ items: [], nextCursor: null }))
+	const items = data.items || []
+
+	if (!items.length) {
+		container.innerHTML = '<div class="live-slide"><p class="live-empty" data-i18n="social.live.empty"></p></div>'
+		return
+	}
+
+	if (liveScope === 'nearby') {
+		renderLiveHallGrid(container, items)
+		return
+	}
+
+	liveFeed.seed(items, data.nextCursor || null)
+	liveFeed.append(container, items)
+
+	snapBind = bindVerticalSnap(container, {
+		/**
+		 * @param {number} index 索引
+		 * @param {HTMLElement} el slide
+		 * @returns {void}
+		 */
+		onEnter: (index, el) => {
+			currentLiveIndex = index
+			activateLiveSlide(container, index)
+			void liveFeed.maybeLoadMore(container, index)
+		},
+		/**
+		 * @param {number} _index 离开索引
+		 * @param {HTMLElement} el slide
+		 * @returns {void}
+		 */
+		onLeave: (_index, el) => {
+			demoteLiveSlide(el)
+		},
+	})
+
+	if (targetEntityHash && targetLiveId)
+		for (const slide of container.children)
+			if (slide.dataset.entityHash === targetEntityHash && slide.dataset.liveId === targetLiveId) {
+				slide.scrollIntoView()
+				break
+			}
+}
+
+/**
+ * 当前条 full；下一条预连 preview。
+ * @param {HTMLElement} container 容器
+ * @param {number} index 当前索引
+ * @returns {void}
+ */
+function activateLiveSlide(container, index) {
+	const current = container.children[index]
+	const next = container.children[index + 1]
+	if (current instanceof HTMLElement)
+		ensureLiveConnected(current, 'full')
+	if (next instanceof HTMLElement)
+		ensureLiveConnected(next, 'preview')
+
+	for (let i = 0; i < container.children.length; i++) {
+		if (i === index || i === index + 1) continue
+		const el = container.children[i]
+		if (el instanceof HTMLElement) closeSlideConn(el)
+	}
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {void}
+ */
+function demoteLiveSlide(slide) {
+	const conn = slideConnections.get(slide)
+	if (!conn?.avSession) return
+	if (typeof conn.avSession.setMode === 'function')
+		conn.avSession.setMode('preview')
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {'full' | 'preview'} mode 档位
+ * @returns {void}
+ */
+function ensureLiveConnected(slide, mode) {
+	const { entityHash, liveId } = slide.dataset
+	if (!entityHash || !liveId) return
+	const conn = getOrCreateConn(slide)
+	if (!conn.signalWs || conn.signalWs.readyState > 1)
+		conn.signalWs = openLiveSignalWs(slide, entityHash, liveId, slide.dataset)
+
+	if (conn.avSession && typeof conn.avSession.setMode === 'function') {
+		conn.avSession.setMode(mode)
+		if (mode === 'full')
+			slide.querySelector('.live-placeholder')?.classList.add('hidden')
+		return
+	}
+
+	const canvas = slide.querySelector('.live-av-canvas')
+	const voiceHost = slide.querySelector('[data-voice-ring]')
+	const mediaKind = slide.dataset.mediaKind || 'av'
+	const audioOnly = mediaKind === 'audio'
+	if (audioOnly && voiceHost instanceof HTMLElement) {
+		canvas?.classList.add('hidden')
+		void mountLiveVoiceRing(voiceHost, entityHash, () => {
+			const lv = conn.avSession?.getAudioLevels?.() || []
+			return lv.length ? lv : Array(16).fill(0.05)
+		})
+	}
+	if (!(canvas instanceof HTMLCanvasElement) && !audioOnly) return
+	const federated = slide.dataset.federated === '1'
+	const finalAvUrl = federated
+		? `${buildSocialLiveAvWsUrl(entityHash, liveId)}?proxy=1&bridgeOrigin=${encodeURIComponent(slide.dataset.bridgeOrigin || '')}&watchSecret=${encodeURIComponent(slide.dataset.watchSecret || '')}`
+		: buildSocialLiveAvWsUrl(entityHash, liveId)
+	void joinAvRelayRoom({
+		wsUrl: finalAvUrl,
+		asPublisher: false,
+		canvas: audioOnly ? null : canvas,
+		mode,
+		/** @param {{ video?: boolean, audio?: boolean }} meta 发布者媒体能力 */
+		onPublishMeta: meta => {
+			if (!meta?.video && meta?.audio && voiceHost instanceof HTMLElement) {
+				canvas?.classList.add('hidden')
+				void mountLiveVoiceRing(voiceHost, entityHash, () => conn.avSession?.getAudioLevels?.() || [])
+			}
+		},
+	}).then(session => {
+		const current = slideConnections.get(slide)
+		if (!current || current !== conn) {
+			session.close()
+			return
+		}
+		conn.avSession = session
+		if (mode === 'full' || session.getMode?.() === 'full')
+			slide.querySelector('.live-placeholder')?.classList.add('hidden')
+	}).catch(() => { /* keep placeholder */ })
+}
+
+/**
+ * @returns {void}
+ */
+function ensureLiveScopeTabs() {
+	const tabs = document.getElementById('liveScopeTabs')
+	const goBroadcast = document.getElementById('liveGoBroadcastButton')
+	if (!tabs) return
+	if (!tabs.dataset.bound) {
+		tabs.dataset.bound = '1'
+		tabs.addEventListener('click', event => {
+			const tabButton = event.target.closest('[data-scope]')
+			if (!(tabButton instanceof HTMLElement)) return
+			liveScope = tabButton.dataset.scope || 'local'
+			void loadLiveView()
+		})
+		goBroadcast?.addEventListener('click', () => {
+			activateView('liveBroadcast')
+		})
+	}
+	if (goBroadcast) goBroadcast.dataset.i18n = 'social.live.broadcast.open'
+	for (const tabButton of tabs.querySelectorAll('[data-scope]')) {
+		if (!(tabButton instanceof HTMLElement)) continue
+		const active = tabButton.dataset.scope === liveScope
+		tabButton.dataset.i18n = tabButton.dataset.scope === 'nearby'
+			? 'social.live.hall'
+			: 'social.live.local'
+		tabButton.classList.toggle('is-active', active)
+		tabButton.setAttribute('aria-selected', active ? 'true' : 'false')
+	}
+}
+
+/**
+ * @param {HTMLElement} container 容器
+ * @param {object[]} items 条目
+ * @returns {void}
+ */
+function renderLiveHallGrid(container, items) {
+	const grid = document.createElement('div')
+	grid.className = 'live-hall-grid'
+	for (const item of items) {
+		const card = document.createElement('button')
+		card.type = 'button'
+		card.className = 'live-hall-card'
+		card.innerHTML = `
+			${renderAvatarHtml(item.entityHash, {
+		name: item.authorName || item.title,
+		avatar: item.avatarUrl || item.authorProfile?.avatar,
+		infoDefaults: item.authorProfile?.infoDefaults,
+	}, 'live-hall-avatar')}
+			<div class="live-hall-meta">
+				<div class="live-hall-title">${escapeHtml(item.title || '')}</div>
+				<div class="live-hall-stats">
+					<span data-i18n="social.live.viewers" data-n="${item.viewerCount || 0}"></span>
+					· <span data-i18n="social.live.likes" data-n="${item.likeCount || 0}"></span>
+				</div>
+			</div>
+		`
+		card.addEventListener('click', () => {
+			liveScope = 'local'
+			for (const child of [...container.children])
+				if (child instanceof HTMLElement) closeSlideConn(child)
+			container.replaceChildren()
+			const slide = buildLiveSlide(item)
+			container.appendChild(slide)
+			ensureLiveConnected(slide, 'full')
+		})
+		grid.appendChild(card)
+	}
+	container.appendChild(grid)
+}
+
+/**
+ * @param {object} item 条目
+ * @returns {HTMLElement} slide
+ */
+function buildLiveSlide(item) {
+	const slide = document.createElement('div')
+	slide.className = 'live-slide'
+	slide.dataset.entityHash = item.entityHash || ''
+	slide.dataset.liveId = item.liveId || ''
+	if (item.federated) slide.dataset.federated = '1'
+	if (item.bridgeOrigin) slide.dataset.bridgeOrigin = item.bridgeOrigin
+	if (item.watchSecret) slide.dataset.watchSecret = item.watchSecret
+
+	if (item.mediaKind) slide.dataset.mediaKind = item.mediaKind
+
+	slide.innerHTML = `
+		<div class="live-av-wrap">
+			<canvas class="live-av-canvas" width="640" height="480"></canvas>
+			<div class="live-voice-ring-host hidden" data-voice-ring></div>
+			<canvas class="live-av-canvas live-av-canvas-peer hidden" width="640" height="480"></canvas>
+		</div>
+		<div class="live-placeholder">
+			<span class="live-badge">LIVE</span>
+			<div class="live-title">${escapeHtml(item.title || item.authorName || '')}</div>
+			<p class="live-viewer-count" data-viewer-count data-i18n="social.live.viewers" data-n="${item.viewerCount || 0}"></p>
+			<p class="live-like-count" data-like-count data-i18n="social.live.likes" data-n="${item.likeCount || 0}"></p>
+		</div>
+		<div class="live-overlay">
+			<div class="danmaku-area" data-danmaku></div>
+			<div class="live-bottom">
+				<div class="live-info">
+					<span class="live-author">${escapeHtml(item.authorName || '')}</span>
+					<span class="live-viewer-count" data-viewer-count data-i18n="social.live.viewers" data-n="${item.viewerCount || 0}"></span>
+					<span class="live-like-count" data-like-count data-i18n="social.live.likes" data-n="${item.likeCount || 0}"></span>
+				</div>
+				<div class="live-danmaku-input">
+					<input type="text" class="live-danmaku-field" maxlength="100" data-i18n="social.live.danmaku" />
+					<button type="button" class="live-danmaku-send-btn" data-i18n="social.live.danmakuSend"></button>
+				</div>
+			</div>
+		</div>
+		<div class="live-actions">
+			<button type="button" class="live-action-btn live-like-btn">
+				<span class="icon icon-like" aria-hidden="true"></span>
+			</button>
+		</div>
+	`
+
+	const sendBtn = slide.querySelector('.live-danmaku-send-btn')
+	const danmakuInput = slide.querySelector('.live-danmaku-field')
+	sendBtn?.addEventListener('click', () => sendDanmaku(slide))
+	danmakuInput?.addEventListener('keydown', event => {
+		if (event.key === 'Enter') sendDanmaku(slide)
+	})
+
+	let lastTap = 0
+	slide.addEventListener('pointerup', async event => {
+		if (event.target.closest('.live-danmaku-input') || event.target.closest('.live-actions')) return
+		const now = Date.now()
+		if (now - lastTap < 350) {
+			lastTap = 0
+			await sendLiveLike(slide)
+		}
+		else lastTap = now
+	})
+
+	slide.querySelector('.live-like-btn')?.addEventListener('click', async event => {
+		event.stopPropagation()
+		await sendLiveLike(slide)
+	})
+
+	return slide
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {void}
+ */
+function sendDanmaku(slide) {
+	const input = slide.querySelector('.live-danmaku-field')
+	if (!(input instanceof HTMLInputElement) || !input.value.trim()) return
+	const text = input.value.trim()
+	input.value = ''
+	const ws = slideConnections.get(slide)?.signalWs
+	if (ws?.readyState === WebSocket.OPEN)
+		ws.send(JSON.stringify({ type: 'danmaku', text }))
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {Promise<void>}
+ */
+async function sendLiveLike(slide) {
+	const ws = slideConnections.get(slide)?.signalWs
+	if (ws?.readyState === WebSocket.OPEN)
+		ws.send(JSON.stringify({ type: 'like' }))
+	showHeartFloat(slide)
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {void}
+ */
+function showHeartFloat(slide) {
+	playHeartAnim(slide, { emoji: '❤️', durationMs: 1000, mode: 'spawn' })
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @param {DOMStringMap | object} [meta] 联邦线索
+ * @returns {WebSocket} 信令 WS
+ */
+function openLiveSignalWs(slide, entityHash, liveId, meta = {}) {
+	const federated = meta.federated === '1' || meta.federated === true
+	const qs = federated
+		? `?proxy=1&bridgeOrigin=${encodeURIComponent(meta.bridgeOrigin || '')}&watchSecret=${encodeURIComponent(meta.watchSecret || '')}`
+		: ''
+	const wsUrl = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/parts/shells:social/live/${entityHash}/${liveId}${qs}`
+	const ws = new WebSocket(wsUrl)
+
+	ws.addEventListener('message', event => {
+		let wireMessage = null
+		try { wireMessage = JSON.parse(event.data) } catch { return }
+		if (!wireMessage?.type) return
+
+		if (wireMessage.type === 'danmaku' && wireMessage.text)
+			addDanmakuItem(slide, wireMessage.text, wireMessage.authorName)
+		else if (wireMessage.type === 'like')
+			showHeartFloat(slide)
+		else if (wireMessage.type === 'viewer_count' || wireMessage.type === 'link_stats') {
+			const n = wireMessage.viewerCount ?? wireMessage.count ?? 0
+			for (const el of slide.querySelectorAll('[data-viewer-count]'))
+				if (el instanceof HTMLElement) setElementI18n(el, 'social.live.viewers', { n })
+			if (wireMessage.likeCount != null)
+				for (const el of slide.querySelectorAll('[data-like-count]'))
+					if (el instanceof HTMLElement) setElementI18n(el, 'social.live.likes', { n: wireMessage.likeCount })
+		}
+		else if (wireMessage.type === 'like_count')
+			for (const el of slide.querySelectorAll('[data-like-count]'))
+				if (el instanceof HTMLElement) setElementI18n(el, 'social.live.likes', { n: wireMessage.count ?? 0 })
+				else if (wireMessage.type === 'hello' && wireMessage.likeCount != null) {
+					for (const el of slide.querySelectorAll('[data-like-count]'))
+						if (el instanceof HTMLElement) setElementI18n(el, 'social.live.likes', { n: wireMessage.likeCount })
+					if (wireMessage.link)
+						slide.classList.add('live-linked')
+				}
+				else if (wireMessage.type === 'link_started')
+					slide.classList.add('live-linked')
+				else if (wireMessage.type === 'link_ended')
+					slide.classList.remove('live-linked')
+	})
+
+	return ws
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {string} text 弹幕
+ * @param {string} [author] 作者
+ * @returns {void}
+ */
+function addDanmakuItem(slide, text, author) {
+	const area = slide.querySelector('[data-danmaku]')
+	if (!area) return
+	const item = document.createElement('div')
+	item.className = 'danmaku-item'
+	item.textContent = author ? `${author}: ${text}` : text
+	item.style.top = `${Math.floor(Math.random() * 80)}%`
+	area.appendChild(item)
+	item.addEventListener('animationend', () => item.remove())
+}
+
+/**
+ * @returns {void}
+ */
+export function initLiveBroadcastView() {
+	const startBtn = document.getElementById('liveStartButton')
+	const stopBtn = document.getElementById('liveStopButton')
+	const statusEl = document.getElementById('liveBroadcastStatus')
+	const previewCanvas = document.getElementById('liveBroadcastCanvas')
+	const voiceRingHost = document.getElementById('liveBroadcastVoiceRing')
+	const mediaModeSelect = document.getElementById('liveMediaMode')
+	const whipPanel = document.getElementById('liveWhipPanel')
+	const whipUrlInput = document.getElementById('liveWhipUrl')
+	const whipTokenInput = document.getElementById('liveWhipToken')
+	const linkPeerInput = document.getElementById('liveLinkPeerInput')
+	const linkInviteBtn = document.getElementById('liveLinkInviteButton')
+	let activeLiveId = null
+	let viewerEntityHash = null
+	/** @type {{ close: () => void, getAudioLevels?: () => number[] } | null} */
+	let publishSession = null
+	/** @type {{ destroy?: () => void } | null} */
+	let broadcastVoiceRing = null
+
+	mediaModeSelect?.addEventListener('change', () => {
+		const mode = mediaModeSelect.value || 'av'
+		previewCanvas?.classList.toggle('hidden', mode === 'audio' || mode === 'whip')
+		voiceRingHost?.classList.toggle('hidden', mode !== 'audio')
+		whipPanel?.classList.toggle('hidden', mode !== 'whip')
+	})
+
+	startBtn?.addEventListener('click', async () => {
+		try {
+			const title = document.getElementById('liveTitleInput')?.value?.trim() || ''
+			const mediaKind = mediaModeSelect?.value || 'av'
+			const data = await socialApi('/live/start', {
+				method: 'POST',
+				body: JSON.stringify({ title, bridgeOrigin: location.origin, mediaKind }),
+			})
+			activeLiveId = data.liveId
+			viewerEntityHash = data.entityHash
+			startBtn.classList.add('hidden')
+			stopBtn?.classList.remove('hidden')
+			document.getElementById('liveLinkRow')?.classList.remove('hidden')
+			if (statusEl) statusEl.dataset.i18n = 'social.live.broadcast.started'
+
+			if (mediaKind === 'whip') {
+				const whip = `${location.origin}/api/parts/shells:social/live/${data.liveId}/whip`
+				if (whipUrlInput instanceof HTMLInputElement) whipUrlInput.value = whip
+				if (whipTokenInput instanceof HTMLInputElement) whipTokenInput.value = data.ingestSecret || ''
+				whipPanel?.classList.remove('hidden')
+				if (statusEl) statusEl.dataset.i18n = 'social.live.broadcast.whipWaiting'
+				return
+			}
+
+			const relayMedia = mediaKind === 'av' ? 'av' : mediaKind
+			if (mediaKind === 'audio' && voiceRingHost instanceof HTMLElement) {
+				previewCanvas?.classList.add('hidden')
+				broadcastVoiceRing?.destroy?.()
+				publishSession = await joinAvRelayRoom({
+					wsUrl: buildSocialLiveAvWsUrl(data.entityHash, data.liveId),
+					asPublisher: true,
+					media: 'audio',
+				})
+				await mountLiveVoiceRing(voiceRingHost, data.entityHash, () => publishSession?.getAudioLevels?.() || [])
+				broadcastVoiceRing = voiceRingMounts.get(voiceRingHost) || null
+				return
+			}
+
+			if (previewCanvas instanceof HTMLCanvasElement && data.entityHash && data.liveId)
+				publishSession = await joinAvRelayRoom({
+					wsUrl: buildSocialLiveAvWsUrl(data.entityHash, data.liveId),
+					asPublisher: true,
+					canvas: previewCanvas,
+					media: relayMedia,
+				})
+		}
+		catch (err) {
+			if (statusEl) statusEl.textContent = String(err?.message || err)
+		}
+	})
+
+	stopBtn?.addEventListener('click', async () => {
+		if (!activeLiveId) return
+		try {
+			publishSession?.close()
+			publishSession = null
+			broadcastVoiceRing?.destroy?.()
+			broadcastVoiceRing = null
+			voiceRingHost?.classList.add('hidden')
+			previewCanvas?.classList.remove('hidden')
+			whipPanel?.classList.add('hidden')
+			await socialApi('/live/stop', { method: 'POST', body: JSON.stringify({ liveId: activeLiveId }) })
+			activeLiveId = null
+			viewerEntityHash = null
+			stopBtn.classList.add('hidden')
+			document.getElementById('liveLinkRow')?.classList.add('hidden')
+			startBtn?.classList.remove('hidden')
+			if (statusEl) statusEl.dataset.i18n = 'social.live.broadcast.stopped'
+		}
+		catch (err) {
+			if (statusEl) statusEl.textContent = String(err?.message || err)
+		}
+	})
+
+	linkInviteBtn?.addEventListener('click', async () => {
+		if (!activeLiveId) return
+		const raw = linkPeerInput?.value?.trim() || ''
+		const [peerEntityHash, peerLiveId] = raw.split(':').map(s => s.trim())
+		if (!peerEntityHash || !peerLiveId) {
+			if (statusEl) statusEl.dataset.i18n = 'social.live.link.needPeer'
+			return
+		}
+		try {
+			const result = await socialApi(`/live/${activeLiveId}/link/invite`, {
+				method: 'POST',
+				body: JSON.stringify({ peerEntityHash, peerLiveId, bridgeOrigin: location.origin }),
+			})
+			if (statusEl)
+				statusEl.dataset.i18n = result.status === 'linked'
+					? 'social.live.link.linked'
+					: 'social.live.link.invited'
+		}
+		catch (err) {
+			if (statusEl) statusEl.textContent = String(err?.message || err)
+		}
+	})
+}

--- a/src/public/parts/shells/social/public/src/views/notifications.mjs
+++ b/src/public/parts/shells/social/public/src/views/notifications.mjs
@@ -1,0 +1,383 @@
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { bindInfiniteScroll, disconnectInfiniteScroll, ensureScrollSentinel } from '/scripts/infiniteScroll.mjs'
+import { formatSocialPostHref, formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { authorLabel, formatTimeHtml, renderAvatarHtml } from '../lib/display.mjs'
+import { state } from '../state.mjs'
+
+/** @type {number | null} */
+let badgeUnreadCount = null
+
+/** @type {boolean} */
+let notificationsLoading = false
+
+/**
+ * 确保已读水位已自服务端加载。
+ * @returns {Promise<number>} 已读水位
+ */
+export async function ensureNotificationsSeenAt() {
+	if (Number.isFinite(state.notificationsSeenAt))
+		return state.notificationsSeenAt
+	const data = await socialApi('/notifications/seen').catch(() => ({ seenAt: 0 }))
+	state.notificationsSeenAt = Number(data.seenAt) || 0
+	return state.notificationsSeenAt
+}
+
+/**
+ * 读取通知已读水位时间戳（内存缓存）。
+ * @returns {number} 已读水位
+ */
+export function getNotificationsSeenAt() {
+	return Number(state.notificationsSeenAt) || 0
+}
+
+/**
+ * 标记通知已读并更新角标。
+ * @param {number} [at=Date.now()] 时间戳
+ * @returns {Promise<void>}
+ */
+export async function markNotificationsSeen(at = Date.now()) {
+	await socialApi('/notifications/seen', {
+		method: 'PUT',
+		body: JSON.stringify({ at }),
+	})
+	state.notificationsSeenAt = at
+	badgeUnreadCount = 0
+	await updateNotificationBadge()
+}
+
+/**
+ * @param {string} type 通知类型
+ * @returns {string} 图标 class
+ */
+function notificationIconClass(type) {
+	if (type === 'reply') return 'icon-notification-reply'
+	if (type === 'mention') return 'icon-notification-mention'
+	if (type === 'like') return 'icon-notification-like'
+	if (type === 'repost') return 'icon-notification-repost'
+	if (type === 'follow') return 'icon-notification-follow'
+	if (type === 'care_post') return 'icon-notification-like'
+	if (type === 'poll_closed') return 'icon-vote'
+	if (type === 'post_note') return 'icon-note'
+	if (type === 'live_started') return 'icon-live'
+	return 'icon-bell'
+}
+
+/**
+ * @returns {string} types 查询参数
+ */
+function notificationsTypesQuery() {
+	const filter = state.notificationsFilter
+	if (!filter || filter === 'all') return ''
+	return `&types=${encodeURIComponent(filter)}`
+}
+
+/**
+ * @param {object} row 通知条目
+ * @returns {string} 动作文案
+ */
+/**
+ * 通知文案的 data-i18n 描述。
+ * @param {object} row 通知条目
+ * @returns {{ i18n: string, author?: string, author1?: string, author2?: string, count?: string }} 属性
+ */
+function notificationMessageAttrs(row) {
+	const actorCount = Number(row.actorCount) || 1
+	const primaryLabel = authorLabel(row.actorEntityHash)
+	const actors = Array.isArray(row.actors) && row.actors.length
+		? row.actors
+		: [{ entityHash: row.actorEntityHash }]
+	const secondaryLabel = actors.length > 1
+		? authorLabel(actors[1].entityHash)
+		: primaryLabel
+	const type = row.type
+	if (actorCount <= 1)
+		return { i18n: `social.notifications.${type}`, author: primaryLabel }
+	if (actorCount === 2 && type !== 'follow')
+		return {
+			i18n: `social.inbox.aggregated.${type}Two`,
+			author1: primaryLabel,
+			author2: secondaryLabel,
+		}
+	return {
+		i18n: `social.inbox.aggregated.${type}`,
+		author1: primaryLabel,
+		author2: secondaryLabel,
+		count: String(actorCount),
+	}
+}
+
+/**
+ * @param {object} row 通知条目
+ * @returns {string} 头像 HTML
+ */
+function notificationAvatarsHtml(row) {
+	const actors = Array.isArray(row.actors) && row.actors.length
+		? row.actors.slice(0, 3)
+		: [{ entityHash: row.actorEntityHash }]
+	if (actors.length <= 1)
+		return renderAvatarHtml(actors[0].entityHash, { name: authorLabel(actors[0].entityHash) })
+	return `<div class="notification-avatars stacked">${actors.map(actor =>
+		renderAvatarHtml(actor.entityHash, { name: authorLabel(actor.entityHash) }),
+	).join('')}</div>`
+}
+
+/**
+ * 更新导航栏通知未读角标。
+ * @returns {Promise<void>}
+ */
+export async function updateNotificationBadge() {
+	const unread = Number.isFinite(badgeUnreadCount)
+		? badgeUnreadCount
+		: Number((await socialApi('/notifications?limit=1').catch(() => ({ unreadCount: 0 }))).unreadCount) || 0
+	badgeUnreadCount = null
+	const label = unread > 99 ? '99+' : String(unread)
+	for (const badgeId of ['notificationsBadge', 'mobileNotificationsBadge']) {
+		const badge = document.getElementById(badgeId)
+		if (!badge) continue
+		if (unread > 0) {
+			badge.textContent = label
+			badge.classList.remove('hidden')
+		}
+		else badge.classList.add('hidden')
+	}
+}
+
+/**
+ * WS 推送通知时递增 badge（避免整页拉 /notifications）。
+ * @returns {void}
+ */
+export function bumpNotificationBadge() {
+	const current = badgeUnreadCount ?? state.lastNotificationUnreadCount ?? 0
+	badgeUnreadCount = current + 1
+	state.lastNotificationUnreadCount = badgeUnreadCount
+	void updateNotificationBadge()
+}
+
+/**
+ * 通知条目跳转链接。
+ * @param {object} row 通知条目
+ * @returns {string} profile 链接
+ */
+function notificationHref(row) {
+	if (row.type === 'reply' || row.type === 'mention')
+		return formatSocialPostHref(row.actorEntityHash, row.postId)
+	if ((row.type === 'like' || row.type === 'repost' || row.type === 'post_note' || row.type === 'poll_closed' || row.type === 'care_post')
+		&& row.targetPostId && (row.targetEntityHash || state.viewerEntityHash))
+		return formatSocialPostHref(row.targetEntityHash || state.viewerEntityHash, row.targetPostId)
+	if (row.type === 'live_started')
+		return formatSocialProfileHref(row.actorEntityHash)
+	return formatSocialProfileHref(row.actorEntityHash)
+}
+
+/**
+ * 渲染单条通知卡片。
+ * @param {object} row 通知条目
+ * @param {number} seenAt 已读水位
+ * @returns {HTMLElement} 卡片
+ */
+function renderNotificationCard(row, seenAt) {
+	const card = document.createElement('article')
+	card.className = `notification-card${row.at > seenAt ? ' unread' : ''}`
+	if (row.aggregateKey) card.dataset.aggregateKey = row.aggregateKey
+	card.dataset.actorCount = String(Number(row.actorCount) || 1)
+	card.dataset.at = String(Number(row.at) || 0)
+	const msg = notificationMessageAttrs(row)
+	const msgParams = Object.entries(msg)
+		.filter(([key]) => key !== 'i18n')
+		.map(([key, value]) => ` data-${key}="${escapeHtml(value)}"`)
+		.join('')
+	const href = notificationHref(row)
+	const snippet = row.snippet
+		? `<p class="notification-snippet">${escapeHtml(row.snippet)}</p>`
+		: ''
+	card.innerHTML = `
+		<span class="notification-icon icon ${notificationIconClass(row.type)}" aria-hidden="true"></span>
+		<div class="notification-body">
+			<div class="post-header-row">
+				${notificationAvatarsHtml(row)}
+				<div>
+					<div class="notification-type" data-i18n="${msg.i18n}"${msgParams}></div>
+					${formatTimeHtml(row.at)}
+				</div>
+			</div>
+			${snippet}
+			<a href="${escapeHtml(href)}" class="notification-view-link" data-i18n="social.notifications.view"></a>
+		</div>
+	`
+	return card
+}
+
+/**
+ * @returns {boolean} 通知视图是否可见
+ */
+function notificationsViewActive() {
+	return !document.getElementById('notificationsView')?.classList.contains('hidden')
+}
+
+/**
+ * @param {object} row 通知条目
+ * @returns {boolean} 是否应被当前 Tab 过滤掉
+ */
+function notificationFilteredOut(row) {
+	const filter = state.notificationsFilter
+	return !!(filter && filter !== 'all' && row.type !== filter)
+}
+
+/**
+ * 将 WS 推送通知合并进当前列表。
+ * @param {object} notification 原始通知
+ * @returns {boolean} 是否已处理（合并或插入）
+ */
+export function mergeIncomingNotification(notification) {
+	if (!notificationsViewActive() || notificationFilteredOut(notification))
+		return false
+	const container = document.getElementById('notificationsView')
+	if (!container) return false
+	container.querySelector('.empty')?.remove()
+	const toolbar = document.getElementById('notificationsToolbar')
+	if (toolbar) toolbar.classList.remove('hidden')
+	const seenAt = getNotificationsSeenAt()
+	const aggregateKey = notification.aggregateKey
+	const existing = aggregateKey
+		? container.querySelector(`.notification-card[data-aggregate-key="${CSS.escape(aggregateKey)}"]`)
+		: null
+	if (existing instanceof HTMLElement) {
+		const knownActors = new Set(
+			(existing.dataset.knownActors || notification.actorEntityHash)
+				.split(',').filter(Boolean),
+		)
+		const isNewActor = !knownActors.has(notification.actorEntityHash)
+		if (isNewActor) knownActors.add(notification.actorEntityHash)
+		const actorCount = Math.max(Number(existing.dataset.actorCount) || 1, knownActors.size)
+		const at = Math.max(Number(existing.dataset.at) || 0, Number(notification.at) || 0)
+		const merged = {
+			...notification,
+			actorCount,
+			at,
+			actors: [
+				{ entityHash: notification.actorEntityHash, at: notification.at },
+				...Array.isArray(notification.actors) ? notification.actors : [],
+			].slice(0, 3),
+			snippet: notification.snippet || existing.querySelector('.notification-snippet')?.textContent || null,
+		}
+		const fresh = renderNotificationCard(merged, seenAt)
+		fresh.dataset.knownActors = [...knownActors].join(',')
+		existing.replaceWith(fresh)
+		container.prepend(fresh)
+		return true
+	}
+	const card = renderNotificationCard({
+		...notification,
+		actorCount: 1,
+		actors: [{ entityHash: notification.actorEntityHash, at: notification.at }],
+	}, seenAt)
+	card.dataset.knownActors = notification.actorEntityHash
+	const sentinel = document.getElementById('notificationsScrollSentinel')
+	container.insertBefore(card, sentinel)
+	return true
+}
+
+/**
+ * 同步 Tab 激活态。
+ * @returns {void}
+ */
+export function syncNotificationFilterTabs() {
+	const filter = state.notificationsFilter || 'all'
+	for (const button of document.querySelectorAll('[data-notif-filter]')) {
+		if (!(button instanceof HTMLButtonElement)) continue
+		const active = button.dataset.notifFilter === filter
+		button.classList.toggle('active', active)
+		button.setAttribute('aria-selected', active ? 'true' : 'false')
+		button.setAttribute('role', 'tab')
+	}
+}
+
+/**
+ * 切换通知 Tab 并重新加载。
+ * @param {string} filter 过滤类型
+ * @returns {Promise<void>}
+ */
+export async function setNotificationFilter(filter) {
+	state.notificationsFilter = filter
+	state.notificationsCursor = null
+	syncNotificationFilterTabs()
+	await loadNotifications(false)
+}
+
+/**
+ * 绑定通知列表无限滚动。
+ * @returns {void}
+ */
+export function bindNotificationsInfiniteScroll() {
+	const container = document.getElementById('notificationsView')
+	if (!container) {
+		disconnectInfiniteScroll()
+		return
+	}
+	const sentinel = ensureScrollSentinel(container, 'notificationsScrollSentinel')
+	bindInfiniteScroll({
+		sentinel,
+		/** @returns {boolean} 通知列表是否仍有下一页 */
+		hasMore: () => !!state.notificationsCursor,
+		/** @returns {Promise<void>} 追加加载下一页通知 */
+		onLoad: () => loadNotifications(true),
+	})
+}
+
+/**
+ * 加载并渲染通知列表。
+ * @param {boolean} [append=false] 追加下一页
+ * @returns {Promise<void>}
+ */
+export async function loadNotifications(append = false) {
+	if (notificationsLoading) return
+	notificationsLoading = true
+	let shouldBind = false
+	try {
+		await ensureNotificationsSeenAt()
+		syncNotificationFilterTabs()
+		const cursorQuery = append && state.notificationsCursor
+			? `&cursor=${encodeURIComponent(state.notificationsCursor)}`
+			: ''
+		const data = await socialApi(`/notifications?limit=40${cursorQuery}${notificationsTypesQuery()}`)
+		const container = document.getElementById('notificationsView')
+		const toolbar = document.getElementById('notificationsToolbar')
+		const seenAt = getNotificationsSeenAt()
+		const rows = data.notifications || []
+		state.notificationsCursor = data.nextCursor || null
+		state.lastNotificationUnreadCount = Number(data.unreadCount) || 0
+
+		if (!append) {
+			container.querySelectorAll('.notification-card, .empty').forEach(node => node.remove())
+			if (!rows.length) {
+				if (toolbar) toolbar.classList.add('hidden')
+				const empty = document.createElement('div')
+				empty.className = 'empty'
+				empty.dataset.i18n = 'social.empty.notifications'
+				container.appendChild(empty)
+				await markNotificationsSeen()
+				disconnectInfiniteScroll()
+				return
+			}
+		}
+
+		if (toolbar) toolbar.classList.toggle('hidden', !append && !rows.length)
+		for (const row of rows) {
+			const card = renderNotificationCard(row, seenAt)
+			if (Array.isArray(row.actors))
+				card.dataset.knownActors = row.actors.map(actor => actor.entityHash).join(',')
+			container.insertBefore(card, document.getElementById('notificationsScrollSentinel'))
+		}
+
+		if (!append)
+			await markNotificationsSeen(rows.reduce((max, row) => Math.max(max, row.at || 0), 0) || Date.now())
+
+		// 必须在释放 notificationsLoading 后再 bind，否则 observe 后立刻触发的 onLoad 会被锁吞掉
+		shouldBind = true
+	}
+	finally {
+		notificationsLoading = false
+	}
+	if (shouldBind) bindNotificationsInfiniteScroll()
+}

--- a/src/public/parts/shells/social/public/src/views/postDetail.mjs
+++ b/src/public/parts/shells/social/public/src/views/postDetail.mjs
@@ -1,0 +1,90 @@
+import { formatActionKey } from '../lib/actionKey.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { rememberEntityHandle } from '../lib/display.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { state } from '../state.mjs'
+import { activateView } from '../viewChrome.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+import { renderRepliesPanel } from './replies.mjs'
+
+/**
+ * 打开并渲染单帖详情页。
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<void>}
+ */
+export async function loadPostDetail(entityHash, postId) {
+	const owner = String(entityHash || '').toLowerCase()
+	const id = String(postId || '')
+	state.postDetailEntityHash = owner
+	state.postDetailPostId = id
+	activateView('postDetail')
+	document.getElementById('composer')?.classList.add('hidden')
+	const hash = `post;${owner};${id}`
+	if (location.hash.replace(/^#/, '') !== hash)
+		history.replaceState(null, '', `${location.pathname}${location.search}#${hash}`)
+
+	const container = document.getElementById('postDetailView')
+	if (!container) return
+	container.innerHTML = `<div class="post-detail-loading">${escapeHtml(geti18n('social.post.loading'))}</div>`
+
+	let data
+	try {
+		data = await socialApi(`/posts/${owner}/${id}`)
+	}
+	catch (error) {
+		const msg = String(error?.message || '')
+		const key = /post not found/i.test(msg) ? 'social.post.notFound' : 'social.post.loadFailed'
+		container.innerHTML = `<div class="empty">${escapeHtml(geti18n(key))}</div>`
+		return
+	}
+	if (!data?.item) {
+		container.innerHTML = `<div class="empty">${escapeHtml(geti18n('social.post.notFound'))}</div>`
+		return
+	}
+
+	const profileData = await socialApi(`/profile/${owner}`).catch(() => null)
+	rememberEntityHandle(owner, profileData?.profile || data.item.authorProfile)
+
+	const card = await buildPostCard(data.item, { openDetail: false })
+	card.classList.add('post-detail-card')
+	const repliesHost = document.createElement('div')
+	repliesHost.className = 'post-detail-replies'
+	const actionKey = formatActionKey(owner, id)
+	repliesHost.dataset.repliesFor = actionKey
+
+	container.replaceChildren()
+	const header = document.createElement('header')
+	header.className = 'view-header post-detail-header'
+	header.innerHTML = `
+		<button type="button" class="btn btn-ghost btn-sm" data-post-detail-back>${escapeHtml(geti18n('social.post.back'))}</button>
+		<h2 class="view-title">${escapeHtml(geti18n('social.post.detailTitle'))}</h2>
+	`
+	header.querySelector('[data-post-detail-back]')?.addEventListener('click', () => {
+		history.back()
+	})
+	container.appendChild(header)
+	container.appendChild(card)
+	container.appendChild(repliesHost)
+
+	const { bindFeedVideoAutoplay } = await import('../lib/videoAutoplay.mjs')
+	bindFeedVideoAutoplay(card)
+
+	const repliesData = await socialApi(`/profile/${owner}/replies/${id}`).catch(() => ({ replies: [] }))
+	await renderRepliesPanel(repliesHost, repliesData.replies || [])
+	repliesHost.dataset.loaded = '1'
+	repliesHost.classList.remove('hidden')
+	// 详情页默认展开回复，隐藏卡片内嵌的折叠面板触发依赖
+	card.querySelector(`[data-replies-for="${CSS.escape(actionKey)}"]`)?.remove()
+}
+
+/**
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {void}
+ */
+export function navigateToPostDetail(entityHash, postId) {
+	location.hash = `post;${entityHash};${postId}`
+}

--- a/src/public/parts/shells/social/public/src/views/profile.mjs
+++ b/src/public/parts/shells/social/public/src/views/profile.mjs
@@ -1,0 +1,406 @@
+import { formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { chatApi, socialApi, viewerEntityHash } from '../lib/apiClient.mjs'
+import { authorLabel, entityHandle, rememberEntityHandle, renderAvatarHtml } from '../lib/display.mjs'
+import { bindInfiniteScroll, disconnectInfiniteScroll, ensureScrollSentinel } from '/scripts/infiniteScroll.mjs'
+import { appendTemplate, renderTemplate, renderTemplateAsHtmlString } from '/scripts/features/template.mjs'
+import { openDialogFromTemplate } from '/scripts/features/dialog.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { isCared } from '/parts/shells:chat/shared/care.mjs'
+import {
+	createEntityProfileCardElement,
+	paintEntityProfileCard,
+	paintEntityProfileExtras,
+} from '/parts/shells:chat/shared/entityProfileCard.mjs'
+import { mountEmptyState } from '../lib/emptyState.mjs'
+import { appendFeedItemsWithThreads } from '../lib/feedThreads.mjs'
+import { bindFeedVideoAutoplay } from '../lib/videoAutoplay.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { state } from '../state.mjs'
+
+import { renderProfileAlbums } from './albums.mjs'
+
+/** @type {Map<string, Set<string>>} entity → 已加载过的 tab */
+const profileLoadedTabs = new Map()
+
+/**
+ * @param {string} entityHash 实体
+ * @returns {Set<string>} 已加载 tab
+ */
+function loadedTabsFor(entityHash) {
+	let set = profileLoadedTabs.get(entityHash)
+	if (!set) {
+		set = new Set()
+		profileLoadedTabs.set(entityHash, set)
+	}
+	return set
+}
+
+/**
+ * 渲染拉黑/隐藏列表 UI。
+ * @param {HTMLElement} container 容器
+ * @returns {Promise<void>}
+ */
+export async function renderBlocklist(container) {
+	if (!(container instanceof HTMLElement)) return
+	const data = await chatApi('/personal-lists')
+	const entries = data.entries || []
+	const sections = [
+		{ kind: 'block', titleKey: 'social.blocklist.title', action: 'unblock', labelKey: 'social.blocklist.unblock' },
+		{ kind: 'hide', titleKey: 'social.blocklist.hiddenTitle', action: 'unhide', labelKey: 'social.blocklist.unhide' },
+	]
+	const grouped = sections.map(section => ({
+		...section,
+		rows: entries.filter(entry => entry.kind === section.kind),
+	}))
+	if (grouped.every(section => !section.rows.length)) {
+		await mountEmptyState(container, { titleKey: 'social.blocklist.empty', modClass: ' empty-state--hint' })
+		return
+	}
+	container.replaceChildren()
+	for (const section of grouped) {
+		if (!section.rows.length) continue
+		await appendTemplate(container, 'blocklist_heading', { titleKey: section.titleKey })
+		for (const entry of section.rows) {
+			const actionHtml = entry.scope === 'entity'
+				? await renderTemplateAsHtmlString('blocklist_action', {
+					action: section.action,
+					value: escapeHtml(entry.value),
+					labelKey: section.labelKey,
+				})
+				: ''
+			await appendTemplate(container, 'blocklist_row', {
+				scopeKey: entry.scope === 'subject'
+					? 'social.blocklist.scopeSubject'
+					: 'social.blocklist.scopeEntity',
+				value: escapeHtml(entry.value),
+				actionHtml,
+			})
+		}
+	}
+}
+
+/**
+ * 打开个人主页设置（迁移到 settings 视图后由 navigation 处理；保留导出供过渡）。
+ * @param {{ hideFromDiscovery?: boolean }} socialMeta 当前 meta
+ * @returns {Promise<void>}
+ */
+export async function openProfileSettingsDialog(socialMeta = {}) {
+	state.profileSocialMeta = socialMeta || state.profileSocialMeta
+	const { switchView } = await import('../navigation.mjs')
+	await switchView('settings')
+}
+
+/**
+ * 绑定 profile 帖子无限滚动。
+ * @param {string} entityHash owner
+ * @param {HTMLElement} container 帖子容器
+ * @returns {void}
+ */
+function bindProfilePostsInfiniteScroll(entityHash, container) {
+	const sentinel = ensureScrollSentinel(container, 'profilePostsScrollSentinel')
+	bindInfiniteScroll({
+		sentinel,
+		/** @returns {boolean} 个人帖列表是否仍有下一页 */
+		hasMore: () => !!state.profilePostsCursor,
+		/** @returns {Promise<void>} 追加渲染下一页帖子 */
+		onLoad: () => renderProfilePosts(entityHash, container, null, true),
+	})
+}
+
+/**
+ * 渲染资料页帖子列表（可选高亮指定帖）。
+ * @param {string} entityHash owner
+ * @param {HTMLElement} container 容器
+ * @param {string | null} [highlightPostId] 高亮帖
+ * @param {boolean} [append=false] 追加下一页
+ * @returns {Promise<void>}
+ */
+export async function renderProfilePosts(entityHash, container, highlightPostId = null, append = false) {
+	const cursorQuery = append && state.profilePostsCursor
+		? `&cursor=${encodeURIComponent(state.profilePostsCursor)}`
+		: ''
+	const data = await socialApi(`/profile/${entityHash}/posts?limit=30${cursorQuery}`)
+	if (!append) container.replaceChildren()
+	const items = data.items || []
+	state.profilePostsCursor = data.nextCursor || null
+	if (!items.length && !append) {
+		await mountEmptyState(container, { titleKey: 'social.empty.profilePosts', modClass: ' empty-state--plain' })
+		disconnectInfiniteScroll()
+		return
+	}
+	await appendFeedItemsWithThreads(container, items, async item => {
+		const card = await buildPostCard(item)
+		if (highlightPostId && card.dataset.postId === highlightPostId)
+			card.classList.add('highlight-post')
+		return card
+	})
+	bindFeedVideoAutoplay(container)
+	bindProfilePostsInfiniteScroll(entityHash, container)
+	if (highlightPostId)
+		container.querySelector(`[data-post-id="${highlightPostId}"]`)?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+}
+
+/**
+ * 渲染资料页点赞列表。
+ * @param {string} entityHash owner
+ * @param {HTMLElement} container 容器
+ * @returns {Promise<void>}
+ */
+export async function renderProfileLikes(entityHash, container) {
+	const data = await socialApi(`/profile/${entityHash}/likes`)
+	container.replaceChildren()
+	const items = data.items || []
+	if (!items.length) {
+		await mountEmptyState(container, { titleKey: 'social.empty.likedPosts', modClass: ' empty-state--plain' })
+		return
+	}
+	for (const item of items)
+		container.appendChild(await buildPostCard(item))
+	bindFeedVideoAutoplay(container)
+}
+
+/**
+ * 渲染关系列表行到容器。
+ * @param {HTMLElement} container 容器
+ * @param {object[]} rows 行
+ * @param {string} emptyKey 空态 i18n
+ * @returns {Promise<void>}
+ */
+async function fillRelationshipRows(container, rows, emptyKey) {
+	container.replaceChildren()
+	if (!rows.length) {
+		await mountEmptyState(container, { titleKey: emptyKey, modClass: ' empty-state--plain' })
+		return
+	}
+	for (const row of rows) {
+		const hash = typeof row === 'string' ? row : row.entityHash
+		const profile = typeof row === 'string' ? null : row.profile
+		rememberEntityHandle(hash, profile)
+		await appendTemplate(container, 'relationship_row', {
+			href: escapeHtml(formatSocialProfileHref(hash)),
+			avatarHtml: renderAvatarHtml(hash, profile),
+			name: escapeHtml(authorLabel(hash, profile)),
+			handle: escapeHtml(entityHandle(hash, profile)),
+		})
+	}
+}
+
+/**
+ * 打开关注/粉丝列表对话框。
+ * @param {string} entityHash 实体
+ * @param {'following' | 'followers'} kind 列表类型
+ * @returns {Promise<void>}
+ */
+export async function openProfileRelationshipList(entityHash, kind) {
+	const dialog = await openDialogFromTemplate('profile_relationship_list', {
+		titleKey: kind === 'followers'
+			? 'social.profile.followersTitle'
+			: 'social.profile.followingTitle',
+	})
+	const list = dialog.querySelector('#profileRelationshipList')
+	if (!(list instanceof HTMLElement)) return
+	await mountEmptyState(list, { titleKey: 'social.post.loading', modClass: ' empty-state--plain' })
+	const path = kind === 'followers'
+		? `/profile/${entityHash}/followers`
+		: `/profile/${entityHash}/following`
+	const data = await socialApi(path)
+	const rows = kind === 'followers' ? data.followers || [] : data.following || []
+	await fillRelationshipRows(
+		list,
+		rows,
+		kind === 'followers' ? 'social.empty.followers' : 'social.empty.following',
+	)
+}
+
+/**
+ * 刷新当前资料页帖子列表。
+ * @param {string | null} [highlightPostId] 高亮帖
+ * @returns {Promise<void>}
+ */
+export async function refreshProfilePosts(highlightPostId = null) {
+	if (!state.profileEntityHash) return
+	state.profilePostsCursor = null
+	const panel = document.getElementById('profilePostsPanel')
+	if (panel)
+		await renderProfilePosts(state.profileEntityHash, panel, highlightPostId)
+}
+
+/**
+ * 激活资料 Tab（懒加载）。
+ * @param {string} tab tab id
+ * @param {{ force?: boolean }} [options] 强制重载
+ * @returns {Promise<void>}
+ */
+export async function activateProfileTab(tab, options = {}) {
+	const entityHash = state.profileEntityHash
+	if (!entityHash) return
+	for (const button of document.querySelectorAll('[data-profile-tab]')) {
+		const active = button.dataset.profileTab === tab
+		button.classList.toggle('active', active)
+		button.classList.toggle('tab-active', active)
+		button.setAttribute('aria-selected', active ? 'true' : 'false')
+	}
+	for (const panel of document.querySelectorAll('[data-profile-panel]'))
+		panel.classList.toggle('hidden', panel.dataset.profilePanel !== tab)
+
+	const loaded = loadedTabsFor(entityHash)
+	if (!options.force && loaded.has(tab) && tab !== 'posts') return
+	loaded.add(tab)
+
+	if (tab === 'posts') {
+		const panel = document.getElementById('profilePostsPanel')
+		if (panel instanceof HTMLElement && (options.force || !panel.childElementCount))
+			await renderProfilePosts(entityHash, panel)
+		return
+	}
+	if (tab === 'albums') {
+		const panel = document.getElementById('profileAlbumsPanel')
+		if (panel instanceof HTMLElement) await renderProfileAlbums(entityHash, panel)
+		return
+	}
+	if (tab === 'likes') {
+		const panel = document.getElementById('profileLikesPanel')
+		if (panel instanceof HTMLElement) await renderProfileLikes(entityHash, panel)
+		return
+	}
+	if (tab === 'cabinets') {
+		const panel = document.getElementById('profileCabinetsPanel')
+		if (panel instanceof HTMLElement) await renderProfileCabinets(entityHash, panel)
+	}
+}
+
+/**
+ * 挂载完整人物卡到资料页宿主。
+ * @param {HTMLElement} host 宿主
+ * @param {string} entityHash 实体
+ * @param {object} profile 资料
+ * @returns {Promise<void>}
+ */
+async function mountProfileEntityCard(host, entityHash, profile) {
+	const card = await createEntityProfileCardElement('embedded')
+	card.classList.add('profile-entity-card')
+	await paintEntityProfileCard(card, profile, {
+		entityHash,
+		selfEntityHash: viewerEntityHash(),
+		nodeHash: state.viewerNodeHash,
+		viewerOwnerEntityHash: state.viewerProfile?.ownerEntityHash,
+	})
+	const ownerEntityHash = profile?.ownerEntityHash
+		? String(profile.ownerEntityHash).toLowerCase()
+		: null
+	if (ownerEntityHash) {
+		let ownerName = null
+		try {
+			const ownerData = await socialApi(`/profile/${ownerEntityHash}`)
+			ownerName = authorLabel(ownerEntityHash, ownerData.profile)
+		}
+		catch { /* remote miss */ }
+		paintEntityProfileExtras(card, { ownerEntityHash, ownerName })
+	}
+	host.replaceChildren(card)
+}
+
+/**
+ * 加载并渲染指定 entity 的资料页。
+ * @param {string} entityHash owner
+ * @param {string | null} [highlightPostId] 高亮帖
+ * @returns {Promise<void>}
+ */
+export async function loadProfileFor(entityHash, highlightPostId = null) {
+	state.profileEntityHash = entityHash
+	state.profilePostsCursor = null
+	profileLoadedTabs.delete(entityHash)
+	const data = await socialApi(`/profile/${entityHash}`)
+	const viewer = viewerEntityHash()
+	const isSelf = viewer && entityHash === viewer
+	const container = document.getElementById('profileView')
+	rememberEntityHandle(entityHash, data.profile)
+	state.profileSocialMeta = data.socialMeta || {}
+
+	const cared = state.viewerEntityHash
+		? await isCared(state.viewerEntityHash, entityHash)
+		: false
+	const headerActions = isSelf
+		? await renderTemplateAsHtmlString('profile_header_actions_self', {})
+		: await renderTemplateAsHtmlString('profile_header_actions_other', {
+			entityHash: escapeHtml(entityHash),
+			isFollowing: data.isFollowing ? '1' : '0',
+			followKey: data.isFollowing ? 'social.actions.following' : 'social.actions.follow',
+			primaryClass: data.isFollowing ? '' : 'primary',
+			isCared: cared ? '1' : '0',
+			careKey: cared ? 'social.actions.careRemove' : 'social.actions.care',
+		})
+
+	container.replaceChildren(await renderTemplate('profile_view', {
+		headerActions,
+		entityHash: escapeHtml(entityHash),
+		postCount: data.postCount || 0,
+		followingCount: data.followingCount || 0,
+		followerCount: data.followerCount || 0,
+	}))
+
+	const cardHost = container.querySelector('#profileEntityCardHost')
+	if (cardHost instanceof HTMLElement)
+		await mountProfileEntityCard(cardHost, entityHash, data.profile)
+
+	await activateProfileTab('posts', { force: true })
+	if (highlightPostId) {
+		const panel = document.getElementById('profilePostsPanel')
+		if (panel)
+			await renderProfilePosts(entityHash, panel, highlightPostId)
+	}
+}
+
+/**
+ * @param {string} entityHash 实体
+ * @param {HTMLElement | null} container 容器
+ * @returns {Promise<void>}
+ */
+async function renderProfileCabinets(entityHash, container) {
+	if (!container) return
+	container.replaceChildren()
+	try {
+		const response = await fetch(`/api/parts/shells:cabinet/remote/${encodeURIComponent(entityHash)}/cabinets`, {
+			credentials: 'include',
+		})
+		if (!response.ok) throw new Error(await response.text())
+		const data = await response.json()
+		const cabinets = data.cabinets || []
+		if (!cabinets.length) {
+			await mountEmptyState(container, { titleKey: 'social.profile.cabinetsEmpty', modClass: ' empty-state--plain' })
+			return
+		}
+		const list = document.createElement('div')
+		list.className = 'flex flex-col gap-2 p-2'
+		for (const row of cabinets) {
+			const link = document.createElement('a')
+			link.className = 'btn btn-ghost justify-start'
+			link.href = `/parts/shells:cabinet/#user:${encodeURIComponent(entityHash)}`
+			link.textContent = row.name || row.cabinet_id
+			list.appendChild(link)
+		}
+		container.appendChild(list)
+	}
+	catch (error) {
+		console.error(error)
+		container.replaceChildren()
+		const empty = document.createElement('div')
+		empty.className = 'empty'
+		empty.dataset.i18n = 'social.profile.cabinetsFailed'
+		empty.dataset.error = error.message || 'failed'
+		container.appendChild(empty)
+	}
+}
+
+/**
+ * 加载当前观看者自身资料页。
+ * @returns {Promise<void>}
+ */
+export async function loadProfile() {
+	const profileHash = viewerEntityHash()
+	if (!profileHash) {
+		await mountEmptyState(document.getElementById('profileView'), { titleKey: 'social.empty.noIdentity', modClass: ' empty-state--plain' })
+		return
+	}
+	await loadProfileFor(profileHash)
+}

--- a/src/public/parts/shells/social/public/src/views/replies.mjs
+++ b/src/public/parts/shells/social/public/src/views/replies.mjs
@@ -1,0 +1,108 @@
+import { renderTemplate } from '../../../../../scripts/features/template.mjs'
+import { formatSocialPostHref, formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { formatActionKey } from '../lib/actionKey.mjs'
+import { authorLabel, entityHandle, formatTimeHtml, rememberEntityHandle, renderAvatarHtml, renderTrustedPostMarkdown } from '../lib/display.mjs'
+import { buildEmptyState } from '../lib/emptyState.mjs'
+import { renderEngagementBarHtml } from '../lib/engagementBar.mjs'
+import { state } from '../state.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+/**
+ * @param {string} actionKey 回复目标 actionKey
+ * @returns {Promise<HTMLElement>} 回复 composer
+ */
+async function buildReplyComposer(actionKey) {
+	const avatarHtml = state.viewerEntityHash
+		? renderAvatarHtml(state.viewerEntityHash, state.viewerProfile || {
+			name: state.viewerDisplayName,
+		}, 'reply-composer-avatar')
+		: ''
+	const composer = await renderTemplate('reply_composer', {
+		actionKey: escapeHtml(actionKey),
+		avatarSlot: avatarHtml
+			? `<div class="reply-composer-avatar-slot" aria-hidden="true">${avatarHtml}</div>`
+			: '',
+	})
+	const textarea = composer.querySelector('textarea')
+	textarea?.addEventListener('input', () => {
+		textarea.style.height = 'auto'
+		textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`
+	})
+	return composer
+}
+
+/**
+ * 渲染单条回复行（头像、显示名、互动栏）。
+ * @param {object} reply 回复 feed item
+ * @returns {Promise<HTMLElement>} 回复行
+ */
+export async function buildReplyRow(reply) {
+	const row = document.createElement('div')
+	row.className = 'reply'
+	const replyId = String(reply.postId || reply.post?.id || '')
+	const entityHash = String(reply.entityHash || '')
+	if (replyId) row.dataset.replyId = replyId
+	row.dataset.authorEntity = entityHash
+	const actionKey = formatActionKey(entityHash, replyId)
+	const text = reply.post?.content?.text || ''
+	const bodyHtml = reply.post?.decryptView?.failed
+		? '<em data-i18n="social.feed.decryptFailed"></em>'
+		: await renderTrustedPostMarkdown(text, entityHash)
+	const engagementBarHtml = await renderEngagementBarHtml(reply, actionKey)
+	rememberEntityHandle(entityHash, reply.authorProfile)
+	row.innerHTML = `
+		<div class="reply-header">
+			<a href="${escapeHtml(formatSocialProfileHref(entityHash))}" class="reply-avatar-link">
+				${renderAvatarHtml(entityHash, reply.authorProfile, 'reply-avatar')}
+			</a>
+			<div class="reply-header-text">
+				<a href="${escapeHtml(formatSocialProfileHref(entityHash))}" class="link-btn author-name">${escapeHtml(authorLabel(entityHash, reply.authorProfile))}</a>
+				<a href="${escapeHtml(formatSocialProfileHref(entityHash))}" class="author-handle">${escapeHtml(entityHandle(entityHash, reply.authorProfile))}</a>
+				<span class="post-meta-sep">·</span>
+				${formatTimeHtml(reply.post?.hlc?.wall || reply.hlc?.wall, 'post-meta reply-time', 'a', {
+		href: formatSocialPostHref(entityHash, replyId),
+	})}
+			</div>
+		</div>
+		<div class="markdown-body reply-body">${bodyHtml}</div>
+		${engagementBarHtml}
+		<div class="replies nested-replies hidden" data-replies-for="${escapeHtml(actionKey)}"></div>
+	`
+	return row
+}
+
+/**
+ * 渲染帖子回复面板与回复 composer。
+ * @param {HTMLElement} panel 面板
+ * @param {object[]} replies 回复列表
+ * @returns {Promise<void>}
+ */
+export async function renderRepliesPanel(panel, replies) {
+	const list = document.createElement('div')
+	list.className = 'replies-list'
+	if (!replies.length) {
+		list.classList.add('is-empty')
+		list.replaceChildren(await buildEmptyState({
+			titleKey: 'social.replies.empty',
+			iconClass: 'icon-reply',
+			hintKey: 'social.replies.emptyHint',
+			modClass: ' empty-state--replies',
+		}))
+	}
+	else
+		for (const reply of replies)
+			list.appendChild(await buildReplyRow(reply))
+
+	panel.replaceChildren()
+	if (panel.classList.contains('video-replies-panel')) {
+		const header = await renderTemplate('video_replies_header', {})
+		header.querySelector('[data-close-replies]')?.addEventListener('click', event => {
+			event.stopPropagation()
+			panel.classList.add('hidden')
+			panel.closest('.video-slide')?.querySelector('[data-comment-ticker]')?.classList.remove('is-dimmed')
+		})
+		panel.appendChild(header)
+	}
+	panel.appendChild(list)
+	panel.appendChild(await buildReplyComposer(panel.dataset.repliesFor || ''))
+}

--- a/src/public/parts/shells/social/public/src/views/saved.mjs
+++ b/src/public/parts/shells/social/public/src/views/saved.mjs
@@ -1,0 +1,377 @@
+import { formatHashShort } from '/parts/shells:chat/shared/entityHash.mjs'
+import { formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { formatActionKey } from '../lib/actionKey.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { renderAvatarHtml } from '../lib/display.mjs'
+import { buildEmptyState } from '../lib/emptyState.mjs'
+import { runWrite } from '../lib/socialWrite.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+import { state } from '../state.mjs'
+
+/** @type {'all' | 'unfiled' | string} */
+let savedFilter = 'all'
+let savedQuery = ''
+let savedSearchBound = false
+/** @type {object | null} */
+let savedCache = null
+
+/**
+ * 关闭收藏帖模态框。
+ * @returns {void}
+ */
+export function closeSaveModal() {
+	state.pendingSave = null
+	document.getElementById('saveModal')?.classList.add('hidden')
+}
+
+/**
+ * 打开收藏帖模态框并填充文件夹选项。
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖子
+ * @param {HTMLElement} button 按钮
+ * @returns {Promise<void>}
+ */
+export async function openSaveModal(entityHash, postId, button) {
+	state.pendingSave = { entityHash, postId, button }
+	const modal = document.getElementById('saveModal')
+	const select = document.getElementById('saveFolderSelect')
+	if (!modal || !select) return
+	select.innerHTML = `<option value="">${escapeHtml(geti18n('social.saved.unfiled'))}</option>`
+	modal.classList.remove('hidden')
+	const savedData = await socialApi('/saved-posts').catch(() => ({ folders: {} }))
+	state.savedFoldersCache = savedData.folders || {}
+	for (const [folderId, folder] of Object.entries(state.savedFoldersCache)) {
+		const option = document.createElement('option')
+		option.value = folderId
+		option.textContent = folder.name || folderId
+		select.appendChild(option)
+	}
+}
+
+/**
+ * 确认收藏当前帖子到选定文件夹。
+ * @returns {Promise<void>}
+ */
+export async function confirmSaveModal() {
+	if (!state.pendingSave) return
+	const folderId = document.getElementById('saveFolderSelect')?.value || undefined
+	const { button } = state.pendingSave
+	const prevText = button.textContent
+	button.textContent = geti18n('social.actions.saved')
+	try {
+		await runWrite('save', () => socialApi('/saved-posts/add', {
+			method: 'POST',
+			body: JSON.stringify({
+				entityHash: state.pendingSave.entityHash,
+				postId: state.pendingSave.postId,
+				folderId: folderId || undefined,
+			}),
+		}))
+		closeSaveModal()
+	}
+	catch {
+		button.textContent = prevText
+	}
+}
+
+/**
+ * @param {string | undefined} name 展示名
+ * @param {string} entityHash entityHash
+ * @returns {string} 作者展示名
+ */
+function savedAuthorLabel(name, entityHash) {
+	return name || formatHashShort(entityHash, { headLen: 8, tailLen: 0 })
+}
+
+/**
+ * @param {string | undefined} preview 预览
+ * @param {string} postId 帖子 id
+ * @returns {string} 预览文本
+ */
+function savedPreviewLabel(preview, postId) {
+	return preview || `${postId.slice(0, 8)}…`
+}
+
+/**
+ * @param {object} ref 收藏引用
+ * @param {string} [folderId] 文件夹
+ * @param {string} [folderName] 文件夹名（搜索结果角标）
+ * @returns {HTMLElement} 行节点
+ */
+function buildSavedRow(ref, folderId, folderName) {
+	const actionKey = formatActionKey(ref.entityHash, ref.postId)
+	const author = savedAuthorLabel(ref.authorName, ref.entityHash)
+	const row = document.createElement('article')
+	row.className = 'saved-row'
+	row.innerHTML = `
+		<a href="${escapeHtml(formatSocialProfileHref(ref.entityHash, ref.postId))}" class="saved-link">
+			${renderAvatarHtml(ref.entityHash, { name: author }, 'saved-row-avatar')}
+			<span class="saved-link-body">
+				<strong class="saved-author">${escapeHtml(author)}</strong>
+				<span class="saved-preview">${escapeHtml(savedPreviewLabel(ref.preview, ref.postId))}</span>
+				${folderName ? `<span class="saved-folder-badge">${escapeHtml(folderName)}</span>` : ''}
+			</span>
+		</a>
+		<button type="button" class="saved-row-action" data-remove-saved="${escapeHtml(actionKey)}"${folderId ? ` data-saved-folder="${escapeHtml(folderId)}"` : ''} aria-label="${escapeHtml(geti18n('social.saved.remove'))}">
+			<span class="icon icon-bookmark-off" aria-hidden="true"></span>
+		</button>
+	`
+	return row
+}
+
+/**
+ * @param {string} title 标题
+ * @param {number} count 数量
+ * @param {{ folderId?: string, emptyKey?: string }} [opts] 选项
+ * @returns {HTMLElement} 分区
+ */
+function buildSavedSection(title, count, opts = {}) {
+	const section = document.createElement('section')
+	section.className = 'saved-section'
+	const actions = opts.folderId
+		? `
+			<div class="saved-folder-actions">
+				<button type="button" class="saved-icon-btn" data-rename-folder="${escapeHtml(opts.folderId)}" aria-label="${escapeHtml(geti18n('social.saved.renameFolder'))}" title="${escapeHtml(geti18n('social.saved.renameFolder'))}">
+					<span class="icon icon-edit" aria-hidden="true"></span>
+				</button>
+				<button type="button" class="saved-icon-btn saved-icon-btn-danger" data-delete-folder="${escapeHtml(opts.folderId)}" aria-label="${escapeHtml(geti18n('social.saved.deleteFolder'))}" title="${escapeHtml(geti18n('social.saved.deleteFolder'))}">
+					<span class="icon icon-delete" aria-hidden="true"></span>
+				</button>
+			</div>
+		`
+		: ''
+	section.innerHTML = `
+		<div class="saved-section-header">
+			<div class="saved-section-title-wrap">
+				<span class="icon ${opts.folderId ? 'icon-folder' : 'icon-bookmark'} saved-section-icon" aria-hidden="true"></span>
+				<h3 class="saved-section-title">${escapeHtml(title)}</h3>
+				<span class="saved-count">${count}</span>
+			</div>
+			${actions}
+		</div>
+	`
+	const list = document.createElement('div')
+	list.className = 'saved-section-list'
+	if (!count && opts.emptyKey) {
+		const empty = document.createElement('div')
+		empty.className = 'saved-section-empty'
+		empty.textContent = geti18n(opts.emptyKey)
+		list.appendChild(empty)
+	}
+	section.appendChild(list)
+	return section
+}
+
+/**
+ * @param {object} data 收藏结构
+ * @returns {number} 总数
+ */
+function totalSavedCount(data) {
+	let n = (data.unfiled || []).length
+	for (const folder of Object.values(data.folders || {}))
+		n += (folder.posts || []).length
+	return n
+}
+
+/**
+ * @param {object} ref 引用
+ * @param {string} query 小写查询
+ * @returns {boolean} 是否匹配
+ */
+function matchesSavedQuery(ref, query) {
+	if (!query) return true
+	const haystack = [ref.preview, ref.authorName, ref.entityHash].filter(Boolean).join('\n').toLowerCase()
+	return haystack.includes(query)
+}
+
+/**
+ * 绑定搜索框（幂等）。
+ * @returns {void}
+ */
+function bindSavedSearch() {
+	if (savedSearchBound) return
+	const panel = document.getElementById('savedPanel')
+	if (!panel) return
+	savedSearchBound = true
+	panel.addEventListener('input', event => {
+		const input = event.target
+		if (!(input instanceof HTMLInputElement) || input.id !== 'savedSearchInput') return
+		savedQuery = input.value.trim()
+		void renderSavedPanel()
+	})
+}
+
+/**
+ * 切换文件夹筛选。
+ * @param {string} filter `all` | `unfiled` | folderId
+ * @returns {void}
+ */
+export function setSavedFilter(filter) {
+	savedFilter = filter
+	void renderSavedPanel()
+}
+
+/**
+ * 用缓存数据重绘收藏面板。
+ * @returns {Promise<void>}
+ */
+export async function renderSavedPanel() {
+	const data = savedCache
+	const panel = document.getElementById('savedPanel')
+	if (!data || !panel) return
+
+	const folders = data.folders || {}
+	const unfiled = data.unfiled || []
+	const folderEntries = Object.entries(folders)
+	const total = totalSavedCount(data)
+	const hasFolders = folderEntries.length > 0
+
+	if (savedFilter !== 'all' && savedFilter !== 'unfiled' && !folders[savedFilter])
+		savedFilter = 'all'
+	if (!total) savedQuery = ''
+
+	panel.replaceChildren()
+
+	if (!total && !hasFolders) {
+		panel.replaceChildren(await buildEmptyState({
+			modClass: ' empty-state--saved',
+			iconClass: 'icon-bookmark',
+			titleKey: 'social.empty.saved',
+			hintKey: 'social.saved.emptyHint',
+		}))
+		return
+	}
+
+	const query = savedQuery.toLowerCase()
+
+	if (total) {
+		const toolbar = document.createElement('div')
+		toolbar.className = 'saved-toolbar'
+		toolbar.innerHTML = `
+			<div class="feed-search-wrap saved-search-wrap">
+				<span class="icon icon-search search-icon" aria-hidden="true"></span>
+				<input type="search" id="savedSearchInput" class="feed-search-input" value="${escapeHtml(savedQuery)}" data-i18n="social.saved.search" autocomplete="off" />
+			</div>
+		`
+		panel.appendChild(toolbar)
+	}
+
+	const tabs = document.createElement('div')
+	tabs.className = 'saved-folder-tabs'
+	tabs.setAttribute('role', 'tablist')
+	const tabSpecs = [
+		{ id: 'all', label: geti18n('social.saved.all'), count: total },
+		{ id: 'unfiled', label: geti18n('social.saved.unfiled'), count: unfiled.length },
+		...folderEntries.map(([folderId, folder]) => ({
+			id: folderId,
+			label: folder.name || folderId,
+			count: (folder.posts || []).length,
+		})),
+	]
+	for (const tab of tabSpecs) {
+		const button = document.createElement('button')
+		button.type = 'button'
+		button.className = `saved-folder-tab${savedFilter === tab.id ? ' active' : ''}`
+		button.dataset.savedFilter = tab.id
+		button.setAttribute('role', 'tab')
+		button.setAttribute('aria-selected', savedFilter === tab.id ? 'true' : 'false')
+		button.innerHTML = `
+			<span class="saved-folder-tab-label">${escapeHtml(tab.label)}</span>
+			<span class="saved-folder-tab-count">${tab.count}</span>
+		`
+		tabs.appendChild(button)
+	}
+	panel.appendChild(tabs)
+
+	const listHost = document.createElement('div')
+	listHost.className = 'saved-list'
+	panel.appendChild(listHost)
+
+	/**
+	 * @param {object[]} refs 引用
+	 * @param {string | undefined} folderId 文件夹
+	 * @param {string} [folderName] 角标名
+	 * @returns {object[]} 过滤后
+	 */
+	const filterRefs = (refs, folderId, folderName) => {
+		const out = []
+		for (const ref of refs || []) {
+			if (!matchesSavedQuery(ref, query)) continue
+			out.push({ ref, folderId, folderName })
+		}
+		return out
+	}
+
+	if (query) {
+		/** @type {{ ref: object, folderId?: string, folderName?: string }[]} */
+		const hits = []
+		if (savedFilter === 'all' || savedFilter === 'unfiled')
+			hits.push(...filterRefs(unfiled, undefined, geti18n('social.saved.unfiled')))
+		for (const [folderId, folder] of folderEntries) {
+			if (savedFilter !== 'all' && savedFilter !== folderId) continue
+			hits.push(...filterRefs(folder.posts, folderId, folder.name || folderId))
+		}
+		if (!hits.length) {
+			listHost.replaceChildren(await buildEmptyState({
+				modClass: ' empty-state--saved empty-state--compact',
+				iconClass: 'icon-search',
+				titleKey: 'social.saved.searchEmpty',
+			}))
+			return
+		}
+		for (const hit of hits)
+			listHost.appendChild(buildSavedRow(hit.ref, hit.folderId, savedFilter === 'all' ? hit.folderName : undefined))
+		return
+	}
+
+	/**
+	 * @param {string} title 标题
+	 * @param {object[]} refs 引用
+	 * @param {{ folderId?: string }} [opts] 选项
+	 */
+	const appendSection = (title, refs, opts = {}) => {
+		const section = buildSavedSection(title, refs.length, {
+			folderId: opts.folderId,
+			emptyKey: 'social.saved.folderEmpty',
+		})
+		const sectionList = section.querySelector('.saved-section-list')
+		for (const ref of refs)
+			sectionList?.appendChild(buildSavedRow(ref, opts.folderId))
+		listHost.appendChild(section)
+	}
+
+	if (savedFilter === 'all') {
+		for (const [folderId, folder] of folderEntries)
+			appendSection(folder.name || folderId, folder.posts || [], { folderId })
+		appendSection(geti18n('social.saved.unfiled'), unfiled)
+		return
+	}
+
+	if (savedFilter === 'unfiled') {
+		appendSection(geti18n('social.saved.unfiled'), unfiled)
+		return
+	}
+
+	const folder = folders[savedFilter]
+	if (folder)
+		appendSection(folder.name || savedFilter, folder.posts || [], { folderId: savedFilter })
+}
+
+/**
+ * 加载并渲染收藏帖与文件夹视图。
+ * @returns {Promise<void>}
+ */
+export async function loadSaved() {
+	bindSavedSearch()
+	const createButton = document.getElementById('createFolderButton')
+	if (createButton) {
+		const label = geti18n('social.saved.createFolder')
+		createButton.setAttribute('aria-label', label)
+		createButton.setAttribute('title', label)
+	}
+	const data = await socialApi('/saved-posts')
+	savedCache = data
+	state.savedFoldersCache = data.folders || {}
+	await renderSavedPanel()
+}

--- a/src/public/parts/shells/social/public/src/views/search.mjs
+++ b/src/public/parts/shells/social/public/src/views/search.mjs
@@ -1,0 +1,165 @@
+import { bindInfiniteScroll, disconnectInfiniteScroll, ensureScrollSentinel } from '/scripts/infiniteScroll.mjs'
+import { chatApi, socialApi } from '../lib/apiClient.mjs'
+import { appendEmptyState, mountEmptyState } from '../lib/emptyState.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { state } from '../state.mjs'
+import { activateView } from '../viewChrome.mjs'
+
+import { updateFeedSearchChrome } from './feed.mjs'
+
+let searchGeneration = 0
+
+/**
+ * @param {HTMLElement} list 容器
+ * @param {string} i18nKey 文案键
+ * @returns {Promise<void>}
+ */
+async function showSearchHint(list, i18nKey) {
+	await mountEmptyState(list, { titleKey: i18nKey, modClass: ' empty-state--hint' })
+}
+
+/**
+ * 同步搜索 hash。
+ * @param {string} q 查询
+ * @returns {void}
+ */
+function syncSearchHash(q) {
+	const next = `#search:${encodeURIComponent(q)}`
+	if (location.hash === next) return
+	history.replaceState(null, '', `${location.pathname}${location.search}${next}`)
+}
+
+/**
+ * 初始化搜索视图事件绑定（只调用一次）。
+ * @returns {void}
+ */
+export function initSearchView() {
+	const view = document.getElementById('searchView')
+	if (!view) return
+	view.querySelector('#searchViewInput')?.addEventListener('keydown', event => {
+		if (event.key === 'Enter') void runSearchView()
+	})
+	view.querySelector('#searchViewButton')?.addEventListener('click', () => void runSearchView())
+}
+
+/**
+ * 激活搜索视图并可选预填查询词。
+ * @param {string} [initialQuery] 初始查询
+ * @returns {Promise<void>}
+ */
+export async function loadSearchView(initialQuery = '') {
+	activateView('search')
+	const view = document.getElementById('searchView')
+	if (!view) return
+	const asideInput = document.getElementById('feedSearchInput')
+	const input = view.querySelector('#searchViewInput')
+	const q = String(initialQuery || '').trim()
+		|| (asideInput instanceof HTMLInputElement ? asideInput.value.trim() : '')
+		|| (input instanceof HTMLInputElement ? input.value.trim() : '')
+	if (input instanceof HTMLInputElement)
+		input.value = q
+	if (asideInput instanceof HTMLInputElement)
+		asideInput.value = q
+	state.activeFeedSearchQuery = q || null
+	updateFeedSearchChrome()
+	if (q)
+		await runSearchView()
+	else
+		input?.focus()
+}
+
+/**
+ * 执行搜索并渲染结果。
+ * @returns {Promise<void>}
+ */
+export async function runSearchView() {
+	const view = document.getElementById('searchView')
+	if (!view) return
+	const input = view.querySelector('#searchViewInput')
+	const q = input instanceof HTMLInputElement ? input.value.trim() : ''
+	if (q.length < 2) {
+		const list = view.querySelector('#searchViewResults')
+		if (list) await showSearchHint(list, 'social.search.tooShort')
+		return
+	}
+
+	const author = view.querySelector('#searchViewAuthor')?.value?.trim() || ''
+	const media = view.querySelector('#searchViewMedia')?.value || ''
+	const tag = view.querySelector('#searchViewTag')?.value?.trim() || ''
+	const sort = view.querySelector('#searchViewSort')?.value || 'recent'
+	const scope = view.querySelector('#searchViewScope')?.value || 'local'
+
+	const gen = ++searchGeneration
+	const list = view.querySelector('#searchViewResults')
+	if (!list) return
+
+	syncSearchHash(q)
+	state.activeFeedSearchQuery = q
+	updateFeedSearchChrome()
+	const asideInput = document.getElementById('feedSearchInput')
+	if (asideInput instanceof HTMLInputElement) asideInput.value = q
+
+	disconnectInfiniteScroll()
+	await showSearchHint(list, 'social.search.loading')
+
+	const baseParams = new URLSearchParams({ q, sort, scope, limit: '30' })
+	if (author) baseParams.set('author', author)
+	if (media) baseParams.set('media', media)
+	if (tag) baseParams.set('tag', tag.replace(/^#/, ''))
+
+	const [data, entityData] = await Promise.all([
+		socialApi(`/search?${baseParams}`).catch(() => ({ items: [] })),
+		chatApi(`/entities/search?q=${encodeURIComponent(q)}&limit=20`).catch(() => ({ entities: [] })),
+	])
+	if (gen !== searchGeneration) return
+
+	const items = data.items || []
+	const entities = entityData.entities || []
+	list.replaceChildren()
+
+	const usersTitle = document.createElement('h3')
+	usersTitle.className = 'section-title'
+	usersTitle.dataset.i18n = 'social.search.usersTitle'
+	list.appendChild(usersTitle)
+	if (!entities.length)
+		await appendEmptyState(list, { titleKey: 'social.search.usersEmpty', modClass: ' empty-state--hint' })
+	else {
+		const { buildEntitySearchCard } = await import('./feed.mjs')
+		for (const entity of entities)
+			list.appendChild(await buildEntitySearchCard(entity))
+	}
+
+	const postsTitle = document.createElement('h3')
+	postsTitle.className = 'section-title'
+	postsTitle.dataset.i18n = 'social.search.postsTitle'
+	list.appendChild(postsTitle)
+
+	if (!items.length) {
+		await appendEmptyState(list, { titleKey: 'social.search.empty', modClass: ' empty-state--hint' })
+		return
+	}
+
+	const cards = await Promise.all(items.map(item => buildPostCard(item).catch(() => null)))
+	if (gen !== searchGeneration) return
+	for (const card of cards) if (card) list.appendChild(card)
+
+	let cursor = data.nextCursor || null
+	if (cursor) {
+		const sentinel = ensureScrollSentinel(list, 'searchViewScrollSentinel')
+		bindInfiniteScroll({
+			sentinel,
+			/** @returns {boolean} 是否还有下一页 */
+			hasMore: () => !!cursor,
+			/** @returns {Promise<void>} */
+			onLoad: async () => {
+				const p2 = new URLSearchParams(baseParams)
+				p2.set('cursor', cursor)
+				const d2 = await socialApi(`/search?${p2}`).catch(() => ({ items: [] }))
+				if (gen !== searchGeneration) return
+				cursor = d2.nextCursor || null
+				const c2 = await Promise.all((d2.items || []).map(item => buildPostCard(item).catch(() => null)))
+				for (const card of c2) if (card) list.appendChild(card)
+			},
+		})
+	}
+}

--- a/src/public/parts/shells/social/public/src/views/settings.mjs
+++ b/src/public/parts/shells/social/public/src/views/settings.mjs
@@ -1,0 +1,261 @@
+import { formatHashShort } from '/parts/shells:chat/shared/entityHash.mjs'
+import { appendTemplate, renderTemplate } from '/scripts/features/template.mjs'
+import { initTranslations, primaryLocale } from '/scripts/i18n/index.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+import { chatApi, socialApi } from '../lib/apiClient.mjs'
+import { mountEmptyState } from '../lib/emptyState.mjs'
+import { runWrite } from '../lib/socialWrite.mjs'
+import { state } from '../state.mjs'
+
+import { renderBlocklist } from './profile.mjs'
+
+/**
+ * @param {number} weight 权重
+ * @returns {string} 格式化权重
+ */
+function formatWeight(weight) {
+	const n = Number(weight)
+	if (!Number.isFinite(n)) return '0'
+	return n.toFixed(2).replace(/\.?0+$/, '')
+}
+
+/**
+ * @param {HTMLElement} panel 面板
+ * @param {object[]} entries 屏蔽词条目
+ * @returns {Promise<void>}
+ */
+async function renderMutedKeywordsSection(panel, entries) {
+	const section = await renderTemplate('settings_muted_keywords', {})
+	panel.appendChild(section)
+
+	const chips = section.querySelector('#mutedKeywordChips')
+	/**
+	 * @param {object[]} list 条目
+	 * @returns {Promise<void>}
+	 */
+	async function paintChips(list) {
+		chips.replaceChildren()
+		if (!list.length) {
+			await mountEmptyState(chips, { titleKey: 'social.settings.mutedKeywordsEmpty', modClass: ' empty-state--hint' })
+			return
+		}
+		for (const entry of list) {
+			const chip = document.createElement('button')
+			chip.type = 'button'
+			chip.className = 'muted-keyword-chip'
+			chip.dataset.pattern = entry.pattern
+			chip.dataset.i18n = 'social.settings.mutedKeywordsRemove'
+			const tagHint = entry.matchTags === false ? '' : ' #Tag'
+			chip.innerHTML = `<span>${escapeHtml(entry.pattern)}${escapeHtml(tagHint)}</span><span aria-hidden="true">×</span>`
+			chips.appendChild(chip)
+		}
+	}
+	await paintChips(entries)
+
+	/**
+	 * @param {object[]} next 下一份条目
+	 * @returns {Promise<object[]>} 服务端条目
+	 */
+	async function persist(next) {
+		const data = await runWrite('mutedKeywords', () => socialApi('/profile/muted-keywords', {
+			method: 'PUT',
+			body: JSON.stringify({ entries: next }),
+		}))
+		const saved = data?.entries || next
+		await paintChips(saved)
+		return saved
+	}
+
+	section.querySelector('#mutedKeywordForm')?.addEventListener('submit', event => {
+		event.preventDefault()
+		const input = section.querySelector('#mutedKeywordInput')
+		const matchTags = section.querySelector('#mutedKeywordMatchTags')
+		const pattern = input instanceof HTMLInputElement ? input.value.trim().toLowerCase() : ''
+		if (!pattern) return
+		const next = [
+			...entries.filter(entry => entry.pattern !== pattern),
+			{
+				pattern,
+				matchTags: matchTags instanceof HTMLInputElement ? matchTags.checked : true,
+			},
+		]
+		void persist(next).then(saved => {
+			entries.splice(0, entries.length, ...saved)
+			if (input instanceof HTMLInputElement) input.value = ''
+		})
+	})
+
+	chips.addEventListener('click', event => {
+		const chip = event.target instanceof Element ? event.target.closest('.muted-keyword-chip') : null
+		if (!(chip instanceof HTMLElement) || !chip.dataset.pattern) return
+		const next = entries.filter(entry => entry.pattern !== chip.dataset.pattern)
+		void persist(next).then(saved => {
+			entries.splice(0, entries.length, ...saved)
+		})
+	})
+}
+
+/**
+ * @param {HTMLElement} panel 面板
+ * @returns {Promise<void>}
+ */
+async function renderTranslationPrefsSection(panel) {
+	const data = await chatApi('/translation-prefs').catch(() => ({ prefs: { autoTranslate: false } }))
+	const prefs = data?.prefs || { autoTranslate: false }
+	const section = await renderTemplate('settings_toggle_card', {
+		titleKey: 'social.settings.autoTranslateTitle',
+		hintKey: 'social.settings.autoTranslateHint',
+		inputId: 'socialAutoTranslate',
+		labelKey: 'social.settings.autoTranslateEnable',
+		checkedAttr: prefs.autoTranslate ? 'checked' : '',
+	})
+	panel.appendChild(section)
+	section.querySelector('#socialAutoTranslate')?.addEventListener('change', event => {
+		const checked = event.target instanceof HTMLInputElement && event.target.checked
+		void runWrite('translationPrefs', () => chatApi('/translation-prefs', {
+			method: 'PUT',
+			body: JSON.stringify({ prefs: { ...prefs, autoTranslate: checked } }),
+		}))
+	})
+}
+
+/**
+ * @param {HTMLElement} panel 面板
+ * @param {object} socialMeta meta
+ * @returns {Promise<void>}
+ */
+async function renderPrivacySection(panel, socialMeta) {
+	const section = await renderTemplate('settings_toggle_card', {
+		titleKey: 'social.settings.privacyTitle',
+		hintKey: 'social.settings.privacyHint',
+		inputId: 'exploreProtectedInput',
+		labelKey: 'social.profile.hideFromExplore',
+		checkedAttr: socialMeta?.hideFromDiscovery ? 'checked' : '',
+	})
+	panel.appendChild(section)
+	section.querySelector('#exploreProtectedInput')?.addEventListener('change', async event => {
+		const checked = event.target instanceof HTMLInputElement && event.target.checked
+		await socialApi('/profile/meta', {
+			method: 'POST',
+			body: JSON.stringify({ hideFromDiscovery: checked }),
+		})
+		state.profileSocialMeta = {
+			...state.profileSocialMeta,
+			hideFromDiscovery: checked,
+		}
+	})
+}
+
+/**
+ * @param {HTMLElement} panel 面板
+ * @param {object} data taste 响应
+ * @returns {Promise<void>}
+ */
+async function renderTasteSection(panel, data) {
+	const tags = data.tags || []
+	const publishPreferences = data.privacy?.publishPreferences !== false
+	const publishReactions = data.privacy?.publishReactions !== false
+
+	const section = await renderTemplate('settings_taste', {
+		prefsCheckedAttr: publishPreferences ? 'checked' : '',
+		reactionsCheckedAttr: publishReactions ? 'checked' : '',
+	})
+	panel.appendChild(section)
+
+	/**
+	 * @returns {Promise<void>}
+	 */
+	function persistPrivacy() {
+		const prefs = section.querySelector('#tastePublishPreferences')
+		const reactions = section.querySelector('#tastePublishReactions')
+		return runWrite('tastePrivacy', () => socialApi('/taste', {
+			method: 'PUT',
+			body: JSON.stringify({
+				privacy: {
+					publishPreferences: prefs instanceof HTMLInputElement ? prefs.checked : true,
+					publishReactions: reactions instanceof HTMLInputElement ? reactions.checked : true,
+				},
+			}),
+		}))
+	}
+
+	section.querySelector('#tastePublishPreferences')?.addEventListener('change', () => { void persistPrivacy() })
+	section.querySelector('#tastePublishReactions')?.addEventListener('change', () => { void persistPrivacy() })
+	section.querySelector('#tasteRebuildButton')?.addEventListener('click', () => {
+		void runWrite('tasteRebuild', () => socialApi('/taste/rebuild', { method: 'POST' }))
+			.then(() => loadSettings())
+	})
+
+	const list = section.querySelector('[data-taste-list]')
+	if (!(list instanceof HTMLElement)) return
+	if (!tags.length)
+		await mountEmptyState(list, { titleKey: 'social.taste.empty', modClass: ' empty-state--hint' })
+	else
+		for (const tag of tags) {
+			const label = tag.label || formatHashShort(tag.tagHash, { headLen: 8, tailLen: 4 })
+			await appendTemplate(list, 'settings_taste_row', {
+				label: escapeHtml(label),
+				labelValue: escapeHtml(tag.label || ''),
+				tagHash: escapeHtml(tag.tagHash),
+				tagHashShort: escapeHtml(formatHashShort(tag.tagHash, { headLen: 10, tailLen: 6 })),
+				weight: formatWeight(tag.weight),
+			})
+		}
+
+	for (const form of list.querySelectorAll('.taste-rename-form'))
+		form.addEventListener('submit', event => {
+			event.preventDefault()
+			const tagHash = form.getAttribute('data-tag-hash')
+			const input = form.querySelector('input')
+			const label = input instanceof HTMLInputElement ? input.value.trim() : ''
+			if (!tagHash || !label) return
+			void runWrite('tasteName', () => socialApi('/taste/names', {
+				method: 'POST',
+				body: JSON.stringify({ tagHash, label, locale: primaryLocale() }),
+			})).then(() => loadSettings())
+		})
+}
+
+/**
+ * @param {HTMLElement} panel 面板
+ * @returns {Promise<void>}
+ */
+async function renderSafetySection(panel) {
+	const section = await renderTemplate('settings_safety', {})
+	panel.appendChild(section)
+	await renderBlocklist(section.querySelector('#blocklistSection'))
+	section.addEventListener('click', async event => {
+		const target = event.target
+		if (!(target instanceof HTMLElement)) return
+		const { handleProfileNavClick } = await import('../actions/profileNavActions.mjs')
+		await handleProfileNavClick(target)
+	})
+}
+
+/**
+ * 加载社交设置视图。
+ * @returns {Promise<void>}
+ */
+export async function loadSettings() {
+	const panel = document.getElementById('settingsPanel')
+	if (!panel) return
+	const [taste, muted, profile] = await Promise.all([
+		socialApi('/taste').catch(() => ({ tags: [], privacy: {} })),
+		socialApi('/profile/muted-keywords').catch(() => ({ entries: [] })),
+		state.viewerEntityHash
+			? socialApi(`/profile/${state.viewerEntityHash}`).catch(() => ({}))
+			: Promise.resolve({}),
+	])
+	const socialMeta = profile.socialMeta || state.profileSocialMeta || {}
+	state.profileSocialMeta = socialMeta
+	const mutedEntries = [...muted.entries || []]
+
+	panel.replaceChildren()
+	await renderPrivacySection(panel, socialMeta)
+	await renderTasteSection(panel, taste)
+	await renderMutedKeywordsSection(panel, mutedEntries)
+	await renderTranslationPrefsSection(panel)
+	await renderSafetySection(panel)
+	await initTranslations()
+}

--- a/src/public/parts/shells/social/public/src/views/topic.mjs
+++ b/src/public/parts/shells/social/public/src/views/topic.mjs
@@ -1,0 +1,122 @@
+import { bindInfiniteScroll, disconnectInfiniteScroll, ensureScrollSentinel } from '/scripts/infiniteScroll.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { mountEmptyState } from '../lib/emptyState.mjs'
+import { buildPostCard } from '../postCard.mjs'
+import { activateView } from '../viewChrome.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+let topicGeneration = 0
+let currentTopicTag = null
+
+/**
+ * 初始化话题视图事件绑定（只调用一次）。
+ * @returns {void}
+ */
+export function initTopicView() {
+	document.getElementById('topicView')?.addEventListener('click', async event => {
+		const followButton = event.target.closest('#topicFollowButton')
+		if (!followButton) return
+		const tag = followButton.dataset.tag
+		if (!tag) return
+		const isFollowed = followButton.dataset.followed === 'true'
+		try {
+			await socialApi('/topics/follow', {
+				method: 'POST',
+				body: JSON.stringify({ tag, follow: !isFollowed }),
+			})
+			followButton.dataset.followed = String(!isFollowed)
+			followButton.textContent = geti18n(!isFollowed ? 'social.topic.unfollow' : 'social.topic.follow')
+			followButton.classList.toggle('btn-primary', isFollowed)
+			followButton.classList.toggle('btn-outline', !isFollowed)
+		}
+		catch { /* ignore */ }
+	})
+}
+
+/**
+ * 加载话题页。
+ * @param {string} tag 话题标签（含或不含 #）
+ * @returns {Promise<void>}
+ */
+export async function loadTopicView(tag) {
+	activateView('topic')
+	const view = document.getElementById('topicView')
+	if (!view) return
+
+	const normalizedTag = String(tag || '').replace(/^#/, '').trim()
+	currentTopicTag = normalizedTag
+
+	const titleEl = view.querySelector('.topic-view-title')
+	if (titleEl) titleEl.textContent = `#${normalizedTag}`
+
+	disconnectInfiniteScroll()
+	const list = document.getElementById('topicPostList')
+	if (list) list.replaceChildren()
+	delete view.dataset.topicCursor
+
+	const followButton = document.getElementById('topicFollowButton')
+	if (followButton) {
+		followButton.dataset.tag = normalizedTag
+		followButton.dataset.followed = 'false'
+		followButton.textContent = geti18n('social.topic.follow')
+		followButton.className = 'btn btn-primary btn-sm'
+		socialApi('/topics/followed').then(data => {
+			const tags = (data.tags || []).map(t => t.toLowerCase())
+			const isFollowed = tags.includes(normalizedTag.toLowerCase())
+			followButton.dataset.followed = String(isFollowed)
+			followButton.textContent = geti18n(isFollowed ? 'social.topic.unfollow' : 'social.topic.follow')
+			followButton.classList.toggle('btn-primary', !isFollowed)
+			followButton.classList.toggle('btn-outline', isFollowed)
+		}).catch(() => {})
+	}
+
+	await loadTopicPosts(normalizedTag, false)
+}
+
+/**
+ * @param {string} tag 标签
+ * @param {boolean} append 是否追加
+ * @returns {Promise<void>}
+ */
+async function loadTopicPosts(tag, append = false) {
+	const view = document.getElementById('topicView')
+	if (!view) return
+	const gen = ++topicGeneration
+	const list = document.getElementById('topicPostList')
+	if (!list) return
+
+	const cursor = append ? view.dataset.topicCursor || '' : ''
+	const params = new URLSearchParams({ limit: '30' })
+	if (cursor) params.set('cursor', cursor)
+
+	const data = await socialApi(`/topics/${encodeURIComponent(tag)}/posts?${params}`).catch(() => ({ items: [] }))
+	if (gen !== topicGeneration) return
+
+	const items = data.items || []
+	if (!append && !items.length) {
+		await mountEmptyState(list, { titleKey: 'social.topic.empty', modClass: ' empty-state--hint' })
+		return
+	}
+
+	const cards = await Promise.all(items.map(item => buildPostCard(item).catch(() => null)))
+	if (gen !== topicGeneration) return
+
+	if (!append) list.replaceChildren(...cards.filter(Boolean))
+	else for (const card of cards) if (card) list.appendChild(card)
+
+	view.dataset.topicCursor = data.nextCursor || ''
+	if (data.nextCursor) {
+		const sentinel = ensureScrollSentinel(list, 'topicScrollSentinel')
+		bindInfiniteScroll({
+			sentinel,
+			/**
+			 * @returns {boolean} 是否还有下一页
+			 */
+			hasMore: () => !!view.dataset.topicCursor,
+			/**
+			 * @returns {Promise<void>} 加载下一页
+			 */
+			onLoad: () => loadTopicPosts(currentTopicTag ?? tag, true),
+		})
+	}
+}

--- a/src/public/parts/shells/social/public/src/views/video.mjs
+++ b/src/public/parts/shells/social/public/src/views/video.mjs
@@ -1,0 +1,663 @@
+import { formatSocialProfileHref } from '../../shared/runUri.mjs'
+import { flashCopiedLabel, shareOrCopyPostLink } from '../actions/shared.mjs'
+import { formatActionKey } from '../lib/actionKey.mjs'
+import { socialApi } from '../lib/apiClient.mjs'
+import { authorLabel, entityHandle, renderAvatarHtml } from '../lib/display.mjs'
+import { buildEmptyState } from '../lib/emptyState.mjs'
+import { playHeartAnim } from '../lib/heartAnim.mjs'
+import { createSnapCursorFeed } from '../lib/snapCursorFeed.mjs'
+import { runWrite } from '../lib/socialWrite.mjs'
+import { bindVerticalSnap } from '../lib/verticalSnap.mjs'
+
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+import { renderRepliesPanel } from './replies.mjs'
+import { mediaRefUrl } from '/parts/shells:chat/shared/evfsMedia.mjs'
+import { geti18n } from '/scripts/i18n/index.mjs'
+
+/** @type {{ disconnect: () => void, observe: (el: HTMLElement) => void } | null} */
+let snapBind = null
+let currentVideoIndex = -1
+/** @type {WeakMap<HTMLElement, object[]>} */
+const slideRepliesCache = new WeakMap()
+
+const VIDEO_MUTE_KEY = 'fount.social.video.muted'
+
+/** @type {ReturnType<typeof createSnapCursorFeed>} */
+const videoFeed = createSnapCursorFeed({
+	/**
+ * @param {string | null} cursor 游标
+ * @returns {Promise<object | null>} 分页结果
+ */
+	fetchPage: cursor => socialApi(
+		`/videos/feed?limit=20&cursor=${encodeURIComponent(cursor || '')}`,
+	).catch(() => null),
+	/**
+	 * @param {HTMLElement} container 容器
+	 * @param {object[]} items 条目
+	 * @returns {void} 无返回
+	 */
+	appendSlides: (container, items) => {
+		for (const item of items) {
+			const slide = buildVideoSlide(item)
+			container.appendChild(slide)
+			snapBind?.observe(slide)
+		}
+	},
+	/**
+	 * @param {HTMLElement} container 容器
+	 * @param {number} index 索引
+	 * @returns {boolean} 是否允许重放
+	 */
+	canReplay: (container, index) => {
+		if (index < 1 && container.scrollTop <= 0) return false
+		return container.scrollHeight > container.clientHeight
+	},
+})
+
+/**
+ * @returns {boolean} 是否偏好静音
+ */
+function readVideoMutedPref() {
+	return localStorage.getItem(VIDEO_MUTE_KEY) === '1'
+}
+
+/**
+ * @param {boolean} muted 是否静音
+ * @returns {void}
+ */
+function writeVideoMutedPref(muted) {
+	localStorage.setItem(VIDEO_MUTE_KEY, muted ? '1' : '0')
+}
+
+/**
+ * 加载并渲染短视频流。
+ * @param {{ focusEntityHash?: string, focusPostId?: string }} [options] 可选焦点帖（深链）
+ * @returns {Promise<void>}
+ */
+export async function loadVideoView(options = {}) {
+	const container = document.getElementById('videoSnapContainer')
+	const view = document.getElementById('videosView')
+	if (!container) return
+
+	snapBind?.disconnect()
+	snapBind = null
+	container.replaceChildren()
+	currentVideoIndex = -1
+	videoFeed.reset()
+
+	const focusEntityHash = String(options.focusEntityHash || '').toLowerCase()
+	const focusPostId = String(options.focusPostId || '')
+
+	const data = await socialApi('/videos/feed?limit=20').catch(() => ({ items: [], nextCursor: null }))
+	let items = [...data.items || []]
+
+	if (focusEntityHash && focusPostId) {
+		const focusKey = `${focusEntityHash}:${focusPostId}`
+		const existingIndex = items.findIndex(item =>
+			`${String(item.entityHash || item.targetEntityHash || '').toLowerCase()}:${item.postId || item.targetPostId}` === focusKey
+			|| `${String(item.targetEntityHash || item.entityHash || '').toLowerCase()}:${item.targetPostId || item.postId}` === focusKey,
+		)
+		if (existingIndex > 0) {
+			const [focused] = items.splice(existingIndex, 1)
+			items = [focused, ...items]
+		}
+		else if (existingIndex < 0) {
+			const focused = await socialApi(`/posts/${focusEntityHash}/${focusPostId}`).catch(() => null)
+			if (focused?.item) items = [focused.item, ...items]
+		}
+	}
+
+	if (!items.length) {
+		container.appendChild(await buildVideoEmptySlide())
+		view?.focus({ preventScroll: true })
+		return
+	}
+
+	videoFeed.seed(items, data.nextCursor || null)
+	videoFeed.append(container, items)
+	view?.focus({ preventScroll: true })
+
+	snapBind = bindVerticalSnap(container, {
+		/**
+		 * @param {number} index 当前索引
+		 * @param {HTMLElement} el slide
+		 * @returns {void}
+		 */
+		onEnter: (index, el) => {
+			currentVideoIndex = index
+			const video = el.querySelector('video')
+			if (video) {
+				video.preload = 'auto'
+				video.play().catch(() => {})
+			}
+			setPauseHint(el, false)
+			for (let i = 1; i <= 2; i++) {
+				const next = container.children[index + i]
+				const nv = next?.querySelector('video')
+				if (nv) nv.preload = 'auto'
+			}
+			void ensureCommentTicker(el)
+			void videoFeed.maybeLoadMore(container, index)
+		},
+		/**
+		 * @param {number} _index 离开索引
+		 * @param {HTMLElement} el slide
+		 * @returns {void}
+		 */
+		onLeave: (_index, el) => {
+			const video = el.querySelector('video')
+			if (video) {
+				video.pause()
+				video.playbackRate = 1
+			}
+			setPauseHint(el, true)
+			closeVideoReplies(el)
+		},
+	})
+
+	if (focusEntityHash && focusPostId)
+		container.children[0]?.scrollIntoView({ behavior: 'instant', block: 'start' })
+}
+
+/**
+ * @returns {Promise<HTMLElement>} 空态 slide
+ */
+async function buildVideoEmptySlide() {
+	const slide = document.createElement('div')
+	slide.className = 'video-slide'
+	const empty = await buildEmptyState({
+		titleKey: 'social.video.empty',
+		iconClass: 'icon-video',
+		hintKey: 'social.video.emptyHint',
+		modClass: ' empty-state--video',
+		actionHtml: '<button type="button" class="btn btn-primary empty-state-action" data-video-compose data-i18n="social.video.compose"></button>',
+	})
+	slide.appendChild(empty)
+	slide.querySelector('[data-video-compose]')?.addEventListener('click', async () => {
+		const { focusComposer } = await import('../navigation.mjs')
+		await focusComposer({ switchToFeed: true })
+	})
+	return slide
+}
+
+/**
+ * @param {object} item feed 条目
+ * @returns {string} 可播放 URL；无则空串
+ */
+function resolveVideoSrc(item) {
+	const refs = item.post?.content?.mediaRefs || item.mediaRefs || []
+	const mediaRef = refs.find(m => String(m?.kind || '').toLowerCase() === 'video')
+	if (!mediaRef) return ''
+	try { return mediaRefUrl(mediaRef) }
+	catch { return '' }
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {boolean} paused 是否暂停
+ * @returns {void}
+ */
+function setPauseHint(slide, paused) {
+	slide.querySelector('.video-pause-hint')?.classList.toggle('is-visible', paused)
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {HTMLVideoElement} video 播放器
+ * @returns {void}
+ */
+function syncMuteButton(slide, video) {
+	const btn = slide.querySelector('.video-mute-btn')
+	if (!(btn instanceof HTMLElement)) return
+	btn.dataset.i18n = video.muted ? 'social.video.unmute' : 'social.video.mute'
+	btn.querySelector('.icon')?.classList.toggle('icon-mute', video.muted)
+	btn.querySelector('.icon')?.classList.toggle('icon-volume', !video.muted)
+}
+
+/**
+ * 将静音偏好应用到容器内全部视频 slide。
+ * @param {boolean} muted 是否静音
+ * @returns {void}
+ */
+function applyMutedToAllVideos(muted) {
+	writeVideoMutedPref(muted)
+	const container = document.getElementById('videoSnapContainer')
+	if (!container) return
+	for (const slide of container.querySelectorAll('.video-slide')) {
+		const video = slide.querySelector('video')
+		if (!video) continue
+		video.muted = muted
+		syncMuteButton(slide, video)
+	}
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {void}
+ */
+function closeVideoReplies(slide) {
+	const panel = slide.querySelector('[data-replies-panel]')
+	if (!panel || panel.classList.contains('hidden')) return
+	panel.classList.add('hidden')
+	slide.querySelector('[data-comment-ticker]')?.classList.remove('is-dimmed')
+}
+
+/**
+ * 用回复列表刷新右下角轮播（回复提交后也可调用）。
+ * @param {HTMLElement} slide slide
+ * @param {object[]} replies 回复
+ * @returns {void}
+ */
+export function syncVideoCommentTicker(slide, replies) {
+	slideRepliesCache.set(slide, replies)
+	renderCommentTicker(slide, replies)
+}
+
+/**
+ * @param {HTMLElement} panel 回复面板
+ * @param {string} replyId 回复帖 id
+ * @returns {void}
+ */
+function focusReplyInPanel(panel, replyId) {
+	if (!replyId) return
+	for (const el of panel.querySelectorAll('.reply.is-focused'))
+		el.classList.remove('is-focused')
+	const row = panel.querySelector(`[data-reply-id="${CSS.escape(replyId)}"]`)
+	if (!(row instanceof HTMLElement)) return
+	row.classList.add('is-focused')
+	row.scrollIntoView({ block: 'center', behavior: 'smooth' })
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {object[]} replies 回复
+ * @returns {void}
+ */
+function renderCommentTicker(slide, replies) {
+	const ticker = slide.querySelector('[data-comment-ticker]')
+	if (!ticker) return
+	const items = replies
+		.map(reply => {
+			const text = String(reply.post?.content?.text || '').trim()
+			if (!text) return null
+			const id = String(reply.post?.id || '')
+			if (!id) return null
+			return { id, author: authorLabel(reply.entityHash, reply.authorProfile), text, entityHash: reply.entityHash, authorProfile: reply.authorProfile }
+		})
+		.filter(Boolean)
+	if (!items.length) {
+		ticker.replaceChildren()
+		ticker.classList.add('hidden')
+		ticker.setAttribute('aria-hidden', 'true')
+		return
+	}
+	ticker.classList.remove('hidden')
+	ticker.setAttribute('aria-hidden', 'false')
+	const track = document.createElement('div')
+	track.className = 'video-comment-ticker-track'
+	// 多复制一份以便无缝滚动
+	const loop = items.length > 1 ? [...items, ...items] : items
+	for (const item of loop) {
+		const row = document.createElement('div')
+		row.className = 'video-comment-ticker-item'
+		row.dataset.replyId = item.id
+		row.setAttribute('role', 'button')
+		row.tabIndex = 0
+		row.innerHTML = `${renderAvatarHtml(item.entityHash, item.authorProfile, 'video-ticker-avatar')}<strong>${escapeHtml(item.author)}</strong><span>${escapeHtml(item.text.slice(0, 80))}</span>`
+		track.appendChild(row)
+	}
+	ticker.replaceChildren(track)
+	track.classList.toggle('is-scrolling', items.length > 1)
+	if (items.length > 1)
+		track.style.setProperty('--ticker-duration', `${Math.max(8, items.length * 3.2)}s`)
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {Promise<object[]>} 回复列表
+ */
+async function loadSlideReplies(slide) {
+	const cached = slideRepliesCache.get(slide)
+	if (cached) return cached
+	const { entityHash, postId } = slide.dataset
+	if (!entityHash || !postId) return []
+	const data = await socialApi(`/profile/${entityHash}/replies/${postId}`).catch(() => ({ replies: [] }))
+	const replies = data.replies || []
+	slideRepliesCache.set(slide, replies)
+	return replies
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @returns {Promise<void>}
+ */
+async function ensureCommentTicker(slide) {
+	if (slide.dataset.tickerLoaded) return
+	slide.dataset.tickerLoaded = '1'
+	const replies = await loadSlideReplies(slide)
+	renderCommentTicker(slide, replies)
+}
+
+/**
+ * @param {HTMLElement} slide slide
+ * @param {boolean} open 是否打开
+ * @param {{ focusReplyId?: string }} [options] 打开选项
+ * @returns {Promise<void>}
+ */
+async function setVideoRepliesOpen(slide, open, options = {}) {
+	const panel = slide.querySelector('[data-replies-panel]')
+	const ticker = slide.querySelector('[data-comment-ticker]')
+	if (!panel) return
+	if (!open) {
+		closeVideoReplies(slide)
+		return
+	}
+	panel.classList.remove('hidden')
+	ticker?.classList.add('is-dimmed')
+	if (!panel.dataset.loaded) {
+		const replies = await loadSlideReplies(slide)
+		panel.dataset.loaded = '1'
+		await renderRepliesPanel(panel, replies)
+		renderCommentTicker(slide, replies)
+	}
+	if (options.focusReplyId) focusReplyInPanel(panel, options.focusReplyId)
+}
+
+/**
+ * @param {object} item feed 条目
+ * @returns {HTMLElement} slide 元素
+ */
+function buildVideoSlide(item) {
+	const slide = document.createElement('div')
+	slide.className = 'video-slide'
+	slide.dataset.entityHash = item.entityHash || ''
+	slide.dataset.postId = item.postId || ''
+
+	const videoSrc = resolveVideoSrc(item)
+	const label = authorLabel(item.entityHash, item.authorProfile)
+	const handle = entityHandle(item.entityHash, item.authorProfile)
+	const caption = String(item.post?.content?.text || item.text || '').trim()
+	const profileHref = formatSocialProfileHref(item.entityHash)
+	const liked = Boolean(item.viewerLiked)
+	const likeCount = item.likeCount || 0
+	const replyCount = item.replyCount || 0
+	const actionKey = formatActionKey(item.entityHash || '', item.postId || '')
+
+	slide.innerHTML = videoSrc
+		? `<video class="video-player" src="${escapeHtml(videoSrc)}" loop playsinline preload="metadata"></video>`
+		: `<div class="video-media-fallback">
+			<span class="icon icon-video" aria-hidden="true"></span>
+			<p data-i18n="social.video.unavailable"></p>
+		</div>`
+
+	slide.insertAdjacentHTML('beforeend', `
+		<div class="video-pause-hint" aria-hidden="true">
+			<span class="icon icon-play"></span>
+		</div>
+		<div class="video-overlay">
+			<div class="video-info">
+				<a class="video-author-row" href="${escapeHtml(profileHref)}" data-video-author>
+					${renderAvatarHtml(item.entityHash, item.authorProfile, 'video-author-avatar')}
+					<span class="video-author">${escapeHtml(label)}</span>
+					<span class="video-author-handle">${escapeHtml(handle)}</span>
+				</a>
+				${caption ? `<div class="video-caption">${escapeHtml(caption.slice(0, 180))}</div>` : ''}
+			</div>
+			<div class="video-comment-ticker hidden" data-comment-ticker aria-hidden="true"></div>
+			<div class="video-actions">
+				<button type="button" class="video-action-btn video-like-btn${liked ? ' is-active' : ''}" data-action="like" aria-label="${escapeHtml(geti18n('social.actions.like'))}">
+					<span class="icon icon-like" aria-hidden="true"></span>
+					<span class="video-like-count">${likeCount}</span>
+				</button>
+				<button type="button" class="video-action-btn video-comment-btn" data-action="comment" data-replies="${escapeHtml(actionKey)}" aria-label="${escapeHtml(geti18n('social.actions.replies'))}">
+					<span class="icon icon-reply" aria-hidden="true"></span>
+					<span class="action-count">${replyCount}</span>
+				</button>
+				<button type="button" class="video-action-btn video-share-btn" data-action="share" data-share="${escapeHtml(actionKey)}" aria-label="${escapeHtml(geti18n('social.actions.share'))}">
+					<span class="icon icon-share" aria-hidden="true"></span>
+					<span class="action-count" data-i18n="social.actions.share"></span>
+				</button>
+				<button type="button" class="video-action-btn video-mute-btn" data-action="mute" data-i18n="social.video.mute">
+					<span class="icon icon-volume" aria-hidden="true"></span>
+				</button>
+			</div>
+		</div>
+		<div class="heart-anim hidden" aria-hidden="true"></div>
+		<div class="video-progress-bar"><div class="video-progress-fill"></div></div>
+		<div class="video-replies-panel hidden" data-replies-panel data-replies-for="${escapeHtml(actionKey)}"></div>
+	`)
+
+	const video = slide.querySelector('video')
+	if (video) {
+		video.muted = readVideoMutedPref()
+		syncMuteButton(slide, video)
+	}
+
+	video?.addEventListener('timeupdate', () => {
+		const fill = slide.querySelector('.video-progress-fill')
+		if (fill && video.duration)
+			fill.style.width = `${(video.currentTime / video.duration) * 100}%`
+	})
+	video?.addEventListener('play', () => setPauseHint(slide, false))
+	video?.addEventListener('pause', () => setPauseHint(slide, true))
+
+	slide.querySelector('[data-video-author]')?.addEventListener('click', event => {
+		event.stopPropagation()
+	})
+
+	/**
+	 * @param {EventTarget | null} target 事件目标
+	 * @returns {boolean} 是否应忽略手势
+	 */
+	const isUiChrome = target => target instanceof Element && Boolean(
+		target.closest('.video-actions')
+		|| target.closest('.video-replies-panel')
+		|| target.closest('[data-comment-ticker]')
+		|| target.closest('[data-video-author]'),
+	)
+
+	let lastTap = 0
+	slide.addEventListener('pointerup', async event => {
+		if (isUiChrome(event.target)) return
+		const panel = slide.querySelector('[data-replies-panel]')
+		if (panel && !panel.classList.contains('hidden')) {
+			closeVideoReplies(slide)
+			return
+		}
+		const now = Date.now()
+		if (now - lastTap < 350) {
+			lastTap = 0
+			await doVideoLike(slide)
+			showHeartAnim(slide)
+		}
+		else {
+			lastTap = now
+			setTimeout(() => {
+				if (lastTap !== now) return
+				if (!video) return
+				if (video.paused) video.play().catch(() => {})
+				else video.pause()
+			}, 360)
+		}
+	})
+
+	let pressTimer = null
+	let pressStartX = 0
+	let seekBaseTime = 0
+	let speedMode = false
+
+	slide.addEventListener('pointerdown', event => {
+		if (isUiChrome(event.target)) return
+		pressStartX = event.clientX
+		pressTimer = setTimeout(() => {
+			pressTimer = null
+			speedMode = true
+			if (video) {
+				video.playbackRate = 2
+				seekBaseTime = video.currentTime
+			}
+		}, 500)
+	})
+
+	slide.addEventListener('pointermove', event => {
+		if (!speedMode || !video) return
+		const dx = event.clientX - pressStartX
+		video.currentTime = Math.max(0, Math.min(video.duration || 0, seekBaseTime + dx / 8))
+	})
+
+	/**
+	 *
+	 */
+	const endPress = () => {
+		if (pressTimer) { clearTimeout(pressTimer); pressTimer = null }
+		if (speedMode) {
+			speedMode = false
+			if (video) video.playbackRate = 1
+		}
+	}
+	slide.addEventListener('pointerup', endPress)
+	slide.addEventListener('pointercancel', endPress)
+
+	let dwellStart = null
+	video?.addEventListener('play', () => { dwellStart = Date.now() })
+	video?.addEventListener('pause', () => {
+		if (!dwellStart || !slide.dataset.postId) return
+		const watchMs = Date.now() - dwellStart
+		void socialApi('/signals/dwell', {
+			method: 'POST',
+			body: JSON.stringify({
+				entityHash: slide.dataset.entityHash,
+				postId: slide.dataset.postId,
+				watchMs,
+				watchRatio: video.duration ? watchMs / (video.duration * 1000) : 0,
+			}),
+		}).catch(() => {})
+		dwellStart = null
+	})
+
+	slide.querySelector('.video-like-btn')?.addEventListener('click', async event => {
+		event.stopPropagation()
+		await doVideoLike(slide)
+	})
+
+	slide.querySelector('.video-mute-btn')?.addEventListener('click', event => {
+		event.stopPropagation()
+		if (!video) return
+		applyMutedToAllVideos(!video.muted)
+	})
+
+	slide.querySelector('.video-share-btn')?.addEventListener('click', async event => {
+		event.stopPropagation()
+		const { entityHash, postId } = slide.dataset
+		if (!entityHash || !postId) return
+		const result = await shareOrCopyPostLink(entityHash, postId, caption || label)
+		if (result !== 'copied') return
+		const labelEl = slide.querySelector('.video-share-btn .action-count')
+		flashCopiedLabel(labelEl, labelEl instanceof HTMLElement ? labelEl.dataset.i18n : undefined)
+	})
+
+	slide.querySelector('.video-comment-btn')?.addEventListener('click', async event => {
+		event.stopPropagation()
+		const panel = slide.querySelector('[data-replies-panel]')
+		if (!panel) return
+		const opening = panel.classList.contains('hidden')
+		await setVideoRepliesOpen(slide, opening)
+	})
+
+	/**
+	 * @param {Event} event 点击 / 键盘事件
+	 * @returns {void}
+	 */
+	const openTickerReply = event => {
+		const item = event.target instanceof Element
+			? event.target.closest('.video-comment-ticker-item')
+			: null
+		if (!item?.dataset.replyId) return
+		event.preventDefault()
+		event.stopPropagation()
+		void setVideoRepliesOpen(slide, true, { focusReplyId: item.dataset.replyId })
+	}
+	const ticker = slide.querySelector('[data-comment-ticker]')
+	ticker?.addEventListener('click', openTickerReply)
+	ticker?.addEventListener('keydown', event => {
+		if (event.key !== 'Enter' && event.key !== ' ') return
+		openTickerReply(event)
+	})
+
+	return slide
+}
+
+/**
+ * @param {HTMLElement} slide slide 元素
+ * @returns {Promise<void>}
+ */
+async function doVideoLike(slide) {
+	const { entityHash, postId } = slide.dataset
+	if (!entityHash || !postId) return
+	const btn = slide.querySelector('.video-like-btn')
+	if (btn?.classList.contains('is-active')) return
+	await runWrite('like', () =>
+		socialApi(`/posts/${entityHash}/${postId}/like`, { method: 'POST' }),
+	)
+	btn?.classList.add('is-active')
+	const countEl = slide.querySelector('.video-like-count')
+	if (countEl) countEl.textContent = String(Number(countEl.textContent) + 1)
+}
+
+/**
+ * 飘心动画。
+ * @param {HTMLElement} slide slide 元素
+ * @returns {void}
+ */
+function showHeartAnim(slide) {
+	playHeartAnim(slide, { emoji: '👍', durationMs: 800 })
+}
+
+/**
+ * 视频视图键盘导航处理器（绑定到 #videosView）。
+ * @param {KeyboardEvent} event 键盘事件
+ * @returns {void}
+ */
+export function handleVideoKeydown(event) {
+	const container = document.getElementById('videoSnapContainer')
+	if (!container) return
+	const currentSlide = container.children[currentVideoIndex]
+	const video = currentSlide?.querySelector('video')
+
+	switch (event.key) {
+		case 'ArrowUp':
+			event.preventDefault()
+			container.children[currentVideoIndex - 1]?.scrollIntoView({ behavior: 'smooth' })
+			break
+		case 'ArrowDown':
+			event.preventDefault()
+			container.children[currentVideoIndex + 1]?.scrollIntoView({ behavior: 'smooth' })
+			void videoFeed.maybeLoadMore(container, currentVideoIndex + 1)
+			break
+		case ' ':
+			event.preventDefault()
+			if (video?.paused) video.play().catch(() => {})
+			else video?.pause()
+			break
+		case 'ArrowLeft':
+			if (video) video.currentTime = Math.max(0, video.currentTime - 5)
+			break
+		case 'ArrowRight':
+			if (video) video.currentTime = Math.min(video.duration || 0, video.currentTime + 5)
+			break
+		case 'l': case 'L':
+			if (currentSlide) void doVideoLike(currentSlide)
+			break
+		case 'm': case 'M':
+			if (video) applyMutedToAllVideos(!video.muted)
+			break
+		case 'c': case 'C': {
+			const btn = currentSlide?.querySelector('.video-comment-btn')
+			btn?.click()
+			break
+		}
+		case 'Escape':
+			if (currentSlide) closeVideoReplies(currentSlide)
+			break
+	}
+}

--- a/src/public/parts/shells/social/public/src/visibilityPicker.mjs
+++ b/src/public/parts/shells/social/public/src/visibilityPicker.mjs
@@ -1,0 +1,149 @@
+import { geti18n } from '/scripts/i18n/index.mjs'
+import { escapeHtml } from '/scripts/lib/escapeHtml.mjs'
+
+/** UI 档位选项 */
+const VISIBILITY_OPTIONS = [
+	{ value: 'public', i18n: 'social.visibility.public' },
+	{ value: 'unlisted', i18n: 'social.visibility.unlisted' },
+	{ value: 'followers', i18n: 'social.visibility.followers' },
+	{ value: 'followers_7d', i18n: 'social.visibility.followers7d' },
+	{ value: 'followers_30d', i18n: 'social.visibility.followers30d' },
+	{ value: 'selected', i18n: 'social.visibility.selected' },
+	{ value: 'private', i18n: 'social.visibility.private' },
+]
+
+/**
+ * 可见性档位图标与 i18n 键。
+ * @param {string} [visibility] 档位
+ * @param {number} [minFollowMs] 关注时长
+ * @returns {{ code: string, icon: string, labelKey: string }} 展示信息
+ */
+export function visibilityDisplay(visibility, minFollowMs = 0) {
+	let code = visibility || 'public'
+	if (code === 'followers_since') {
+		const day = 24 * 60 * 60 * 1000
+		code = minFollowMs >= 30 * day ? 'followers_30d' : 'followers_7d'
+	}
+	const map = {
+		public: { icon: 'globe', labelKey: 'social.visibility.public' },
+		unlisted: { icon: 'unlisted', labelKey: 'social.visibility.unlisted' },
+		followers: { icon: 'lock', labelKey: 'social.visibility.followers' },
+		followers_7d: { icon: 'lock', labelKey: 'social.visibility.followers7d' },
+		followers_30d: { icon: 'lock', labelKey: 'social.visibility.followers30d' },
+		selected: { icon: 'selected', labelKey: 'social.visibility.selected' },
+		private: { icon: 'private', labelKey: 'social.visibility.private' },
+	}
+	const row = map[code] || map.public
+	return { code, ...row }
+}
+
+/**
+ * 从 picker DOM 读取可见性 draft。
+ * @param {HTMLElement | Document} root 根节点
+ * @returns {object} visibility draft
+ */
+export function readVisibilityPicker(root = document) {
+	const select = root.querySelector('[data-visibility-select]')
+	const visibility = select instanceof HTMLSelectElement ? select.value : 'public'
+	/** @type {object} */
+	const draft = { visibility }
+	if (visibility === 'selected') {
+		const allowInput = root.querySelector('[data-visibility-allow]')
+		const raw = allowInput instanceof HTMLInputElement ? allowInput.value : ''
+		draft.allow = raw.split(/[\s,]+/u).map(s => s.trim().toLowerCase()).filter(Boolean)
+	}
+	const exceptInput = root.querySelector('[data-visibility-except]')
+	if (exceptInput instanceof HTMLInputElement && exceptInput.value.trim())
+		draft.except = exceptInput.value.split(/[\s,]+/u).map(s => s.trim().toLowerCase()).filter(Boolean)
+	return draft
+}
+
+/**
+ * 渲染可见性 picker HTML。
+ * @param {object} [options] 选项
+ * @param {string} [options.selected='public'] 当前值（含 UI 预设）
+ * @param {string} [options.allow=''] allow 列表文本
+ * @param {string} [options.except=''] except 列表文本
+ * @param {string} [options.idPrefix=''] id 前缀
+ * @returns {string} HTML
+ */
+export function renderVisibilityPickerHtml(options = {}) {
+	const selected = options.selected || 'public'
+	const idPrefix = options.idPrefix || ''
+	const optionHtml = VISIBILITY_OPTIONS.map(opt =>
+		`<option value="${opt.value}"${opt.value === selected ? ' selected' : ''}>${escapeHtml(geti18n(opt.i18n))}</option>`,
+	).join('')
+	const showAllow = selected === 'selected' ? '' : ' hidden'
+	const showExcept = ['public', 'unlisted', 'followers', 'followers_7d', 'followers_30d'].includes(selected) ? '' : ' hidden'
+	return `
+		<div class="visibility-picker" data-visibility-picker>
+			<select data-visibility-select id="${escapeHtml(idPrefix)}Visibility" class="select select-bordered select-sm composer-select composer-visibility">
+				${optionHtml}
+			</select>
+			<input data-visibility-allow type="text" class="input input-bordered input-sm visibility-allow${showAllow}"
+				placeholder="${escapeHtml(geti18n('social.visibility.allow.placeholder'))}"
+				value="${escapeHtml(options.allow || '')}" />
+			<input data-visibility-except type="text" class="input input-bordered input-sm visibility-except${showExcept}"
+				placeholder="${escapeHtml(geti18n('social.visibility.except.placeholder'))}"
+				value="${escapeHtml(options.except || '')}" />
+		</div>
+	`
+}
+
+/**
+ * 绑定 picker 交互（选 selected 时显示 allow 等）。
+ * @param {HTMLElement} root picker 根或祖先
+ * @returns {void}
+ */
+export function bindVisibilityPicker(root) {
+	const picker = root.querySelector('[data-visibility-picker]') || root
+	const select = picker.querySelector('[data-visibility-select]')
+	if (!(select instanceof HTMLSelectElement)) return
+	/**
+	 * 输入框可能被 [data-visibility-field] 标签包裹（composer 高级面板），此时按整行显隐。
+	 * @param {HTMLElement | null} el 输入节点
+	 * @returns {HTMLElement | null} 字段容器或原节点
+	 */
+	const fieldOf = el => el?.closest('[data-visibility-field]') || el
+	/**
+	 * 按当前可见性档位同步 allow / except 显隐。
+	 * @returns {void}
+	 */
+	const sync = () => {
+		const value = select.value
+		const allow = picker.querySelector('[data-visibility-allow]')
+		const except = picker.querySelector('[data-visibility-except]')
+		if (allow instanceof HTMLElement)
+			fieldOf(allow).classList.toggle('hidden', value !== 'selected')
+		if (except instanceof HTMLElement)
+			fieldOf(except).classList.toggle('hidden', !['public', 'unlisted', 'followers', 'followers_7d', 'followers_30d'].includes(value))
+	}
+	select.addEventListener('change', sync)
+	sync()
+}
+
+/**
+ * 将可见性草稿写回 picker DOM。
+ * @param {HTMLElement | Document} root 根节点
+ * @param {object} [draft] 可见性字段
+ * @returns {void}
+ */
+export function applyVisibilityPicker(root = document, draft = {}) {
+	const select = root.querySelector('[data-visibility-select]')
+	if (!(select instanceof HTMLSelectElement)) return
+	let value = String(draft.visibility || 'public')
+	if (value === 'followers_since') {
+		const day = 24 * 60 * 60 * 1000
+		const ms = Number(draft.minFollowMs) || 0
+		value = ms >= 30 * day ? 'followers_30d' : 'followers_7d'
+	}
+	const known = new Set(VISIBILITY_OPTIONS.map(opt => opt.value))
+	select.value = known.has(value) ? value : 'public'
+	const allow = root.querySelector('[data-visibility-allow]')
+	if (allow instanceof HTMLInputElement)
+		allow.value = Array.isArray(draft.allow) ? draft.allow.join(' ') : ''
+	const except = root.querySelector('[data-visibility-except]')
+	if (except instanceof HTMLInputElement)
+		except.value = Array.isArray(draft.except) ? draft.except.join(' ') : ''
+	select.dispatchEvent(new Event('change', { bubbles: true }))
+}

--- a/src/public/parts/shells/social/public/styles.css
+++ b/src/public/parts/shells/social/public/styles.css
@@ -1,0 +1,3756 @@
+:root {
+	color-scheme: light dark;
+	font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+#shell {
+	min-height: 100vh;
+	--bg: var(--color-base-100);
+	--bg-soft: var(--color-base-200);
+	--surface: var(--color-base-200);
+	--surface-hover: var(--color-base-300);
+	--border: color-mix(in srgb, var(--color-base-content) 8%, transparent);
+	--border-strong: color-mix(in srgb, var(--color-base-content) 14%, transparent);
+	--text: var(--color-base-content);
+	--muted: color-mix(in srgb, var(--color-base-content) 55%, transparent);
+	--accent: var(--color-primary);
+	--accent-hover: color-mix(in srgb, var(--color-primary) 85%, var(--color-base-content));
+	--like: var(--color-error);
+	--repost: var(--color-success);
+	--reply: var(--color-primary);
+	--radius: 1rem;
+	--radius-sm: 999px;
+	--side-width: 275px;
+	--aside-width: 350px;
+	--timeline-width: 600px;
+	--nav-item-h: 52px;
+	--transition: 140ms ease;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+body {
+	margin: 0;
+	background: var(--color-base-100);
+	color: var(--color-base-content);
+	min-height: 100vh;
+}
+
+.hidden {
+	display: none !important;
+}
+
+/* Icon system (Iconify SVG via mask) */
+.icon {
+	display: inline-block;
+	width: 1.35rem;
+	height: 1.35rem;
+	background: currentColor;
+	mask-image: var(--icon);
+	-webkit-mask-image: var(--icon);
+	mask-size: contain;
+	mask-repeat: no-repeat;
+	mask-position: center;
+	-webkit-mask-size: contain;
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+	flex-shrink: 0;
+}
+
+.icon-home { --icon: url("https://api.iconify.design/mdi/home-outline.svg"); }
+.icon-explore { --icon: url("https://api.iconify.design/mdi/compass-outline.svg"); }
+.icon-bell { --icon: url("https://api.iconify.design/mdi/bell-outline.svg"); }
+.icon-bookmark { --icon: url("https://api.iconify.design/mdi/bookmark-outline.svg"); }
+.icon-bookmark-off { --icon: url("https://api.iconify.design/mdi/bookmark-remove-outline.svg"); }
+.icon-draft { --icon: url("https://api.iconify.design/mdi/file-document-edit-outline.svg"); }
+.icon-folder { --icon: url("https://api.iconify.design/mdi/folder-outline.svg"); }
+.icon-folder-plus { --icon: url("https://api.iconify.design/mdi/folder-plus-outline.svg"); }
+.icon-user { --icon: url("https://api.iconify.design/mdi/account-outline.svg"); }
+.icon-compose { --icon: url("https://api.iconify.design/mdi/feather.svg"); }
+.icon-emoji { --icon: url("https://api.iconify.design/mdi/emoticon-outline.svg"); }
+.icon-media { --icon: url("https://api.iconify.design/mdi/image-outline.svg"); }
+.icon-search { --icon: url("https://api.iconify.design/mdi/magnify.svg"); }
+.icon-refresh { --icon: url("https://api.iconify.design/mdi/refresh.svg"); }
+.icon-reply { --icon: url("https://api.iconify.design/mdi/message-outline.svg"); }
+.icon-repost { --icon: url("https://api.iconify.design/mdi/repeat.svg"); }
+.icon-like { --icon: url("https://api.iconify.design/mdi/thumb-up-outline.svg"); }
+.icon-dislike { --icon: url("https://api.iconify.design/mdi/thumb-down-outline.svg"); }
+.icon-settings { --icon: url("https://api.iconify.design/mdi/cog-outline.svg"); }
+.icon-share { --icon: url("https://api.iconify.design/mdi/share-outline.svg"); }
+.icon-more { --icon: url("https://api.iconify.design/mdi/dots-horizontal.svg"); }
+.icon-quote { --icon: url("https://api.iconify.design/mdi/format-quote-close.svg"); }
+.icon-link { --icon: url("https://api.iconify.design/mdi/link-variant.svg"); }
+.icon-download { --icon: url("https://api.iconify.design/mdi/download-outline.svg"); }
+.icon-translate { --icon: url("https://api.iconify.design/mdi/translate.svg"); }
+.icon-note { --icon: url("https://api.iconify.design/mdi/note-text-outline.svg"); }
+.icon-history { --icon: url("https://api.iconify.design/mdi/history.svg"); }
+.icon-direct-message { --icon: url("https://api.iconify.design/mdi/email-outline.svg"); }
+.icon-block { --icon: url("https://api.iconify.design/mdi/block-helper.svg"); }
+.icon-hide { --icon: url("https://api.iconify.design/mdi/eye-off-outline.svg"); }
+.icon-delete { --icon: url("https://api.iconify.design/mdi/delete-outline.svg"); }
+.icon-notification-reply { --icon: url("https://api.iconify.design/mdi/message-reply-outline.svg"); }
+.icon-notification-mention { --icon: url("https://api.iconify.design/mdi/at.svg"); }
+.icon-notification-like { --icon: url("https://api.iconify.design/mdi/heart.svg"); }
+.icon-notification-follow { --icon: url("https://api.iconify.design/mdi/account-plus-outline.svg"); }
+.icon-notification-repost { --icon: url("https://api.iconify.design/mdi/repeat.svg"); }
+.icon-vote { --icon: url("https://api.iconify.design/mdi/poll.svg"); }
+.icon-edit { --icon: url("https://api.iconify.design/mdi/pencil-outline.svg"); }
+.icon-mute { --icon: url("https://api.iconify.design/mdi/volume-off.svg"); }
+.icon-volume { --icon: url("https://api.iconify.design/mdi/volume-high.svg"); }
+.icon-play { --icon: url("https://api.iconify.design/mdi/play.svg"); }
+.icon-content-warning { --icon: url("https://api.iconify.design/mdi/alert-outline.svg"); }
+.icon-options { --icon: url("https://api.iconify.design/mdi/tune-variant.svg"); }
+.icon-close { --icon: url("https://api.iconify.design/mdi/close.svg"); }
+.icon-video { --icon: url("https://api.iconify.design/mdi/play-circle-outline.svg"); }
+.icon-live { --icon: url("https://api.iconify.design/mdi/broadcast.svg"); }
+.icon-globe { --icon: url("https://api.iconify.design/mdi/earth.svg"); }
+.icon-unlisted { --icon: url("https://api.iconify.design/mdi/link-variant.svg"); }
+.icon-lock { --icon: url("https://api.iconify.design/mdi/lock-outline.svg"); }
+.icon-selected { --icon: url("https://api.iconify.design/mdi/account-multiple-outline.svg"); }
+.icon-private { --icon: url("https://api.iconify.design/mdi/eye-off-outline.svg"); }
+
+/* Social shell layout */
+.shell {
+	display: grid;
+	grid-template-columns: var(--side-width) minmax(0, var(--timeline-width)) var(--aside-width);
+	justify-content: center;
+	gap: 0 1.5rem;
+	padding: 0 1rem;
+	max-width: 1280px;
+	margin: 0 auto;
+}
+
+.side-nav {
+	position: sticky;
+	top: 0;
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+	padding: 0.5rem 0.75rem 1rem;
+}
+
+.side-nav-brand {
+	padding: 0.75rem 1rem 1.25rem;
+}
+
+.brand-title {
+	margin: 0;
+	font-size: 1.65rem;
+	font-weight: 800;
+	letter-spacing: -0.02em;
+}
+
+.side-nav-links {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+	flex: 1;
+}
+
+.nav-btn {
+	display: flex;
+	align-items: center;
+	gap: 1.25rem;
+	width: 100%;
+	min-height: var(--nav-item-h);
+	padding: 0 1.15rem;
+	border: none;
+	border-radius: var(--radius-sm);
+	background: transparent;
+	color: var(--text);
+	font: inherit;
+	font-size: 1.25rem;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background var(--transition);
+	text-decoration: none;
+	position: relative;
+}
+
+.nav-btn:hover {
+	background: var(--surface-hover);
+}
+
+.nav-btn.active {
+	font-weight: 700;
+}
+
+.nav-btn.active .icon {
+	font-weight: 700;
+}
+
+.nav-badge {
+	position: absolute;
+	top: 0.35rem;
+	left: 1.85rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 1.1rem;
+	height: 1.1rem;
+	padding: 0 0.25rem;
+	border-radius: 999px;
+	background: var(--accent);
+	color: white;
+	font-size: 0.65rem;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.compose-nav-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	min-height: 52px;
+	margin-top: 1rem;
+	padding: 0 1.5rem;
+	font: inherit;
+	font-size: 1.05rem;
+	font-weight: 700;
+}
+
+.compose-nav-btn:hover {
+	opacity: 0.92;
+}
+
+.compose-nav-icon {
+	display: none;
+}
+
+.timeline-col {
+	min-width: 0;
+	border-left: 1px solid var(--border);
+	border-right: 1px solid var(--border);
+	min-height: 100vh;
+	padding-bottom: 4rem;
+}
+
+.aside-col {
+	position: sticky;
+	top: 0;
+	height: 100vh;
+	overflow-y: auto;
+	padding: 0.75rem 0 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.mobile-tabbar {
+	display: none;
+}
+
+/* Cards & surfaces */
+.card {
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+}
+
+.hint {
+	font-size: 0.82rem;
+	color: var(--muted);
+	margin: 0;
+}
+
+.section-title {
+	font-size: 1.1rem;
+	font-weight: 800;
+	margin: 0 0 0.75rem;
+}
+
+.empty {
+	color: var(--muted);
+	text-align: center;
+	padding: 3rem 1.5rem;
+	font-size: 0.95rem;
+}
+
+.empty-state--plain {
+	padding: 3rem 1.5rem;
+}
+
+.empty-state--plain .empty-state-title {
+	font-weight: 400;
+	color: var(--muted);
+	font-size: 0.95rem;
+}
+
+.empty-state--hint {
+	padding: 0.75rem 0;
+	gap: 0;
+}
+
+.empty-state--hint .empty-state-title {
+	font-weight: 400;
+	color: var(--muted);
+	font-size: 0.9rem;
+}
+
+.link-btn {
+	background: transparent;
+	border: none;
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	text-decoration: none;
+	padding: 0;
+}
+
+.link-btn:hover {
+	text-decoration: underline;
+}
+
+/* View headers */
+.view-header {
+	position: sticky;
+	top: 0;
+	z-index: 3;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	padding: 0 1rem;
+	min-height: 53px;
+	background: color-mix(in srgb, var(--color-base-100) 65%, transparent);
+	backdrop-filter: blur(12px);
+	border-bottom: 1px solid var(--border);
+}
+
+.view-title {
+	margin: 0;
+	font-size: 1.25rem;
+	font-weight: 800;
+}
+
+.view-header-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--accent);
+	cursor: pointer;
+	transition: background var(--transition);
+}
+
+.view-header-btn:hover {
+	background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.view-header-text-btn {
+	border: none;
+	background: transparent;
+	color: var(--accent);
+	font: inherit;
+	font-size: 0.85rem;
+	font-weight: 600;
+	cursor: pointer;
+	padding: 0.35rem 0.5rem;
+	border-radius: 999px;
+}
+
+.view-header-text-btn:hover {
+	background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+/* Composer */
+.composer {
+	border-bottom: 1px solid var(--border);
+	padding: 0.85rem 1rem 0.75rem;
+}
+
+.composer-inner {
+	display: flex;
+	gap: 0.75rem;
+	align-items: flex-start;
+}
+
+.composer-avatar-slot .author-avatar {
+	width: 40px;
+	height: 40px;
+}
+
+.composer-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.composer #postText {
+	width: 100%;
+	min-height: 52px;
+	resize: none;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	font: inherit;
+	font-size: 1.25rem;
+	line-height: 1.4;
+	padding: 0.5rem 0;
+	outline: none;
+}
+
+.composer #postText::placeholder {
+	color: var(--muted);
+}
+
+.composer-cw {
+	margin: 0.35rem 0;
+	width: 100%;
+}
+
+/* Collapsible panels below the composer textarea (poll, advanced options) */
+.composer-panel {
+	margin: 0.5rem 0;
+	padding: 0.75rem;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: color-mix(in srgb, var(--color-base-200) 55%, transparent);
+	display: flex;
+	flex-direction: column;
+	gap: 0.6rem;
+}
+
+.poll-composer-options {
+	width: 100%;
+	resize: vertical;
+}
+
+.poll-composer-row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.6rem;
+}
+
+.poll-composer-row .btn {
+	margin-left: auto;
+}
+
+.composer-advanced {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+	gap: 0.6rem 0.9rem;
+}
+
+.composer-advanced-full {
+	grid-column: 1 / -1;
+}
+
+.composer-field {
+	display: flex;
+	flex-direction: column;
+	gap: 0.3rem;
+	min-width: 0;
+}
+
+.composer-field .select,
+.composer-field .input {
+	width: 100%;
+}
+
+.composer-field-label {
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--muted);
+}
+
+.composer-check {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.85rem;
+	cursor: pointer;
+}
+
+.composer-tool-btn.active {
+	background: color-mix(in srgb, var(--color-primary) 15%, transparent);
+}
+
+.scroll-sentinel {
+	height: 1px;
+	width: 100%;
+	pointer-events: none;
+	overflow-anchor: none;
+}
+
+.composer-toolbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	padding-top: 0.65rem;
+	border-top: 1px solid var(--border);
+}
+
+.composer-tools {
+	display: flex;
+	align-items: center;
+	gap: 0.15rem;
+	flex-wrap: wrap;
+}
+
+.composer-tool-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--accent);
+	cursor: pointer;
+	transition: background var(--transition);
+}
+
+.composer-tool-btn:hover {
+	background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.composer-select {
+	background: var(--bg-soft);
+	border: 1px solid var(--border);
+	color: var(--text);
+	border-radius: 999px;
+	padding: 0.35rem 0.65rem;
+	font: inherit;
+	font-size: 0.8rem;
+	max-width: 10rem;
+}
+
+.composer-post-btn {
+	border: none;
+	border-radius: 999px;
+	background: var(--accent);
+	color: white;
+	font: inherit;
+	font-size: 0.95rem;
+	font-weight: 700;
+	padding: 0.45rem 1.1rem;
+	cursor: pointer;
+	transition: background var(--transition);
+}
+
+.composer-draft-btn {
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--muted);
+	font: inherit;
+	font-size: 0.9rem;
+	font-weight: 600;
+	padding: 0.45rem 0.85rem;
+	cursor: pointer;
+	transition: background var(--transition), color var(--transition);
+}
+
+.composer-draft-btn:hover {
+	background: var(--surface-hover);
+	color: var(--text);
+}
+
+.composer-post-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.composer-post-btn:hover {
+	opacity: 0.92;
+}
+
+/* Aside search & trending */
+.aside-search {
+	padding: 0.65rem 0.85rem;
+}
+
+.feed-search-wrap {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.search-icon {
+	position: absolute;
+	left: 0.85rem;
+	color: var(--muted);
+	width: 1.1rem;
+	height: 1.1rem;
+	pointer-events: none;
+}
+
+.feed-search-input {
+	flex: 1;
+	width: 100%;
+	padding: 0.65rem 2.5rem 0.65rem 2.5rem;
+	border: none;
+	border-radius: 999px;
+	background: var(--bg-soft);
+	color: var(--text);
+	font: inherit;
+	outline: none;
+}
+
+.feed-search-input:focus {
+	box-shadow: 0 0 0 1px var(--accent);
+}
+
+.search-clear-btn {
+	position: absolute;
+	right: 0.5rem;
+	border: none;
+	background: transparent;
+	color: var(--accent);
+	font: inherit;
+	font-size: 0.8rem;
+	cursor: pointer;
+}
+
+.feed-trending {
+	padding: 0.85rem 1rem;
+}
+
+.feed-trending .trending-tags {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+}
+
+.feed-trending .trending-tag {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.65rem 0.35rem;
+	border: none;
+	border-radius: 0;
+	background: transparent;
+	text-decoration: none;
+	color: var(--text);
+	transition: background var(--transition);
+}
+
+.feed-trending .trending-tag:hover {
+	background: var(--surface-hover);
+}
+
+.feed-trending .trending-count {
+	font-size: 0.8rem;
+	color: var(--muted);
+}
+
+.aside-card-title {
+	margin: 0 0 0.65rem;
+	font-size: 1.25rem;
+	font-weight: 800;
+}
+
+.aside-suggested {
+	padding: 0.85rem 1rem;
+}
+
+.aside-suggested-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.suggested-account {
+	display: flex;
+	gap: 0.65rem;
+	align-items: flex-start;
+}
+
+.suggested-account-info {
+	flex: 1;
+	min-width: 0;
+}
+
+.suggested-account-name {
+	display: block;
+	font-weight: 700;
+	font-size: 0.95rem;
+	color: var(--text);
+	text-decoration: none;
+}
+
+.suggested-account-name:hover {
+	text-decoration: underline;
+}
+
+.suggested-account-handle {
+	display: block;
+	font-size: 0.85rem;
+	color: var(--muted);
+}
+
+.suggested-follow-btn {
+	border: 1px solid var(--border-strong);
+	border-radius: 999px;
+	background: var(--text);
+	color: var(--bg);
+	font: inherit;
+	font-size: 0.85rem;
+	font-weight: 700;
+	padding: 0.35rem 0.85rem;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.suggested-follow-btn:hover {
+	opacity: 0.9;
+}
+
+/* Feed list */
+.feed-new-posts-banner {
+	display: block;
+	width: calc(100% - 2rem);
+	margin: 0.75rem 1rem 0;
+}
+
+.feed-list {
+	display: flex;
+	flex-direction: column;
+}
+
+/* Post card */
+.post-card {
+	padding: 0.85rem 1rem;
+	border-bottom: 1px solid var(--border);
+	border-radius: 0;
+	background: transparent;
+	transition: background var(--transition);
+	cursor: pointer;
+}
+
+.post-card :is(a, button, input, textarea, select, summary, .poll, .media-gallery, .live-ref-card, .post-actions, .repost-panel, .replies, .post-more-menu, .body-expand) {
+	cursor: auto;
+}
+
+.post-card :is(a, button, summary, .body-expand) {
+	cursor: pointer;
+}
+
+.post-card:hover {
+	background: color-mix(in srgb, var(--color-base-content) 2%, transparent);
+}
+
+.post-card.card {
+	border: none;
+	margin: 0;
+	box-shadow: none;
+}
+
+.post-header {
+	margin-bottom: 0.35rem;
+}
+
+.post-header-row {
+	display: flex;
+	gap: 0.65rem;
+	align-items: flex-start;
+}
+
+.author-avatar-link {
+	display: block;
+	flex-shrink: 0;
+	border-radius: 999px;
+	line-height: 0;
+	text-decoration: none;
+	color: inherit;
+}
+
+.author-avatar-link:hover {
+	opacity: 0.92;
+}
+
+.author-avatar {
+	width: 40px;
+	height: 40px;
+	border-radius: 999px;
+	object-fit: cover;
+	flex-shrink: 0;
+	background: var(--bg-soft);
+}
+
+.author-avatar.hash-avatar {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: 700;
+	font-size: 0.95rem;
+	line-height: 1;
+	overflow: hidden;
+	position: relative;
+}
+
+.author-avatar.hash-avatar .hash-avatar-img {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.author-avatar.hash-avatar:has(.hash-avatar-img.is-loaded) .hash-avatar-letter {
+	visibility: hidden;
+}
+
+.author-avatar.profile-avatar {
+	width: 80px;
+	height: 80px;
+	border: 4px solid var(--bg);
+	margin-top: -2.5rem;
+}
+
+.post-author {
+	flex: 1;
+	min-width: 0;
+}
+
+.post-author-line {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+}
+
+.author-name {
+	font-weight: 700;
+	font-size: 0.95rem;
+	color: var(--text);
+	text-decoration: none;
+}
+
+.author-name:hover {
+	text-decoration: underline;
+}
+
+.author-handle {
+	font-size: 0.85rem;
+	color: var(--muted);
+	text-decoration: none;
+}
+
+.author-handle:hover {
+	text-decoration: underline;
+}
+
+.post-meta-sep {
+	color: var(--muted);
+	font-size: 0.85rem;
+}
+
+.post-meta {
+	font-size: 0.85rem;
+	color: var(--muted);
+}
+
+.post-card .body {
+	line-height: 1.5;
+	font-size: 0.98rem;
+	word-wrap: break-word;
+}
+
+.post-card .body.body-foldable:not(.body-expanded) {
+	max-height: 17.5rem;
+	overflow: hidden;
+	mask-image: linear-gradient(to bottom, #000 calc(100% - 2.75rem), transparent);
+	-webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 2.75rem), transparent);
+}
+
+.body-expand {
+	display: block;
+	margin: 0.15rem 0 0;
+	padding: 0.2rem 0;
+	border: none;
+	background: transparent;
+	color: var(--accent);
+	font: inherit;
+	font-size: 0.9rem;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.body-expand:hover {
+	text-decoration: underline;
+}
+
+.post-actions {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	max-width: 425px;
+	margin-top: 0.65rem;
+}
+
+.action-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+	border: none;
+	background: transparent;
+	color: var(--muted);
+	font: inherit;
+	font-size: 0.82rem;
+	cursor: pointer;
+	padding: 0.35rem;
+	border-radius: 999px;
+	transition: color var(--transition), background var(--transition);
+	min-width: 2rem;
+}
+
+.action-btn .icon {
+	width: 1.15rem;
+	height: 1.15rem;
+}
+
+.action-btn:hover {
+	background: color-mix(in srgb, var(--color-base-content) 4%, transparent);
+}
+
+.action-btn-reply:hover {
+	color: var(--reply);
+}
+
+.action-btn-repost:hover {
+	color: var(--repost);
+}
+
+.action-btn-like:hover,
+.action-btn-like.liked {
+	color: var(--like);
+}
+
+.action-btn-like.liked .icon-like { --icon: url("https://api.iconify.design/mdi/thumb-up.svg"); }
+
+.action-btn-dislike:hover,
+.action-btn-dislike.disliked {
+	color: var(--muted);
+}
+
+.action-btn-dislike.disliked .icon-dislike { --icon: url("https://api.iconify.design/mdi/thumb-down.svg"); }
+
+.action-btn-save:hover {
+	color: var(--accent);
+}
+
+.action-count {
+	font-size: 0.82rem;
+	font-variant-numeric: tabular-nums;
+}
+
+.post-visibility-icon {
+	width: 0.85rem;
+	height: 0.85rem;
+	color: var(--muted);
+	vertical-align: middle;
+}
+
+.post-more-dropdown {
+	position: relative;
+	margin-left: auto;
+	flex-shrink: 0;
+}
+
+.post-more-menu {
+	position: absolute;
+	right: 0;
+	top: 100%;
+	z-index: 5;
+	min-width: 180px;
+	max-width: calc(100vw - 2rem);
+	padding: 0.35rem 0;
+	border-radius: 12px;
+	background: var(--color-base-100);
+	border: 1px solid var(--border-strong);
+	box-shadow: 0 8px 24px color-mix(in srgb, var(--color-base-content) 25%, transparent);
+}
+
+.post-more-menu button {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+	width: 100%;
+	padding: 0.65rem 1rem;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	font: inherit;
+	font-size: 0.9rem;
+	cursor: pointer;
+	text-align: left;
+}
+
+.post-more-menu button:hover {
+	background: var(--surface-hover);
+}
+
+.post-more-menu .danger-item {
+	color: var(--color-error);
+}
+
+.post-more-menu .danger-item:hover {
+	background: color-mix(in srgb, var(--color-error) 10%, transparent);
+}
+
+/* Markdown & media */
+.markdown-body a[href*="#topic:"],
+.markdown-body a[href*="#search;"] {
+	color: var(--accent);
+	text-decoration: none;
+}
+
+.markdown-body a[href*="#topic:"]:hover,
+.markdown-body a[href*="#search;"]:hover {
+	text-decoration: underline;
+}
+
+.markdown-body :is(pre, code) {
+	font-family: ui-monospace, monospace;
+}
+
+.post-media {
+	position: relative;
+	margin: 0.5rem 0;
+	border-radius: 16px;
+	overflow: hidden;
+	border: 1px solid var(--border);
+	background: var(--bg-soft);
+}
+
+.post-media-track {
+	display: grid;
+	grid-auto-flow: column;
+	grid-auto-columns: 100%;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scrollbar-width: none;
+}
+
+.post-media-track::-webkit-scrollbar {
+	display: none;
+}
+
+.post-media-slide {
+	scroll-snap-align: start;
+	border: 0;
+	padding: 0;
+	margin: 0;
+	background: transparent;
+	display: block;
+	width: 100%;
+	cursor: zoom-in;
+}
+
+.post-media-item {
+	width: 100%;
+	max-height: 510px;
+	object-fit: cover;
+	display: block;
+	background: var(--bg-soft);
+}
+
+.post-media-video {
+	max-height: 510px;
+	cursor: pointer;
+}
+
+.post-media-heart {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	z-index: 5;
+}
+
+.post-media-nav {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	z-index: 2;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 999px;
+	border: 0;
+	background: color-mix(in srgb, black 45%, transparent);
+	color: white;
+	cursor: pointer;
+}
+
+.post-media-prev { left: 0.4rem; }
+.post-media-next { right: 0.4rem; }
+
+.post-media-dots {
+	display: flex;
+	justify-content: center;
+	gap: 0.3rem;
+	padding: 0.35rem 0;
+}
+
+.post-media-dot {
+	width: 0.4rem;
+	height: 0.4rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--text) 35%, transparent);
+}
+
+.post-media-dot.active {
+	background: var(--accent);
+}
+
+.media-lightbox-box {
+	max-width: min(96vw, 960px);
+	width: fit-content;
+	background: #111;
+	color: #fff;
+	position: relative;
+}
+
+.media-lightbox-img {
+	max-width: 90vw;
+	max-height: 75vh;
+	object-fit: contain;
+	display: block;
+	margin: 0 auto;
+}
+
+.media-lightbox-alt {
+	opacity: 0.8;
+	font-size: 0.9rem;
+	margin-top: 0.5rem;
+}
+
+.media-lightbox-nav {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: 0.75rem;
+}
+
+.media-lightbox-close {
+	position: absolute;
+	top: 0.5rem;
+	right: 0.5rem;
+}
+
+.media-chip-alt {
+	width: 100%;
+	margin-top: 0.25rem;
+}
+
+.media-chip-edit {
+	position: absolute;
+	left: 0.25rem;
+	bottom: 2rem;
+	font-size: 0.7rem;
+	padding: 0.1rem 0.35rem;
+	border-radius: 4px;
+	border: 0;
+	background: color-mix(in srgb, black 55%, transparent);
+	color: white;
+	cursor: pointer;
+}
+
+.muted-keywords {
+	padding: 0.75rem 1rem;
+	margin-bottom: 0.75rem;
+}
+
+.muted-keyword-form {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+	margin: 0.5rem 0;
+}
+
+.muted-keyword-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+}
+
+.muted-keyword-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35rem;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 0.15rem 0.55rem;
+	background: var(--bg-soft);
+	cursor: pointer;
+}
+
+.post-media:has(.post-media-item:nth-child(2)) {
+	grid-template-columns: unset;
+}
+
+.media-preview {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin: 0.5rem 0;
+}
+
+.media-chip {
+	position: relative;
+	width: 80px;
+	height: 80px;
+	border-radius: 12px;
+	overflow: hidden;
+	background: var(--bg-soft);
+}
+
+.media-chip.media-chip-editable {
+	width: 10rem;
+	height: auto;
+	overflow: visible;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	padding-bottom: 0.25rem;
+}
+
+.media-chip.media-chip-editable img,
+.media-chip.media-chip-editable video {
+	width: 100%;
+	height: 80px;
+	object-fit: cover;
+	border-radius: 12px;
+}
+
+.media-chip img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.media-chip-remove {
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	width: 22px;
+	height: 22px;
+	border: none;
+	border-radius: 999px;
+	background: rgb(0 0 0 / 70%);
+	color: white;
+	cursor: pointer;
+}
+
+.quote-block,
+.quote-preview,
+.group-ref-preview,
+.group-ref-block,
+.embedded-post,
+.translation-block {
+	border-radius: 12px;
+	border: 1px solid var(--border);
+	background: var(--bg-soft);
+}
+
+.translation-block {
+	margin-top: 0.5rem;
+	padding: 0.65rem 0.85rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+}
+
+.translation-toggle {
+	align-self: flex-start;
+}
+
+.quote-block {
+	margin: 0.5rem 0;
+	padding: 0.65rem 0.85rem;
+	border-left: 3px solid var(--accent);
+}
+
+.repost-banner {
+	font-size: 0.82rem;
+	color: var(--muted);
+	margin-bottom: 0.35rem;
+	display: flex;
+	align-items: center;
+	gap: 0.35rem;
+}
+
+.repost-banner .icon {
+	width: 0.95rem;
+	height: 0.95rem;
+}
+
+.embedded-post {
+	padding: 0.75rem;
+	margin-top: 0.35rem;
+}
+
+.replies,
+.repost-panel {
+	margin-top: 0.75rem;
+	padding-top: 0.75rem;
+	border-top: 1px solid var(--border);
+}
+
+.repost-panel textarea {
+	width: 100%;
+	box-sizing: border-box;
+	margin-bottom: 0.35rem;
+	background: var(--bg-soft);
+	border: 1px solid var(--border);
+	color: inherit;
+	border-radius: 12px;
+	padding: 0.5rem;
+	font: inherit;
+}
+
+.replies-list.is-empty {
+	border: none;
+}
+
+/* Unified empty states */
+.empty-state {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.45rem;
+	text-align: center;
+	color: var(--muted);
+}
+
+.empty-state-icon {
+	opacity: 0.4;
+	margin-bottom: 0.15rem;
+}
+
+.empty-state-title {
+	margin: 0;
+	font-weight: 700;
+	color: var(--text);
+}
+
+.empty-state-hint,
+.empty-state p {
+	margin: 0;
+	line-height: 1.45;
+}
+
+.empty-state--replies {
+	gap: 0.3rem;
+	padding: 1.5rem 1rem;
+}
+
+.empty-state--replies .empty-state-icon {
+	width: 1.85rem;
+	height: 1.85rem;
+}
+
+.empty-state--replies .empty-state-title {
+	font-size: 0.95rem;
+	opacity: 0.82;
+}
+
+.empty-state--replies .empty-state-hint {
+	font-size: 0.84rem;
+}
+
+.empty-state--explore {
+	width: 100%;
+	box-sizing: border-box;
+	gap: 0.55rem;
+	padding: 1.75rem 1.5rem 2rem;
+	font-size: 0.9rem;
+}
+
+.empty-state--explore .empty-state-icon {
+	width: 2rem;
+	height: 2rem;
+	opacity: 0.45;
+}
+
+.empty-state--saved {
+	flex: 1;
+	padding: 4rem 1.5rem;
+}
+
+.empty-state--compact {
+	padding: 2.5rem 1.5rem;
+}
+
+.empty-state--saved .empty-state-icon {
+	width: 2.5rem;
+	height: 2.5rem;
+	margin-bottom: 0.25rem;
+}
+
+.empty-state--saved .empty-state-title {
+	font-size: 1.05rem;
+}
+
+.empty-state--saved .empty-state-hint {
+	font-size: 0.88rem;
+	max-width: 16rem;
+}
+
+.empty-state--video {
+	width: min(22rem, 86vw);
+	padding: 2rem 1.25rem;
+	gap: 0.85rem;
+	color: #fff;
+}
+
+.empty-state--video .empty-state-icon {
+	width: 3.25rem;
+	height: 3.25rem;
+	background: rgba(255, 255, 255, 0.85);
+	opacity: 1;
+}
+
+.empty-state--video .empty-state-title {
+	font-size: 1.2rem;
+	color: #fff;
+}
+
+.empty-state--video .empty-state-hint {
+	color: rgba(255, 255, 255, 0.72);
+	font-size: 0.92rem;
+}
+
+.empty-state-action {
+	margin-top: 0.35rem;
+}
+
+.reply-composer {
+	display: flex;
+	gap: 0.75rem;
+	align-items: flex-start;
+	padding: 0.85rem 0 0.15rem;
+	border-top: 1px solid var(--border);
+}
+
+.replies-list.is-empty + .reply-composer {
+	border-top: none;
+	padding-top: 0.15rem;
+}
+
+.replies-list.is-empty .empty-state--replies {
+	padding-bottom: 0.35rem;
+}
+
+.reply-composer-avatar-slot {
+	flex-shrink: 0;
+	padding-top: 0.2rem;
+}
+
+.reply-composer-avatar,
+.reply-composer-avatar-slot .author-avatar {
+	width: 2.25rem;
+	height: 2.25rem;
+	font-size: 0.8rem;
+}
+
+.reply-composer-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.reply-composer textarea {
+	width: 100%;
+	box-sizing: border-box;
+	display: block;
+	margin: 0;
+	min-height: 2.4rem;
+	max-height: 10rem;
+	resize: none;
+	background: transparent;
+	border: none;
+	color: inherit;
+	font: inherit;
+	font-size: 1rem;
+	line-height: 1.45;
+	padding: 0.35rem 0;
+	outline: none;
+}
+
+.reply-composer textarea::placeholder {
+	color: var(--muted);
+}
+
+.reply-composer-actions {
+	display: flex;
+	justify-content: flex-end;
+	padding-top: 0.55rem;
+	border-top: 1px solid var(--border);
+}
+
+.reply-composer-submit {
+	border: none;
+	border-radius: 999px;
+	background: var(--accent);
+	color: white;
+	font: inherit;
+	font-weight: 700;
+	font-size: 0.9rem;
+	padding: 0.4rem 1.15rem;
+	cursor: pointer;
+	transition: background var(--transition);
+}
+
+.reply-composer-submit:hover {
+	background: var(--accent-hover);
+}
+
+.replies-list .reply {
+	padding: 0.5rem 0.35rem;
+	font-size: 0.9rem;
+	border-bottom: 1px solid var(--border);
+	border-radius: 0.5rem;
+	transition: background 180ms ease;
+}
+
+.replies-list .reply.is-focused {
+	background: color-mix(in srgb, var(--accent) 16%, transparent);
+	outline: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.reply-header {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-bottom: 0.25rem;
+}
+
+.reply-avatar {
+	width: 2rem;
+	height: 2rem;
+	font-size: 0.75rem;
+}
+
+.reply-header-text {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0.35rem;
+	min-width: 0;
+}
+
+.reply .post-actions {
+	margin-top: 0.35rem;
+}
+
+.nested-replies {
+	margin: 0.35rem 0 0 1.5rem;
+	padding-left: 0.5rem;
+	border-left: 2px solid var(--border);
+}
+
+.reply-context {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+	margin: 0.35rem 0 0.5rem;
+	padding: 0.45rem 0.65rem;
+	border-left: 3px solid var(--accent);
+	border-radius: 0.35rem;
+	background: color-mix(in srgb, var(--color-base-200) 80%, transparent);
+	color: inherit;
+	text-decoration: none;
+	font-size: 0.85rem;
+}
+
+.reply-context:hover {
+	background: color-mix(in srgb, var(--color-base-300) 70%, transparent);
+}
+
+.reply-context-label {
+	font-weight: 600;
+	opacity: 0.85;
+}
+
+.reply-context-snippet {
+	opacity: 0.7;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.post-thread {
+	position: relative;
+	margin: 0.25rem 0;
+	padding-left: 0.75rem;
+	border-left: 2px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+
+.post-thread .post-thread-item {
+	position: relative;
+}
+
+.post-thread .post-thread-item + .post-thread-item {
+	border-top: none;
+}
+
+.post-time-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.post-time-link:hover {
+	text-decoration: underline;
+}
+
+.post-detail-header {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.post-detail-card {
+	cursor: default;
+}
+
+.post-detail-replies {
+	padding: 0.75rem 1rem 2rem;
+	border-top: 1px solid var(--border);
+}
+
+.post-detail-replies .reply-composer {
+	padding-top: 0.15rem;
+}
+
+.post-detail-replies .empty-state--replies {
+	padding: 2rem 1rem 1.25rem;
+}
+
+.highlight-post {
+	background: color-mix(in srgb, var(--color-primary) 8%, transparent);
+}
+
+/* Profile */
+.profile-entity-card-host {
+	padding: 0;
+}
+
+.profile-entity-card-host .profile-entity-card {
+	width: 100%;
+	max-width: none;
+	border-radius: 0;
+	box-shadow: none;
+}
+
+.profile-header {
+	padding: 0 1rem 1rem;
+	border-bottom: 1px solid var(--border);
+}
+
+.profile-header-actions {
+	display: flex;
+	justify-content: flex-end;
+	padding: 0.75rem 0;
+	gap: 0.5rem;
+}
+
+.profile-settings-btn {
+	min-width: 2.25rem;
+	padding: 0.4rem;
+}
+
+.profile-settings-btn .icon {
+	width: 1.15rem;
+	height: 1.15rem;
+}
+
+.profile-stats {
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.25rem 0 0.75rem;
+	font-size: 0.95rem;
+	color: var(--muted);
+	flex-wrap: wrap;
+}
+
+.profile-stat {
+	appearance: none;
+	border: 0;
+	background: transparent;
+	padding: 0.35rem 0.55rem;
+	border-radius: 0.5rem;
+	cursor: pointer;
+	color: inherit;
+	font: inherit;
+	line-height: 1.2;
+}
+
+.profile-stat:hover {
+	background: color-mix(in srgb, var(--text, currentColor) 8%, transparent);
+}
+
+.profile-stat strong {
+	color: var(--text);
+	font-weight: 700;
+	margin-right: 0.2rem;
+}
+
+.profile-relationship-dialog {
+	max-width: 28rem;
+}
+
+.profile-relationship-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	max-height: min(60vh, 28rem);
+	overflow: auto;
+	margin-top: 0.75rem;
+}
+
+.profile-handle {
+	font-size: 0.95rem;
+	color: var(--muted);
+}
+
+.profile-stat span {
+	color: var(--muted);
+}
+
+.profile-tabs {
+	display: flex;
+	border-bottom: 1px solid var(--border);
+}
+
+.profile-tab {
+	flex: 1;
+	padding: 1rem 0.5rem;
+	border: none;
+	background: transparent;
+	color: var(--muted);
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+	position: relative;
+	transition: color var(--transition);
+}
+
+.profile-tab:hover {
+	background: color-mix(in srgb, var(--color-base-content) 3%, transparent);
+	color: var(--text);
+}
+
+.profile-tab.active {
+	color: var(--text);
+	font-weight: 700;
+}
+
+.profile-tab.active::after {
+	content: "";
+	position: absolute;
+	bottom: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 56px;
+	height: 4px;
+	border-radius: 999px;
+	background: var(--accent);
+}
+
+.profile-tab-panel.hidden {
+	display: none;
+}
+
+.profile-action-btn {
+	border: 1px solid var(--border-strong);
+	border-radius: 999px;
+	background: transparent;
+	color: var(--text);
+	font: inherit;
+	font-weight: 700;
+	padding: 0.45rem 1rem;
+	cursor: pointer;
+	text-decoration: none;
+	display: inline-flex;
+	align-items: center;
+}
+
+.profile-action-btn.primary {
+	background: var(--text);
+	color: var(--bg);
+	border-color: var(--text);
+}
+
+.profile-action-btn:hover {
+	opacity: 0.92;
+}
+
+.profile-settings-blocklist {
+	margin-top: 0.75rem;
+}
+
+.settings-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding: 0.75rem 1rem 2rem;
+}
+
+.settings-card {
+	padding: 1rem 1.1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.65rem;
+}
+
+.settings-card-title {
+	font-size: 1.05rem;
+	font-weight: 700;
+	margin: 0;
+}
+
+.settings-hint {
+	margin: 0;
+	font-size: 0.85rem;
+	color: var(--muted);
+	line-height: 1.4;
+}
+
+.settings-toggle {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.6rem;
+	font-size: 0.95rem;
+	cursor: pointer;
+}
+
+.settings-toggle input {
+	margin-top: 0.2rem;
+}
+	border-top: 1px solid var(--border);
+	padding-top: 0.75rem;
+	max-height: 40vh;
+	overflow: auto;
+}
+
+.following-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.65rem 1rem;
+	border-bottom: 1px solid var(--border);
+	text-decoration: none;
+	color: var(--text);
+	width: 100%;
+}
+
+.following-link:hover {
+	background: rgb(255 255 255 / 2%);
+}
+
+.blocklist-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid var(--border);
+}
+
+.entity-hash {
+	font-size: 0.75rem;
+	word-break: break-all;
+	color: var(--muted);
+}
+
+/* Notifications */
+.inbox-filter-tabs {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	padding: 0 1rem 0.75rem;
+	border-bottom: 1px solid var(--border);
+}
+
+.inbox-filter-tab.active {
+	background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+	color: var(--color-primary);
+}
+
+.notification-card {
+	display: flex;
+	gap: 0.75rem;
+	padding: 0.85rem 1rem;
+	border-bottom: 1px solid var(--border);
+	background: transparent;
+	border-radius: 0;
+}
+
+.notification-card.unread {
+	background: color-mix(in srgb, var(--color-primary) 4%, transparent);
+}
+
+.notification-icon {
+	color: var(--muted);
+	margin-top: 0.15rem;
+}
+
+.notification-body {
+	flex: 1;
+	min-width: 0;
+}
+
+.notification-avatars.stacked {
+	display: flex;
+	align-items: center;
+}
+
+.notification-avatars.stacked > * {
+	margin-left: -0.35rem;
+	border: 2px solid var(--color-base-100, #fff);
+	border-radius: 9999px;
+}
+
+.notification-avatars.stacked > *:first-child {
+	margin-left: 0;
+}
+
+.notification-type {
+	font-size: 0.95rem;
+	line-height: 1.4;
+}
+
+.notification-snippet {
+	color: var(--muted);
+	font-size: 0.9rem;
+	margin: 0.35rem 0 0;
+}
+
+.notification-view-link {
+	display: inline-block;
+	margin-top: 0.35rem;
+	color: var(--accent);
+	font-size: 0.85rem;
+	text-decoration: none;
+}
+
+.notification-view-link:hover {
+	text-decoration: underline;
+}
+
+/* Explore */
+.explore-media-toggle {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	flex-shrink: 0;
+	font-size: 0.82rem;
+	font-weight: 600;
+	color: var(--muted);
+	cursor: pointer;
+	padding: 0.35rem 0.65rem;
+	border-radius: var(--radius-sm);
+	border: 1px solid var(--border);
+	background: transparent;
+	transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.explore-media-toggle:hover {
+	background: var(--surface-hover);
+	color: var(--text);
+}
+
+.explore-media-toggle:has(input:checked) {
+	background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+	border-color: color-mix(in srgb, var(--color-primary) 35%, transparent);
+	color: var(--color-primary);
+}
+
+.explore-media-toggle input {
+	/* 覆盖整块 label，便于点击与自动化；视觉由 :has(input:checked) 承担 */
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	margin: 0;
+	opacity: 0;
+	cursor: pointer;
+}
+
+.explore-media-toggle .icon {
+	width: 1.05rem;
+	height: 1.05rem;
+}
+
+.explore-shortcuts {
+	display: none;
+	gap: 0.5rem;
+	padding: 0.5rem 1rem 0;
+	flex-wrap: wrap;
+}
+
+.explore-mobile-aside {
+	display: none;
+	margin: 0.75rem 1rem 0;
+}
+
+@media (max-width: 1100px) {
+	.explore-shortcuts {
+		display: flex;
+	}
+
+	.explore-mobile-aside:not(.hidden) {
+		display: block;
+	}
+}
+
+.explore-section {
+	padding: 0.85rem 0 0;
+	border-bottom: 1px solid var(--border);
+}
+
+.explore-section:last-child {
+	border-bottom: none;
+	padding-bottom: 1.25rem;
+}
+
+.explore-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	min-height: 2rem;
+	padding: 0 1rem;
+	margin-bottom: 0.55rem;
+}
+
+.explore-section-header .section-title {
+	margin: 0;
+	font-size: 0.95rem;
+	letter-spacing: 0.01em;
+	color: var(--muted);
+	font-weight: 700;
+}
+
+.explore-account-list {
+	display: flex;
+	gap: 0.65rem;
+	padding: 0 1rem 0.85rem;
+	overflow-x: auto;
+	scrollbar-width: thin;
+	scroll-snap-type: x proximity;
+}
+
+.explore-account-list:has(.empty-state--explore) {
+	display: block;
+	overflow: visible;
+	padding: 0;
+	scroll-snap-type: none;
+}
+
+.explore-account {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 0.55rem;
+	flex: 0 0 11.5rem;
+	scroll-snap-align: start;
+	padding: 0.85rem;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	background: color-mix(in srgb, var(--surface) 55%, transparent);
+	transition: border-color var(--transition), background var(--transition);
+}
+
+.explore-account:hover {
+	border-color: var(--border-strong);
+	background: var(--surface);
+}
+
+.explore-account-avatar-link {
+	align-self: center;
+	text-decoration: none;
+}
+
+.explore-account-avatar {
+	width: 3.25rem;
+	height: 3.25rem;
+	font-size: 1.15rem;
+}
+
+.explore-account-body {
+	min-width: 0;
+	text-align: center;
+}
+
+.explore-account .suggested-account-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.explore-account .suggested-account-handle {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.explore-account-bio {
+	margin: 0.35rem 0 0;
+	font-size: 0.8rem;
+	line-height: 1.35;
+	color: var(--muted);
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.explore-account .suggested-follow-btn {
+	width: 100%;
+	margin-top: auto;
+}
+
+.explore-post-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.explore-post-card {
+	padding: 0.9rem 1rem;
+	border-bottom: 1px solid var(--border);
+	transition: background var(--transition);
+}
+
+.explore-post-card:hover {
+	background: color-mix(in srgb, var(--surface-hover) 55%, transparent);
+}
+
+.explore-post-header {
+	display: flex;
+	align-items: center;
+	gap: 0.65rem;
+	margin-bottom: 0.45rem;
+}
+
+.explore-post-avatar-link {
+	flex-shrink: 0;
+	text-decoration: none;
+}
+
+.explore-post-avatar {
+	width: 2.25rem;
+	height: 2.25rem;
+	font-size: 0.85rem;
+}
+
+.explore-post-author {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0.35rem 0.55rem;
+	min-width: 0;
+}
+
+.explore-post-author .author-name {
+	font-weight: 700;
+	color: var(--text);
+	text-decoration: none;
+}
+
+.explore-post-author .author-name:hover {
+	text-decoration: underline;
+}
+
+.explore-post-body {
+	display: block;
+	color: inherit;
+	text-decoration: none;
+	margin-left: calc(2.25rem + 0.65rem);
+}
+
+.explore-snippet {
+	margin: 0;
+	white-space: pre-wrap;
+	line-height: 1.45;
+	font-size: 0.95rem;
+}
+
+.explore-thumbs {
+	display: grid;
+	gap: 0.25rem;
+	margin-top: 0.55rem;
+	border-radius: 0.75rem;
+	overflow: hidden;
+	max-width: 22rem;
+}
+
+.explore-thumbs[data-count="1"] {
+	grid-template-columns: 1fr;
+}
+
+.explore-thumbs[data-count="2"],
+.explore-thumbs[data-count="4"] {
+	grid-template-columns: 1fr 1fr;
+}
+
+.explore-thumbs[data-count="3"] {
+	grid-template-columns: 1.2fr 1fr;
+	grid-template-rows: 1fr 1fr;
+}
+
+.explore-thumbs[data-count="3"] .explore-thumb:first-child {
+	grid-row: 1 / span 2;
+}
+
+.explore-thumb {
+	aspect-ratio: 1;
+	min-height: 4.5rem;
+	background: var(--bg-soft);
+	overflow: hidden;
+}
+
+.explore-thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.explore-thumb-video {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--muted);
+}
+
+/* Saved */
+.saved-panel {
+	display: flex;
+	flex-direction: column;
+	min-height: calc(100vh - 53px);
+}
+
+.saved-toolbar {
+	padding: 0.75rem 1rem 0.35rem;
+}
+
+.saved-search-wrap {
+	width: 100%;
+}
+
+.saved-search-wrap .feed-search-input {
+	width: 100%;
+}
+
+.saved-folder-tabs {
+	display: flex;
+	gap: 0.4rem;
+	padding: 0.55rem 1rem 0.75rem;
+	overflow-x: auto;
+	scrollbar-width: thin;
+	border-bottom: 1px solid var(--border);
+}
+
+.saved-folder-tab {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	flex: 0 0 auto;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	background: transparent;
+	color: var(--muted);
+	font: inherit;
+	font-size: 0.85rem;
+	font-weight: 600;
+	padding: 0.35rem 0.75rem;
+	cursor: pointer;
+	transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.saved-folder-tab:hover {
+	background: var(--surface-hover);
+	color: var(--text);
+}
+
+.saved-folder-tab.active {
+	background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+	border-color: color-mix(in srgb, var(--color-primary) 35%, transparent);
+	color: var(--color-primary);
+}
+
+.saved-folder-tab-count {
+	min-width: 1.1rem;
+	padding: 0.05rem 0.35rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--color-base-content) 8%, transparent);
+	font-size: 0.72rem;
+	font-weight: 700;
+	line-height: 1.25;
+	text-align: center;
+}
+
+.saved-folder-tab.active .saved-folder-tab-count {
+	background: color-mix(in srgb, var(--color-primary) 18%, transparent);
+}
+
+.saved-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.saved-section + .saved-section {
+	border-top: 1px solid var(--border);
+}
+
+.saved-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	padding: 0.9rem 1rem 0.35rem;
+}
+
+.saved-section-title-wrap {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	min-width: 0;
+}
+
+.saved-section-icon {
+	width: 1.1rem;
+	height: 1.1rem;
+	opacity: 0.55;
+}
+
+.saved-section-title {
+	margin: 0;
+	font-size: 0.92rem;
+	font-weight: 700;
+	color: var(--muted);
+}
+
+.saved-count {
+	min-width: 1.15rem;
+	padding: 0.05rem 0.4rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--color-base-content) 7%, transparent);
+	color: var(--muted);
+	font-size: 0.72rem;
+	font-weight: 700;
+	line-height: 1.3;
+	text-align: center;
+}
+
+.saved-folder-actions {
+	display: flex;
+	align-items: center;
+	gap: 0.15rem;
+}
+
+.saved-icon-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	transition: background var(--transition), color var(--transition);
+}
+
+.saved-icon-btn .icon {
+	width: 1.1rem;
+	height: 1.1rem;
+}
+
+.saved-icon-btn:hover {
+	background: var(--surface-hover);
+	color: var(--text);
+}
+
+.saved-icon-btn-danger:hover {
+	background: color-mix(in srgb, var(--color-error) 12%, transparent);
+	color: var(--color-error);
+}
+
+.saved-section-empty {
+	color: var(--muted);
+	font-size: 0.85rem;
+	padding: 0.5rem 1rem 1rem;
+}
+
+.saved-row,
+.draft-row {
+	display: flex;
+	align-items: stretch;
+	gap: 0.25rem;
+	border-bottom: 1px solid var(--border);
+	transition: background var(--transition);
+}
+
+.saved-row:hover,
+.draft-row:hover {
+	background: color-mix(in srgb, var(--color-base-content) 3%, transparent);
+}
+
+.saved-link {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	flex: 1;
+	min-width: 0;
+	padding: 0.8rem 0.35rem 0.8rem 1rem;
+	text-decoration: none;
+	color: inherit;
+}
+
+.saved-row-avatar {
+	width: 2.5rem;
+	height: 2.5rem;
+	flex-shrink: 0;
+}
+
+.saved-link-body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+	min-width: 0;
+}
+
+.saved-author {
+	font-size: 0.95rem;
+	font-weight: 700;
+	line-height: 1.25;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.saved-preview {
+	color: var(--muted);
+	font-size: 0.88rem;
+	line-height: 1.35;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.saved-folder-badge {
+	align-self: flex-start;
+	margin-top: 0.15rem;
+	padding: 0.1rem 0.45rem;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--color-base-content) 7%, transparent);
+	color: var(--muted);
+	font-size: 0.72rem;
+	font-weight: 600;
+}
+
+.saved-row-action,
+.draft-row-action {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	align-self: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	margin-right: 0.55rem;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	opacity: 0.55;
+	transition: background var(--transition), color var(--transition), opacity var(--transition);
+}
+
+.saved-row:hover .saved-row-action,
+.draft-row:hover .draft-row-action,
+.saved-row-action:focus-visible,
+.draft-row-action:focus-visible {
+	opacity: 1;
+}
+
+.saved-row-action:hover,
+.draft-row-action:hover {
+	background: color-mix(in srgb, var(--color-error) 12%, transparent);
+	color: var(--color-error);
+}
+
+/* Drafts */
+.drafts-panel {
+	display: flex;
+	flex-direction: column;
+	min-height: calc(100vh - 53px);
+}
+
+.drafts-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.draft-row-main {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.25rem;
+	flex: 1;
+	min-width: 0;
+	padding: 0.85rem 0.35rem 0.85rem 1rem;
+	border: none;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.draft-row-preview {
+	margin: 0;
+	font-size: 0.95rem;
+	line-height: 1.4;
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.draft-row-meta {
+	color: var(--muted);
+	font-size: 0.8rem;
+}
+
+/* Mention autocomplete */
+.mention-panel {
+	position: absolute;
+	left: 0;
+	right: 0;
+	background: var(--color-base-100);
+	border: 1px solid var(--border-strong);
+	border-radius: 12px;
+	max-height: 220px;
+	overflow-y: auto;
+	z-index: 10;
+	box-shadow: 0 8px 24px color-mix(in srgb, var(--color-base-content) 25%, transparent);
+}
+
+.mention-option {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	gap: 0.5rem;
+	padding: 0.65rem 0.85rem;
+	background: transparent;
+	border: none;
+	color: inherit;
+	cursor: pointer;
+	text-align: left;
+}
+
+.mention-option.active,
+.mention-option:hover {
+	background: var(--surface-hover);
+}
+
+.mention-option small {
+	color: var(--muted);
+}
+
+.composer-body {
+	position: relative;
+}
+
+/* Save modal */
+.save-modal {
+	position: fixed;
+	inset: 0;
+	background: color-mix(in srgb, var(--color-base-content) 35%, transparent);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 50;
+	padding: 1rem;
+}
+
+.save-modal-card {
+	width: min(100%, 400px);
+	padding: 1.25rem;
+}
+
+.save-modal-card select {
+	width: 100%;
+	box-sizing: border-box;
+	margin: 0.75rem 0;
+	background: var(--bg-soft);
+	border: 1px solid var(--border);
+	color: inherit;
+	border-radius: 12px;
+	padding: 0.5rem;
+	font: inherit;
+}
+
+.save-modal-actions {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.save-modal-actions button {
+	border: none;
+	border-radius: 999px;
+	background: var(--accent);
+	color: white;
+	font: inherit;
+	font-weight: 600;
+	padding: 0.5rem 1rem;
+	cursor: pointer;
+}
+
+/* Responsive */
+.compose-fab,
+.mobile-only-btn {
+	display: none;
+}
+
+@media (max-width: 1100px) {
+	.shell {
+		grid-template-columns: 88px minmax(0, 1fr);
+		gap: 0 1rem;
+	}
+
+	.aside-col {
+		display: none;
+	}
+
+	.nav-label,
+	.compose-nav-btn .nav-label {
+		display: none;
+	}
+
+	.compose-nav-btn {
+		width: 52px;
+		height: 52px;
+		min-height: 52px;
+		padding: 0;
+		border-radius: 999px;
+		margin: 0.5rem auto 0;
+	}
+
+	.compose-nav-icon {
+		display: block;
+		width: 1.35rem;
+		height: 1.35rem;
+	}
+
+	.nav-btn {
+		justify-content: center;
+		padding: 0;
+		width: 52px;
+		height: 52px;
+		margin: 0 auto;
+	}
+
+	.side-nav-links {
+		align-items: center;
+	}
+
+	.nav-badge {
+		left: auto;
+		right: 0.15rem;
+		top: 0.15rem;
+	}
+}
+
+@media (max-width: 700px) {
+	.shell {
+		grid-template-columns: 1fr;
+		padding: 0;
+		max-width: 100%;
+	}
+
+	.side-nav {
+		display: none;
+	}
+
+	.timeline-col {
+		border-left: none;
+		border-right: none;
+		padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0));
+	}
+
+	.mobile-tabbar {
+		display: flex;
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		z-index: 20;
+		justify-content: space-around;
+		align-items: center;
+		padding: 0.35rem 0 calc(0.35rem + env(safe-area-inset-bottom, 0));
+		backdrop-filter: blur(12px);
+	}
+
+	.mobile-tabbar .nav-btn {
+		width: auto;
+		min-height: 44px;
+		padding: 0.35rem 0.75rem;
+		justify-content: center;
+	}
+
+	.mobile-tabbar .nav-badge {
+		position: absolute;
+		top: 0;
+		right: 0.15rem;
+		left: auto;
+	}
+
+	.compose-fab {
+		display: inline-flex;
+		position: fixed;
+		right: 1rem;
+		bottom: calc(4.5rem + env(safe-area-inset-bottom, 0));
+		z-index: 25;
+		width: 3.25rem;
+		height: 3.25rem;
+		box-shadow: 0 6px 20px color-mix(in srgb, var(--color-base-content) 28%, transparent);
+	}
+
+	.mobile-only-btn {
+		display: inline-flex;
+	}
+
+	.feed-ranking-tabs {
+		flex: 1 1 auto;
+		min-width: 0;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		flex-wrap: nowrap;
+	}
+
+	.live-broadcast-panel {
+		padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0));
+		width: 100%;
+		box-sizing: border-box;
+	}
+}
+
+@media (max-width: 480px) {
+	.profile-tab {
+		padding: 0.65rem 0.25rem;
+		font-size: 0.75rem;
+	}
+
+	.view-header {
+		padding: 0 0.65rem;
+		gap: 0.4rem;
+	}
+
+	.view-title {
+		font-size: 1.05rem;
+	}
+}
+
+.community-note {
+	margin: 0.5rem 0;
+	padding: 0.65rem 0.75rem;
+	border-radius: 10px;
+	border: 1px solid color-mix(in srgb, #f59e0b 40%, var(--border));
+	background: color-mix(in srgb, #f59e0b 10%, transparent);
+}
+
+.community-note-label {
+	font-size: 0.75rem;
+	font-weight: 700;
+	margin-bottom: 0.25rem;
+}
+
+.community-note-text {
+	margin: 0 0 0.5rem;
+	white-space: pre-wrap;
+}
+
+.community-note-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+}
+
+.trending-scope-tabs {
+	display: flex;
+	gap: 0.35rem;
+	margin: 0.35rem 0 0.5rem;
+}
+
+.taste-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.taste-row {
+	padding: 0.75rem 1rem;
+}
+
+.taste-row-main {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 0.5rem 0.75rem;
+	margin-bottom: 0.5rem;
+}
+
+.taste-hash,
+.taste-weight {
+	font-size: 0.82rem;
+	color: var(--muted);
+}
+
+.taste-rename-form {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+
+.taste-rename-form input {
+	flex: 1 1 12rem;
+	min-width: 0;
+	border: 1px solid var(--border);
+	border-radius: 999px;
+	padding: 0.35rem 0.75rem;
+	font: inherit;
+	background: transparent;
+	color: inherit;
+}
+
+/* === Search view === */
+.search-view-filters {
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid var(--border);
+}
+
+.search-filters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+	align-items: center;
+}
+
+/* === Topic view === */
+.topic-view-title {
+	font-size: 1.3rem;
+}
+
+/* === Fullscreen video/live views === */
+#videosView,
+#liveView {
+	position: fixed;
+	inset: 0;
+	z-index: 100;
+	background: #000;
+	overflow: hidden;
+}
+
+.vertical-snap-view {
+	height: 100%;
+	overflow-y: scroll;
+	scroll-snap-type: y mandatory;
+	-webkit-overflow-scrolling: touch;
+}
+
+.video-slide,
+.live-slide {
+	position: relative;
+	height: 100svh;
+	scroll-snap-align: start;
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #000;
+	touch-action: pan-y;
+}
+
+/* === Video view === */
+.video-player {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+	display: block;
+}
+
+.video-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 50%);
+	pointer-events: none;
+}
+
+.video-info {
+	padding: 0.75rem 4.5rem 2.75rem 1rem;
+	pointer-events: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 0.45rem;
+}
+
+.video-author-row {
+	display: flex;
+	align-items: center;
+	gap: 0.55rem;
+	color: #fff;
+	text-decoration: none;
+	width: fit-content;
+	max-width: 100%;
+}
+
+.video-author-row:hover .video-author {
+	text-decoration: underline;
+}
+
+.video-author-row .author-avatar {
+	width: 2.25rem;
+	height: 2.25rem;
+	border-radius: 999px;
+	flex-shrink: 0;
+	border: 1.5px solid rgba(255, 255, 255, 0.55);
+}
+
+.video-author {
+	font-weight: 700;
+	color: #fff;
+	font-size: 0.95rem;
+	text-shadow: 0 1px 4px rgba(0,0,0,0.7);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.video-author-handle {
+	font-size: 0.82rem;
+	opacity: 0.72;
+	color: #fff;
+	text-shadow: 0 1px 4px rgba(0,0,0,0.7);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.video-caption {
+	color: rgba(255,255,255,0.92);
+	font-size: 0.88rem;
+	line-height: 1.35;
+	text-shadow: 0 1px 4px rgba(0,0,0,0.7);
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.video-comment-ticker {
+	position: absolute;
+	right: 4.75rem;
+	bottom: 5.25rem;
+	width: min(14.5rem, 46vw);
+	height: 6.25rem;
+	overflow: hidden;
+	pointer-events: auto;
+	mask-image: linear-gradient(to bottom, transparent, #000 18%, #000 78%, transparent);
+	-webkit-mask-image: linear-gradient(to bottom, transparent, #000 18%, #000 78%, transparent);
+	transition: opacity 160ms ease;
+	z-index: 2;
+}
+
+.video-comment-ticker.is-dimmed {
+	opacity: 0;
+	pointer-events: none;
+}
+
+.video-comment-ticker-track {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
+.video-comment-ticker-track.is-scrolling {
+	animation: videoCommentTicker var(--ticker-duration, 12s) linear infinite;
+}
+
+.video-comment-ticker-item {
+	display: grid;
+	grid-template-columns: auto 1fr;
+	grid-template-rows: auto auto;
+	column-gap: 0.4rem;
+	row-gap: 0.1rem;
+	padding: 0.35rem 0.55rem;
+	border-radius: 0.65rem;
+	background: rgba(0, 0, 0, 0.42);
+	color: rgba(255, 255, 255, 0.94);
+	font-size: 0.78rem;
+	line-height: 1.3;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+	backdrop-filter: blur(4px);
+	cursor: pointer;
+	align-items: center;
+}
+
+.video-comment-ticker-item .video-ticker-avatar {
+	grid-row: 1 / span 2;
+	width: 1.35rem;
+	height: 1.35rem;
+	font-size: 0.55rem;
+	flex-shrink: 0;
+}
+
+.video-comment-ticker-item:hover,
+.video-comment-ticker-item:focus-visible {
+	background: rgba(0, 0, 0, 0.62);
+	outline: none;
+}
+
+.video-comment-ticker-item strong {
+	font-size: 0.72rem;
+	font-weight: 700;
+	opacity: 0.9;
+}
+
+.video-comment-ticker-item span {
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	grid-column: 2;
+}
+
+@keyframes videoCommentTicker {
+	from { transform: translateY(0); }
+	to { transform: translateY(-50%); }
+}
+
+.video-actions {
+	position: absolute;
+	right: 0.75rem;
+	bottom: 3.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+	align-items: center;
+	pointer-events: auto;
+	z-index: 3;
+}
+
+.video-action-btn {
+	background: none;
+	border: none;
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.2rem;
+	font-size: 0.75rem;
+	text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+	padding: 0.25rem;
+}
+
+.video-action-btn .icon {
+	width: 2rem;
+	height: 2rem;
+	background: #fff;
+	filter: drop-shadow(0 1px 3px rgba(0,0,0,0.5));
+}
+
+.video-action-btn.is-active .icon-like {
+	--icon: url("https://api.iconify.design/mdi/heart.svg");
+	background: var(--like);
+}
+
+.video-progress-bar {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: 3px;
+	background: rgba(255,255,255,0.2);
+}
+
+.video-progress-fill {
+	height: 100%;
+	background: var(--accent);
+	transition: width 0.1s linear;
+	will-change: width;
+}
+
+.video-pause-hint {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 160ms ease;
+	background: rgba(0, 0, 0, 0.18);
+}
+
+.video-pause-hint.is-visible {
+	opacity: 1;
+}
+
+.video-pause-hint .icon {
+	width: 3.5rem;
+	height: 3.5rem;
+	background: rgba(255, 255, 255, 0.92);
+	filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.45));
+}
+
+.video-media-fallback {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.75rem;
+	padding: 2rem;
+	text-align: center;
+	background: radial-gradient(circle at 30% 20%, #243044 0%, #0d1118 55%, #07090d 100%);
+	color: rgba(255, 255, 255, 0.88);
+}
+
+.video-media-fallback .icon {
+	width: 3rem;
+	height: 3rem;
+	background: rgba(255, 255, 255, 0.75);
+}
+
+.live-empty {
+	color: #fff;
+	font-size: 1rem;
+	padding: 2rem;
+	text-align: center;
+}
+
+/* Heart animation */
+.heart-anim {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	font-size: 4rem;
+	pointer-events: none;
+	z-index: 10;
+}
+
+@keyframes heartFloat {
+	0%   { opacity: 1; transform: translate(-50%, -50%) scale(0.5); }
+	50%  { opacity: 1; transform: translate(-50%, -80%) scale(1.3); }
+	100% { opacity: 0; transform: translate(-50%, -130%) scale(1); }
+}
+
+/* Video replies panel (bottom drawer inside slide) */
+.video-replies-panel {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	max-height: 55%;
+	background: var(--bg);
+	border-radius: 1rem 1rem 0 0;
+	overflow-y: auto;
+	padding: 0.75rem 1rem 1rem;
+	z-index: 20;
+	color: var(--text);
+	display: flex;
+	flex-direction: column;
+	gap: 0.65rem;
+}
+
+.video-replies-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.75rem;
+	position: sticky;
+	top: 0;
+	background: var(--bg);
+	padding-bottom: 0.35rem;
+	z-index: 1;
+}
+
+.video-replies-title {
+	font-weight: 700;
+	font-size: 0.95rem;
+}
+
+.video-replies-close {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border: none;
+	border-radius: 999px;
+	background: var(--surface-hover);
+	color: var(--text);
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.video-replies-close .icon {
+	width: 1.15rem;
+	height: 1.15rem;
+}
+
+/* === Live view === */
+.live-placeholder {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.live-badge {
+	background: #e53e3e;
+	color: #fff;
+	font-size: 0.75rem;
+	font-weight: bold;
+	padding: 0.15rem 0.6rem;
+	border-radius: 999px;
+	letter-spacing: 0.08em;
+}
+
+.live-title {
+	font-size: 1.1rem;
+	font-weight: bold;
+	color: #fff;
+	text-align: center;
+	padding: 0 2rem;
+}
+
+.live-overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-end;
+	pointer-events: none;
+}
+
+.danmaku-area {
+	flex: 1;
+	overflow: hidden;
+	position: relative;
+	pointer-events: none;
+}
+
+.danmaku-item {
+	position: absolute;
+	white-space: nowrap;
+	color: #fff;
+	text-shadow: 0 1px 3px rgba(0,0,0,0.9);
+	font-size: 0.88rem;
+	animation: danmakuScroll 6s linear forwards;
+	right: 0;
+}
+
+@keyframes danmakuScroll {
+	from { transform: translateX(110%); }
+	to   { transform: translateX(-105vw); }
+}
+
+.live-bottom {
+	padding: 0.75rem;
+	background: linear-gradient(to top, rgba(0,0,0,0.72) 0%, transparent 100%);
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	pointer-events: auto;
+}
+
+.live-info {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	color: #fff;
+}
+
+.live-author { font-weight: bold; font-size: 0.9rem; }
+.live-viewer-count,
+.live-like-count { font-size: 0.78rem; opacity: 0.8; }
+
+.live-top-bar {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 110;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: max(0.75rem, env(safe-area-inset-top, 0)) 0.85rem 1.25rem;
+	background: linear-gradient(to bottom, rgba(0,0,0,0.55) 0%, transparent 100%);
+	pointer-events: none;
+}
+.live-top-bar > * {
+	pointer-events: auto;
+}
+.live-top-bar .view-back-btn {
+	position: static;
+	flex-shrink: 0;
+	width: 2.25rem;
+	height: 2.25rem;
+}
+.live-scope-tabs {
+	display: flex;
+	gap: 0.35rem;
+	min-width: 0;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+	scrollbar-width: none;
+}
+.live-scope-tabs::-webkit-scrollbar { display: none; }
+.live-scope-btn,
+.live-go-broadcast-btn {
+	border: 1px solid rgba(255,255,255,0.3);
+	background: rgba(0,0,0,0.45);
+	color: #fff;
+	border-radius: 999px;
+	padding: 0.3rem 0.8rem;
+	font-size: 0.75rem;
+	line-height: 1.2;
+	cursor: pointer;
+	white-space: nowrap;
+	flex-shrink: 0;
+}
+.live-scope-btn.is-active {
+	background: var(--color-primary, #5865f2);
+	border-color: transparent;
+}
+.live-go-broadcast-btn {
+	margin-left: auto;
+	border-color: color-mix(in srgb, var(--color-primary, #5865f2) 55%, rgba(255,255,255,0.35));
+	background: color-mix(in srgb, var(--color-primary, #5865f2) 35%, rgba(0,0,0,0.45));
+}
+
+.live-hall-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+	gap: 0.75rem;
+	padding: 3rem 0.75rem 1rem;
+}
+.live-hall-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	padding: 0.75rem;
+	border-radius: 12px;
+	border: 1px solid var(--fallback-bc, #333);
+	background: var(--fallback-b1, #1a1a1a);
+	text-align: left;
+	cursor: pointer;
+	color: inherit;
+}
+.live-hall-avatar {
+	width: 48px;
+	height: 48px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+.live-hall-title { font-weight: 600; font-size: 0.9rem; }
+.live-hall-stats { font-size: 0.75rem; opacity: 0.7; }
+
+.live-av-wrap { position: absolute; inset: 0; display: flex; }
+.live-linked .live-av-wrap { gap: 2px; }
+.live-linked .live-av-canvas { width: 50%; }
+.live-linked .live-av-canvas-peer { display: block !important; width: 50%; }
+
+.live-link-row {
+	display: flex;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+	align-items: center;
+}
+
+.voice-ring-host,
+.live-voice-ring-host {
+	position: relative;
+	width: min(72vw, 320px);
+	height: min(72vw, 320px);
+	margin: 0 auto;
+}
+.voice-ring-canvas {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+}
+.voice-ring-avatar {
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	width: 42%;
+	height: 42%;
+	transform: translate(-50%, -50%);
+	border-radius: 50%;
+	object-fit: cover;
+	z-index: 1;
+}
+.live-broadcast-preview {
+	position: relative;
+	min-height: 240px;
+}
+.live-whip-panel {
+	margin-top: 0.75rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+}
+
+.live-ref-card {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.6rem 0.75rem;
+	border-radius: 10px;
+	background: rgba(88, 101, 242, 0.15);
+	border: 1px solid rgba(88, 101, 242, 0.4);
+	margin-bottom: 0.5rem;
+	text-decoration: none;
+	color: inherit;
+}
+.live-ref-card--ended { background: rgba(128,128,128,0.12); border-color: rgba(128,128,128,0.35); }
+.live-ref-badge {
+	font-size: 0.7rem;
+	font-weight: 700;
+	background: #e11;
+	color: #fff;
+	padding: 0.1rem 0.4rem;
+	border-radius: 4px;
+}
+.live-ref-card--ended .live-ref-badge { background: #666; }
+.live-ref-avatar {
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	font-size: 0.7rem;
+}
+
+.live-actions {
+	position: absolute;
+	right: 0.75rem;
+	bottom: 5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	align-items: center;
+	pointer-events: auto;
+}
+
+.live-action-btn {
+	background: none;
+	border: none;
+	color: #fff;
+	cursor: pointer;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.2rem;
+	font-size: 0.75rem;
+	padding: 0.25rem;
+}
+
+.live-action-btn .icon {
+	width: 2rem;
+	height: 2rem;
+	background: #fff;
+}
+
+.live-danmaku-input {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+}
+
+.live-danmaku-field {
+	flex: 1;
+	background: rgba(255,255,255,0.15);
+	border: 1px solid rgba(255,255,255,0.3);
+	border-radius: 999px;
+	padding: 0.4rem 0.85rem;
+	color: #fff;
+	font-size: 0.85rem;
+	outline: none;
+}
+
+.live-danmaku-field::placeholder { color: rgba(255,255,255,0.5); }
+
+.live-danmaku-send-btn {
+	background: var(--accent);
+	color: #fff;
+	border: none;
+	border-radius: 999px;
+	padding: 0.4rem 1rem;
+	cursor: pointer;
+	font-size: 0.85rem;
+	white-space: nowrap;
+}
+
+/* Back button for fullscreen views */
+.view-back-btn {
+	background: rgba(0,0,0,0.45);
+	color: #fff;
+	border: none;
+	border-radius: 999px;
+	width: 2.5rem;
+	height: 2.5rem;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+#videosView .view-back-btn {
+	position: absolute;
+	top: 1rem;
+	left: 1rem;
+	z-index: 110;
+}
+
+.view-back-btn .icon {
+	background: #fff;
+}
+
+/* === Live broadcast panel === */
+.live-broadcast-panel {
+	padding: 1.5rem 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	align-items: flex-start;
+}
+
+.live-broadcast-canvas {
+	max-width: 100%;
+	height: auto;
+	display: block;
+}
+
+.live-broadcast-status {
+	font-size: 0.9rem;
+	color: var(--muted);
+	margin: 0;
+}
+
+/* === Visibility / albums === */
+.visibility-picker {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	align-items: center;
+}
+
+.visibility-allow,
+.visibility-except {
+	min-width: 12rem;
+}
+
+.post-album-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	padding: 0.25rem 0 0.5rem;
+}
+
+.post-album-chip {
+	border: 1px solid var(--border, #333);
+	background: transparent;
+	border-radius: 999px;
+	padding: 0.15rem 0.65rem;
+	font-size: 0.75rem;
+	cursor: pointer;
+	color: var(--muted);
+}
+
+.album-toolbar {
+	margin-bottom: 0.75rem;
+}
+
+.album-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+	gap: 0.75rem;
+}
+
+.album-card {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	padding: 0;
+	border: 1px solid var(--border, #333);
+	border-radius: 0.75rem;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	overflow: hidden;
+}
+
+.album-card-cover {
+	aspect-ratio: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: color-mix(in srgb, var(--muted, #888) 18%, transparent);
+	font-weight: 600;
+	padding: 0;
+	overflow: hidden;
+}
+
+.album-card-cover-img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.album-card-cover-fallback {
+	padding: 0.5rem;
+	text-align: center;
+}
+
+.album-card-meta {
+	padding: 0.5rem 0.65rem 0.75rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+}
+
+.album-detail-header {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+	margin-bottom: 1rem;
+}
+
+.album-detail-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+}
+
+.album-posts {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+/* Shared floating emoji picker (#fount-shared-emoji-picker) */
+#fount-shared-emoji-picker.emoji-picker {
+	background: var(--color-base-200);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 12px;
+	box-shadow: 0 8px 16px color-mix(in srgb, var(--color-base-content) 18%, transparent);
+	max-height: 360px;
+	display: block;
+}
+
+#fount-shared-emoji-picker .emoji-tabs {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 8px;
+	flex-wrap: wrap;
+}
+
+#fount-shared-emoji-picker .emoji-tab {
+	background: transparent;
+	border: none;
+	color: var(--muted);
+	padding: 4px 8px;
+	cursor: pointer;
+	border-radius: 4px;
+	font-size: 14px;
+	min-width: 32px;
+	min-height: 32px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+#fount-shared-emoji-picker .emoji-tab-glyph {
+	font-size: 20px;
+	line-height: 1;
+	font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+}
+
+#fount-shared-emoji-picker .emoji-tab:hover {
+	background: var(--surface-hover);
+}
+
+#fount-shared-emoji-picker .emoji-tab.active {
+	background: color-mix(in srgb, var(--color-base-content) 12%, transparent);
+	color: var(--text);
+}
+
+#fount-shared-emoji-picker .emoji-grid {
+	display: grid;
+	grid-template-columns: repeat(8, 1fr);
+	gap: 2px;
+	max-height: 280px;
+	overflow-y: auto;
+}
+
+#fount-shared-emoji-picker .emoji-grid-button {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 6px;
+	border-radius: 4px;
+	font-size: 22px;
+	line-height: 1;
+}
+
+#fount-shared-emoji-picker .emoji-grid-button:hover {
+	background: var(--surface-hover);
+	transform: scale(1.2);
+}
+
+#fount-shared-emoji-picker .group-emoji-grid-button {
+	padding: 4px;
+}
+
+#fount-shared-emoji-picker .group-emoji-img {
+	width: 28px;
+	height: 28px;
+	object-fit: contain;
+	display: block;
+}
+
+#fount-shared-emoji-picker .emoji-grid-empty {
+	grid-column: 1 / -1;
+	padding: 16px 8px;
+	text-align: center;
+	color: var(--muted);
+	font-size: 13px;
+}

--- a/src/public/parts/shells/social/public/ui-details.md
+++ b/src/public/parts/shells/social/public/ui-details.md
@@ -1,0 +1,24 @@
+# Social UI details (less common)
+
+Day-to-day rules: [AGENTS.md](AGENTS.md).
+
+## Short video / live UI
+
+- Slide fields from `buildPostFeedItem`: `post.content.text` / `post.content.mediaRefs` / `authorProfile` — not flat `item.text` / `item.authorName`.
+- Action bar: like / comment / share / mute; mute in `localStorage` (`fount.social.video.muted`). Comment drawer: close button / click-outside / Esc. Reply ticker: `syncVideoCommentTicker`. `cardRoot` for panels: `.post-card, .reply, .video-slide`.
+- Live: vertical snap + cursor near end; next slide preconnect with AV `subscribe mode=preview`. Empty lobby → `buildNearbyLiveFeed`.
+
+## Long body fold
+
+Feed/profile/search cards (`openDetail !== false`) collapse markdown code `<details>` by default and clamp tall `.body` (~280px) with `.body-expand`. Post detail keeps full height. `POST_CARD_OPEN_EXCLUDE` includes `summary` / `.body-expand`.
+
+## Feed pagination / replay
+
+- Shared: `/scripts/infiniteScroll.mjs`. After replay, **move** the sentinel — do not rebind while intersecting. Rising-edge arm. If loader has its own mutex, bind **after** releasing it.
+- Prefetch next cursor into `state.feedPrefetch`. Replay when `nextCursor` exhausted: re-append shown items (`.feed-replay-divider`); requires real scroll. Delete/hide/block/mute must `purgeFeedShownPost` / `purgeFeedShownAuthor`.
+- Hashtag/trending → `#topic:…`; search deep links → `#searchView`.
+
+## Empty states / shared widgets
+
+- `templates/empty_state.html` via `lib/emptyState.mjs`. Snap feeds: `lib/snapCursorFeed.mjs`. Suggested accounts: `lib/suggestedAccounts.mjs`. Engagement: `templates/engagement_bar.html` + `lib/engagementBar.mjs`.
+- Governance optimistic UX: `socialWrite.mjs` + `runWrite` failure toasts.

--- a/src/public/parts/shells/social/src/api/client/albums.mjs
+++ b/src/public/parts/shells/social/src/api/client/albums.mjs
@@ -1,0 +1,318 @@
+import { randomUUID } from 'node:crypto'
+
+import { httpError } from '../../../../../../../scripts/http_error.mjs'
+import { buildPostFeedItem } from '../../feed/buildItem.mjs'
+import { loadViewerContext } from '../../feed/home.mjs'
+import { createFeedItemBuildContext } from '../../feed/iterate.mjs'
+import { canViewAlbum, canViewPost } from '../../feedVisibility.mjs'
+import { albumsForPostFromView } from '../../lib/albumRefs.mjs'
+import { ensureEntitySocialReady } from '../../lib/bootstrap.mjs'
+import { resolveSensitiveMedia } from '../../lib/mediaRefs.mjs'
+import { setPostVisibility } from '../../lib/postVisibility.mjs'
+import {
+	minVisibilitySpec,
+	normalizeVisibilitySpec,
+	visibilitySpecFromContent,
+	visibilitySpecsEqual,
+	visibilitySpecToContentFields,
+} from '../../lib/visibilitySpec.mjs'
+import { commitTimelineEvent } from '../../timeline/append.mjs'
+import { getTimelineMaterialized } from '../../timeline/materialize.mjs'
+import { DEFAULT_ALBUM_ID } from '../../timeline/reducers.mjs'
+import { maybeDecryptPostContent } from '../../vault_crypto/vault.mjs'
+
+/**
+ * 重算帖子密级 = 所属真实相册中最公开档位；无所属则保持不变。
+ * @param {string} username replica
+ * @param {string} entityHash owner
+ * @param {Iterable<string>} postIds 受影响帖
+ * @returns {Promise<void>}
+ */
+export async function reconcileAlbumPostVisibility(username, entityHash, postIds) {
+	const owner = String(entityHash).toLowerCase()
+	const view = await getTimelineMaterialized(username, owner)
+	const unique = [...new Set([...postIds].map(String))]
+	for (const postId of unique) {
+		const albumIds = (view.albumsByPost?.[postId] || []).filter(id => id !== DEFAULT_ALBUM_ID)
+		if (!albumIds.length) continue
+		const specs = albumIds.map(id => view.albums?.[id]).filter(Boolean)
+		const target = minVisibilitySpec(specs)
+		if (!target) continue
+		const row = view.postById?.[postId]
+		if (!row) continue
+		const plain = await maybeDecryptPostContent(username, owner, row.content, owner)
+		if (!plain) continue
+		if (visibilitySpecsEqual(visibilitySpecFromContent(plain), target)) continue
+		await setPostVisibility(username, owner, postId, target)
+	}
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} albums 方法
+ */
+export function createAlbumsMethods(apiContext) {
+	return {
+		albums: {
+			/**
+			 * @param {object} draft 创建草稿
+			 * @returns {Promise<object>} 相册
+			 */
+			async create(draft = {}) {
+				await ensureEntitySocialReady(apiContext.username, apiContext.entityHash)
+				const albumId = String(draft.albumId || randomUUID()).trim()
+				if (!albumId || albumId === DEFAULT_ALBUM_ID)
+					throw httpError(400, 'invalid albumId')
+				const view = await getTimelineMaterialized(apiContext.username, apiContext.entityHash)
+				if (view.albums?.[albumId] && !view.albums[albumId].virtual)
+					throw httpError(409, 'album exists')
+				const spec = normalizeVisibilitySpec(draft)
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_create',
+					content: {
+						albumId,
+						name: String(draft.name || albumId).trim().slice(0, 80) || albumId,
+						description: String(draft.description || '').trim().slice(0, 500),
+						...visibilitySpecToContentFields(spec),
+					},
+				})
+				return { albumId, event }
+			},
+
+			/**
+			 * @param {string} albumId id
+			 * @param {object} patch 更新
+			 * @returns {Promise<object>} 结果
+			 */
+			async update(albumId, patch = {}) {
+				const id = String(albumId || '').trim()
+				if (!id || id === DEFAULT_ALBUM_ID) throw httpError(400, 'cannot update default album')
+				const view = await getTimelineMaterialized(apiContext.username, apiContext.entityHash)
+				const album = view.albums?.[id]
+				if (!album || album.virtual) throw httpError(404, 'album not found')
+				const next = {
+					...album,
+					...patch,
+					albumId: id,
+					visibility: patch.visibility ?? album.visibility,
+					minFollowMs: patch.minFollowMs ?? album.minFollowMs,
+					allow: patch.allow ?? album.allow,
+					except: patch.except ?? album.except,
+				}
+				const spec = normalizeVisibilitySpec(next)
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_update',
+					content: {
+						albumId: id,
+						name: String(next.name || album.name).trim().slice(0, 80),
+						description: String(next.description ?? album.description ?? '').trim().slice(0, 500),
+						...visibilitySpecToContentFields(spec),
+					},
+				})
+				await reconcileAlbumPostVisibility(apiContext.username, apiContext.entityHash, album.postIds || [])
+				return { albumId: id, event }
+			},
+
+			/**
+			 * @param {string} albumId id
+			 * @param {{ deletePosts?: boolean }} [options] 删除选项
+			 * @returns {Promise<object>} 结果
+			 */
+			async delete(albumId, options = {}) {
+				const id = String(albumId || '').trim()
+				if (!id || id === DEFAULT_ALBUM_ID) throw httpError(400, 'cannot delete default album')
+				const view = await getTimelineMaterialized(apiContext.username, apiContext.entityHash)
+				const album = view.albums?.[id]
+				if (!album || album.virtual) throw httpError(404, 'album not found')
+				const postIds = [...album.postIds || []]
+				if (options.deletePosts)
+					for (const postId of postIds)
+						await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+							type: 'post_delete',
+							content: { targetPostId: postId },
+						})
+
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_delete',
+					content: { albumId: id },
+				})
+				if (!options.deletePosts)
+					await reconcileAlbumPostVisibility(apiContext.username, apiContext.entityHash, postIds)
+				return { albumId: id, event, deletedPosts: Boolean(options.deletePosts) }
+			},
+
+			/**
+			 * @param {string} albumId 相册
+			 * @param {string} postId 帖
+			 * @returns {Promise<object>} 结果
+			 */
+			async addPost(albumId, postId) {
+				const id = String(albumId || '').trim()
+				const pid = String(postId || '').trim()
+				if (!id || id === DEFAULT_ALBUM_ID || !pid) throw httpError(400, 'invalid album/post')
+				const view = await getTimelineMaterialized(apiContext.username, apiContext.entityHash)
+				if (!view.albums?.[id] || view.albums[id].virtual) throw httpError(404, 'album not found')
+				if (!view.postById?.[pid]) throw httpError(404, 'post not found')
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_post_add',
+					content: { albumId: id, postId: pid },
+				})
+				await reconcileAlbumPostVisibility(apiContext.username, apiContext.entityHash, [pid])
+				return { event }
+			},
+
+			/**
+			 * @param {string} albumId 相册
+			 * @param {string} postId 帖
+			 * @returns {Promise<object>} 结果
+			 */
+			async removePost(albumId, postId) {
+				const id = String(albumId || '').trim()
+				const pid = String(postId || '').trim()
+				if (!id || id === DEFAULT_ALBUM_ID || !pid) throw httpError(400, 'invalid album/post')
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_post_remove',
+					content: { albumId: id, postId: pid },
+				})
+				await reconcileAlbumPostVisibility(apiContext.username, apiContext.entityHash, [pid])
+				return { event }
+			},
+
+			/**
+			 * @param {string} postId 帖
+			 * @param {string} fromAlbumId 源
+			 * @param {string} toAlbumId 目标
+			 * @returns {Promise<object>} 结果
+			 */
+			async movePost(postId, fromAlbumId, toAlbumId) {
+				const pid = String(postId || '').trim()
+				const from = String(fromAlbumId || '').trim()
+				const to = String(toAlbumId || '').trim()
+				if (!pid || !to || to === DEFAULT_ALBUM_ID) throw httpError(400, 'invalid move')
+				if (from && from !== DEFAULT_ALBUM_ID)
+					await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+						type: 'album_post_remove',
+						content: { albumId: from, postId: pid },
+					})
+				await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'album_post_add',
+					content: { albumId: to, postId: pid },
+				})
+				await reconcileAlbumPostVisibility(apiContext.username, apiContext.entityHash, [pid])
+				return { postId: pid, fromAlbumId: from || null, toAlbumId: to }
+			},
+
+			/**
+			 * @param {string} [entityHash] owner；缺省自身
+			 * @returns {Promise<object[]>} 相册列表
+			 */
+			async list(entityHash) {
+				const owner = String(entityHash || apiContext.entityHash).toLowerCase()
+				const viewerContext = await loadViewerContext(apiContext.username, apiContext.entityHash)
+				const view = await getTimelineMaterialized(apiContext.username, owner)
+				const albums = []
+				for (const album of Object.values(view.albums || {})) {
+					if (!canViewAlbum(album, owner, viewerContext)) continue
+					albums.push(await summarizeAlbum(apiContext.username, owner, album, view, viewerContext))
+				}
+				return albums
+			},
+
+			/**
+			 * @param {string} entityHash owner
+			 * @param {string} albumId id
+			 * @returns {Promise<object>} 相册详情 + 成员帖
+			 */
+			async get(entityHash, albumId) {
+				const owner = String(entityHash || apiContext.entityHash).toLowerCase()
+				const id = String(albumId || '').trim() || DEFAULT_ALBUM_ID
+				const viewerContext = await loadViewerContext(apiContext.username, apiContext.entityHash)
+				const view = await getTimelineMaterialized(apiContext.username, owner)
+				const album = view.albums?.[id]
+				if (!album) throw httpError(404, 'album not found')
+				if (!canViewAlbum(album, owner, viewerContext)) throw httpError(404, 'album not found')
+
+				const itemContext = await createFeedItemBuildContext(
+					apiContext.username,
+					new Set([owner]),
+					apiContext.entityHash,
+				)
+				/**
+				 * @param {string} _author 作者（忽略，用外层 owner）
+				 * @param {string} postId 帖 id
+				 * @returns {{ albumId: string, name: string }[]} 可见相册
+				 */
+				itemContext.albumsForPost = (_author, postId) => albumsForPostFromView(view, owner, postId, viewerContext)
+
+				/** @type {object[]} */
+				const items = []
+				for (const postId of album.postIds || []) {
+					const post = view.postById?.[postId]
+					if (!post) continue
+					const enriched = { ...post, entityHash: owner }
+					if (!canViewPost(enriched, viewerContext)) continue
+					items.push(await buildPostFeedItem(apiContext.username, owner, post, itemContext))
+				}
+				return {
+					album: await summarizeAlbum(apiContext.username, owner, album, view, viewerContext),
+					items,
+				}
+			},
+		},
+	}
+}
+
+/**
+ * 选取相册封面：时间最新的首张可见、非剧透/非敏感图片。
+ * @param {string} username replica
+ * @param {string} owner 相册 owner
+ * @param {object} album 相册
+ * @param {object} view 物化视图
+ * @param {object} viewerContext 观看者
+ * @returns {Promise<object | null>} mediaRef 或 null
+ */
+async function pickAlbumCoverMediaRef(username, owner, album, view, viewerContext) {
+	for (const postId of album.postIds || []) {
+		const post = view.postById?.[postId]
+		if (!post) continue
+		const enriched = { ...post, entityHash: owner }
+		if (!canViewPost(enriched, viewerContext)) continue
+		const plain = await maybeDecryptPostContent(username, owner, post.content, viewerContext.viewerEntityHash)
+		if (!plain) continue
+		if (String(plain.contentWarning || '').trim()) continue
+		if (resolveSensitiveMedia(plain.sensitiveMedia, plain.contentWarning)) continue
+		const refs = Array.isArray(plain.mediaRefs) ? plain.mediaRefs : []
+		for (const ref of refs) {
+			if (!ref || typeof ref !== 'object') continue
+			const mimeType = String(ref.mimeType || '')
+			const kind = String(ref.kind || (mimeType.startsWith('video/') ? 'video' : 'image'))
+			if (kind !== 'image' && !mimeType.startsWith('image/')) continue
+			return ref
+		}
+	}
+	return null
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} owner owner
+ * @param {object} album 相册
+ * @param {object} view 物化视图
+ * @param {object} viewerContext 观看者
+ * @returns {Promise<object>} 摘要
+ */
+async function summarizeAlbum(username, owner, album, view, viewerContext) {
+	return {
+		albumId: album.albumId,
+		name: album.name,
+		description: album.description || '',
+		visibility: album.visibility || 'public',
+		minFollowMs: album.minFollowMs,
+		allow: album.allow,
+		except: album.except,
+		postIds: [...album.postIds || []],
+		postCount: (album.postIds || []).length,
+		virtual: Boolean(album.virtual),
+		coverMediaRef: await pickAlbumCoverMediaRef(username, owner, album, view, viewerContext),
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/drafts.mjs
+++ b/src/public/parts/shells/social/src/api/client/drafts.mjs
@@ -1,0 +1,39 @@
+import { deleteDraft, getDraft, listDrafts, upsertDraft } from '../../drafts.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {{ drafts: object }} 草稿箱命名空间
+ */
+export function createDraftsMethods(apiContext) {
+	return {
+		drafts: {
+			/**
+			 * @returns {Promise<{ drafts: object[] }>} 草稿列表
+			 */
+			async list() {
+				return listDrafts(apiContext.username, apiContext.entityHash)
+			},
+			/**
+			 * @param {string} draftId id
+			 * @returns {Promise<object>} 单条草稿
+			 */
+			async get(draftId) {
+				return getDraft(apiContext.username, apiContext.entityHash, draftId)
+			},
+			/**
+			 * @param {object} body 发帖字段；可选 draftId 更新
+			 * @returns {Promise<object>} 写入后草稿行
+			 */
+			async upsert(body) {
+				return upsertDraft(apiContext.username, apiContext.entityHash, body)
+			},
+			/**
+			 * @param {string} draftId id
+			 * @returns {Promise<{ drafts: object[] }>} 删除后列表
+			 */
+			async delete(draftId) {
+				return deleteDraft(apiContext.username, apiContext.entityHash, draftId)
+			},
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/feed.mjs
+++ b/src/public/parts/shells/social/src/api/client/feed.mjs
@@ -1,0 +1,183 @@
+import { discoverWithNetwork } from '../../discover/network.mjs'
+import { buildHomeFeed } from '../../feed/home.mjs'
+import { buildForYouFeed } from '../../feed/ranking.mjs'
+import { suggestMentions } from '../../lib/mentionSuggest.mjs'
+import { searchPosts } from '../../search.mjs'
+import { maintainSocialTimeline } from '../../timeline/materialize.mjs'
+import { syncFollowingTimelines } from '../../timeline/sync.mjs'
+import { buildTrendingHashtags } from '../../trending/hashtags.mjs'
+
+import { makeViewerOptions } from './helpers.mjs'
+
+/**
+ * 首页/短视频：首屏不足时触发联邦 backfill 再重读。
+ * @param {string} username replica
+ * @param {object} options 含 viewerEntityHash / cursor / limit
+ * @param {() => Promise<{ items: object[] }>} build 构建本页
+ * @param {{ defaultLimit: number, maxLimit: number, mediaOnly?: boolean }} caps 上限
+ * @returns {Promise<object>} feed 页
+ */
+async function withThinFeedBackfill(username, options, build, { defaultLimit, maxLimit, mediaOnly = false }) {
+	let result = await build()
+	const limit = Math.min(Math.max(Number(options.limit) || defaultLimit, 1), maxLimit)
+	if (!options.cursor && result.items.length < limit) {
+		const { backfillPosts } = await import('../../federation/backfill.mjs')
+		await backfillPosts(username, {
+			viewerEntityHash: options.viewerEntityHash,
+			...mediaOnly ? { mediaOnly: true } : {},
+			/**
+			 * @returns {Promise<boolean>} 本地是否已足够
+			 */
+			enough: async () => {
+				result = await build()
+				return result.items.length >= limit
+			},
+		})
+		result = await build()
+	}
+	return result
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} feed / 搜索 / 探索 / 话题方法
+ */
+export function createFeedMethods(apiContext) {
+	const viewerOptions = makeViewerOptions(apiContext)
+	return {
+		/**
+		 * @param {{ mode?: 'home' | 'forYou', limit?: number, cursor?: string, ranking?: string }} [options] feed 选项
+		 * @returns {Promise<object>} feed
+		 */
+		async feed(options = {}) {
+			const mode = options.mode || (options.ranking === 'for_you' ? 'forYou' : 'home')
+			options = { ...options, ...viewerOptions() }
+			return withThinFeedBackfill(
+				apiContext.username,
+				options,
+				() => mode === 'forYou'
+					? buildForYouFeed(apiContext.username, options)
+					: buildHomeFeed(apiContext.username, options),
+				{ defaultLimit: 50, maxLimit: 200 },
+			)
+		},
+		/**
+		 * @returns {Promise<{ synced: true }>} 同步结果
+		 */
+		async syncFollowing() {
+			await syncFollowingTimelines(apiContext.username)
+			return { synced: true }
+		},
+		/**
+		 * @param {string} query 查询串
+		 * @param {{ limit?: number, cursor?: string }} [options] 选项
+		 * @returns {Promise<object>} 搜索结果
+		 */
+		async search(query, options = {}) {
+			return searchPosts(apiContext.username, {
+				q: String(query || ''),
+				...options,
+				...viewerOptions(),
+			})
+		},
+		/**
+		 * @param {string} tag 话题
+		 * @param {boolean} [follow] 是否订阅
+		 * @returns {Promise<object>} 结果
+		 */
+		async followTopic(tag, follow = true) {
+			const { setTagFollow } = await import('../../topics.mjs')
+			return setTagFollow(apiContext.username, apiContext.entityHash, tag, follow !== false)
+		},
+		/**
+		 * @returns {Promise<{ tags: string[] }>} 已订阅话题
+		 */
+		async followedTopics() {
+			const { listFollowedTags } = await import('../../topics.mjs')
+			return listFollowedTags(apiContext.username, apiContext.entityHash)
+		},
+		/**
+		 * @param {string} tag 话题
+		 * @param {{ limit?: number, cursor?: string }} [options] 分页
+		 * @returns {Promise<object>} 话题帖流
+		 */
+		async topicPosts(tag, options = {}) {
+			const { buildTopicFeed } = await import('../../topics.mjs')
+			return buildTopicFeed(apiContext.username, tag, { ...options, ...viewerOptions() })
+		},
+		/**
+		 * @param {{ limit?: number, cursor?: string }} [options] 分页
+		 * @returns {Promise<object>} 短视频流
+		 */
+		async videosFeed(options = {}) {
+			const { buildVideosFeed } = await import('../../videosFeed.mjs')
+			options = { ...options, ...viewerOptions() }
+			return withThinFeedBackfill(
+				apiContext.username,
+				options,
+				() => buildVideosFeed(apiContext.username, options),
+				{ defaultLimit: 20, maxLimit: 50, mediaOnly: true },
+			)
+		},
+		/**
+		 * @param {string} query 搜索词
+		 * @param {{ maxHits?: number }} [options] 选项
+		 * @returns {Promise<{ query: string, entities: object[] }>} 实体网络搜索
+		 */
+		async searchEntities(query, options = {}) {
+			const { searchEntitiesNetwork } = await import('../../../../chat/src/entity/entitySearch.mjs')
+			return searchEntitiesNetwork(apiContext.username, query, {
+				viewerEntityHash: apiContext.entityHash,
+				maxHits: options.maxHits,
+			})
+		},
+		/**
+		 * @param {{ limit?: number }} [options] 选项
+		 * @returns {Promise<object>} 探索账户
+		 */
+		async explore(options = {}) {
+			return discoverWithNetwork(apiContext.username, {
+				type: 'social_discover_request',
+				n: Number(options.limit) || 20,
+			}, viewerOptions())
+		},
+		/**
+		 * @param {{ limit?: number, mediaOnly?: boolean }} [options] 选项
+		 * @returns {Promise<object>} 探索帖
+		 */
+		async explorePosts(options = {}) {
+			return discoverWithNetwork(apiContext.username, {
+				type: 'social_post_discover_request',
+				n: Number(options.limit) || 20,
+				mediaOnly: options.mediaOnly === true,
+			}, viewerOptions())
+		},
+		/**
+		 * @param {{ limit?: number }} [options] 选项
+		 * @returns {Promise<object>} 热门话题
+		 */
+		async trendingHashtags(options = {}) {
+			if (options.scope === 'nearby') {
+				const { buildNearbyTrendingHashtags } = await import('../../trending/network.mjs')
+				return buildNearbyTrendingHashtags(apiContext.username, { ...options, ...viewerOptions() })
+			}
+			return buildTrendingHashtags(apiContext.username, { ...options, ...viewerOptions() })
+		},
+		/**
+		 * @param {string} q 前缀
+		 * @param {{ limit?: number }} [options] 选项
+		 * @returns {Promise<object>} @ 建议
+		 */
+		async suggestMentions(q, options = {}) {
+			return suggestMentions(apiContext.username, String(q || ''), Number(options.limit) || 20, apiContext.entityHash)
+		},
+		/**
+		 * @param {string} entityHash 时间线 owner
+		 * @returns {Promise<{ checkpointEventId: string | null }>} 维护结果
+		 */
+		async maintainTimeline(entityHash) {
+			const snapshot = await maintainSocialTimeline(apiContext.username, String(entityHash).toLowerCase())
+			return { checkpointEventId: snapshot.checkpoint_event_id }
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/follow.mjs
+++ b/src/public/parts/shells/social/src/api/client/follow.mjs
@@ -1,0 +1,141 @@
+import {
+	setPersonalHidden,
+	setPersonalMuted,
+} from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { httpError } from '../../../../../../../scripts/http_error.mjs'
+import { getEntityActivePubKey } from '../../../../chat/src/entity/identity.mjs'
+import { dispatchFollowEvent } from '../../dispatch.mjs'
+import { resolveSocialEntity } from '../../federation/hosting.mjs'
+import { setFollow } from '../../following.mjs'
+import { ensureEntitySocialReady } from '../../lib/bootstrap.mjs'
+import { isKnownSocialTarget } from '../../lib/entityTarget.mjs'
+import { setPersonalBlock } from '../../personalBlock.mjs'
+import { commitTimelineEvent } from '../../timeline/append.mjs'
+import { syncTimelineForEntity } from '../../timeline/sync.mjs'
+import { autoApproveFollower } from '../../vault_crypto/followApprove.mjs'
+import { buildFollowApprovePayload } from '../../vault_crypto/vault.mjs'
+
+import { normalizeTarget, requireKnownTarget } from './helpers.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} 关注 / 拉黑 / 隐藏 / 静音方法
+ */
+export function createFollowMethods(apiContext) {
+	return {
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async follow(target) {
+			return setFollowRelation(apiContext, target, true)
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async unfollow(target) {
+			return setFollowRelation(apiContext, target, false)
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async block(target) {
+			return setBlockRelation(apiContext, target, true)
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async unblock(target) {
+			return setBlockRelation(apiContext, target, false)
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async hide(target) {
+			const hash = await requireKnownTarget(apiContext, target)
+			const hidden = await setPersonalHidden(apiContext.entityHash, hash, true)
+			return { entityHash: hash, hidden }
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async unhide(target) {
+			const hash = await requireKnownTarget(apiContext, target)
+			const hidden = await setPersonalHidden(apiContext.entityHash, hash, false)
+			return { entityHash: hash, hidden }
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async mute(target) {
+			const hash = await requireKnownTarget(apiContext, target)
+			await setPersonalMuted(apiContext.entityHash, hash, true)
+			return { entityHash: hash, muted: true }
+		},
+		/**
+		 * @param {string} target 目标 entityHash
+		 * @returns {Promise<object>} 关系结果
+		 */
+		async unmute(target) {
+			const hash = await requireKnownTarget(apiContext, target)
+			await setPersonalMuted(apiContext.entityHash, hash, false)
+			return { entityHash: hash, muted: false }
+		},
+		/**
+		 * @param {string} follower 关注者 Ed25519 pubKeyHex
+		 * @returns {Promise<object>} follow_approve 事件
+		 */
+		async approveFollow(follower) {
+			const followerPubKeyHex = String(follower)
+			const payload = await buildFollowApprovePayload(apiContext.username, apiContext.entityHash, followerPubKeyHex)
+			return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+				type: 'follow_approve',
+				content: payload,
+			})
+		},
+	}
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext 上下文
+ * @param {string} target 目标
+ * @param {boolean} follow 关注/取关
+ * @returns {Promise<object>} 关系结果
+ */
+async function setFollowRelation(apiContext, target, follow) {
+	const hash = normalizeTarget(target)
+	await setFollow(apiContext.username, apiContext.entityHash, hash, follow)
+	if (follow) {
+		await dispatchFollowEvent(apiContext.username, apiContext.entityHash, hash)
+		const targetEntity = await resolveSocialEntity(hash)
+		if (targetEntity?.local && targetEntity.replicaUsername) {
+			const followerPubKeyHex = await getEntityActivePubKey(apiContext.username, apiContext.entityHash)
+			if (followerPubKeyHex)
+				await autoApproveFollower(targetEntity.replicaUsername, hash, followerPubKeyHex)
+		}
+		await syncTimelineForEntity(apiContext.username, hash)
+	}
+	return { entityHash: hash, isFollowing: follow }
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext 上下文
+ * @param {string} target 目标
+ * @param {boolean} block 拉黑/解除
+ * @returns {Promise<object>} 关系结果
+ */
+async function setBlockRelation(apiContext, target, block) {
+	const hash = normalizeTarget(target)
+	if (!await isKnownSocialTarget(apiContext.username, hash))
+		throw httpError(400, 'unknown entity')
+	await ensureEntitySocialReady(apiContext.username, apiContext.entityHash)
+	await setPersonalBlock(apiContext.username, apiContext.entityHash, hash, block)
+	return { entityHash: hash, blocked: block }
+}

--- a/src/public/parts/shells/social/src/api/client/helpers.mjs
+++ b/src/public/parts/shells/social/src/api/client/helpers.mjs
@@ -1,0 +1,38 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { httpError } from '../../../../../../../scripts/http_error.mjs'
+import { isKnownSocialTarget } from '../../lib/entityTarget.mjs'
+
+/**
+ * @typedef {{ username: string, entityHash: string, charPartName?: string }} SocialApiContext
+ */
+
+/**
+ * @param {SocialApiContext} apiContext API 上下文
+ * @returns {() => { viewerEntityHash: string }} 读侧观看者选项工厂
+ */
+export function makeViewerOptions(apiContext) {
+	return () => ({ viewerEntityHash: apiContext.entityHash })
+}
+
+/**
+ * @param {string} target 目标
+ * @returns {string} 规范化 entityHash
+ */
+export function normalizeTarget(target) {
+	const hash = String(target || '').toLowerCase()
+	if (!isEntityHash128(hash)) throw httpError(400, 'invalid entityHash')
+	return hash
+}
+
+/**
+ * @param {SocialApiContext} apiContext 上下文
+ * @param {string} target 目标
+ * @returns {Promise<string>} 已知社交目标 entityHash
+ */
+export async function requireKnownTarget(apiContext, target) {
+	const hash = normalizeTarget(target)
+	if (!await isKnownSocialTarget(apiContext.username, hash))
+		throw httpError(400, 'unknown entity')
+	return hash
+}

--- a/src/public/parts/shells/social/src/api/client/index.mjs
+++ b/src/public/parts/shells/social/src/api/client/index.mjs
@@ -1,0 +1,70 @@
+import { httpError } from '../../../../../../../scripts/http_error.mjs'
+import { resolveOperatorEntityHashForUser } from '../../../../chat/src/entity/identity.mjs'
+import { resolveSocialEntity } from '../../federation/hosting.mjs'
+
+import { createAlbumsMethods } from './albums.mjs'
+import { createDraftsMethods } from './drafts.mjs'
+import { createFeedMethods } from './feed.mjs'
+import { createFollowMethods } from './follow.mjs'
+import { createLiveMethods } from './live.mjs'
+import { createNotificationsMethods } from './notifications.mjs'
+import { createPostsMethods } from './posts.mjs'
+import { createProfileMethods } from './profile.mjs'
+import { createSavedMethods } from './saved.mjs'
+import { createTasteMethods } from './taste.mjs'
+import { createVaultMethods } from './vault.mjs'
+
+/**
+ * 解析 SocialClient 绑定实体：缺省 operator；指定时须为本 username 托管的本地实体。
+ * @param {string} username replica 登录名
+ * @param {string | undefined | null} [entityHash] 缺省 = operator
+ * @returns {Promise<{ entityHash: string, charPartName?: string }>} 绑定实体
+ */
+export async function resolveSocialClientEntity(username, entityHash) {
+	const requested = String(entityHash || '').trim().toLowerCase()
+	if (requested) {
+		const resolved = await resolveSocialEntity(requested, username)
+		if (!resolved?.local || resolved.replicaUsername !== username)
+			throw httpError(403, 'invalid entityHash')
+		return {
+			entityHash: resolved.entityHash,
+			...resolved.charPartName ? { charPartName: resolved.charPartName } : {},
+		}
+	}
+	const operator = await resolveOperatorEntityHashForUser(username)
+	if (!operator)
+		throw httpError(403, 'configure Chat federation identity first (same P2P entity as Social)')
+	return { entityHash: operator }
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} SocialClient 鸭子类型
+ */
+export function createSocialClient(apiContext) {
+	return {
+		entityHash: apiContext.entityHash,
+		...createPostsMethods(apiContext),
+		...createFollowMethods(apiContext),
+		...createFeedMethods(apiContext),
+		...createNotificationsMethods(apiContext),
+		...createLiveMethods(apiContext),
+		...createSavedMethods(apiContext),
+		...createDraftsMethods(apiContext),
+		...createVaultMethods(apiContext),
+		...createTasteMethods(apiContext),
+		...createProfileMethods(apiContext),
+		...createAlbumsMethods(apiContext),
+	}
+}
+
+/**
+ * 获取以指定实体自签的 SocialClient。
+ * @param {string} username replica 登录名
+ * @param {string | undefined | null} [entityHash] 缺省 = operator
+ * @returns {Promise<object>} SocialClient
+ */
+export async function getSocialClient(username, entityHash) {
+	const entity = await resolveSocialClientEntity(username, entityHash)
+	return createSocialClient({ username, ...entity })
+}

--- a/src/public/parts/shells/social/src/api/client/live.mjs
+++ b/src/public/parts/shells/social/src/api/client/live.mjs
@@ -1,0 +1,58 @@
+import { makeViewerOptions } from './helpers.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} 直播方法
+ */
+export function createLiveMethods(apiContext) {
+	const viewerOptions = makeViewerOptions(apiContext)
+	return {
+		/**
+		 * @param {object} draft 开播草稿
+		 * @returns {Promise<object>} live 会话
+		 */
+		async startLive(draft = {}) {
+			const { startLiveSession } = await import('../../live/session.mjs')
+			return startLiveSession(apiContext.username, apiContext.entityHash, draft)
+		},
+		/**
+		 * @param {string} liveId 直播 id
+		 * @returns {Promise<object>} 结束结果
+		 */
+		async stopLive(liveId) {
+			const { stopLiveSession } = await import('../../live/session.mjs')
+			return stopLiveSession(apiContext.username, apiContext.entityHash, liveId)
+		},
+		/**
+		 * @param {{ limit?: number, cursor?: string, scope?: string }} [options] 选项
+		 * @returns {Promise<object>} 在播列表
+		 */
+		async liveFeed(options = {}) {
+			const { buildLiveFeed } = await import('../../live/feed.mjs')
+			options = { ...options, ...viewerOptions() }
+			let result = await buildLiveFeed(apiContext.username, options)
+			if (!options.cursor && !result.items.length && String(options.scope || 'local') !== 'nearby') {
+				const { buildNearbyLiveFeed } = await import('../../live/network.mjs')
+				result = await buildNearbyLiveFeed(apiContext.username, options)
+			}
+			return result
+		},
+		/**
+		 * @param {string} liveId 本端直播
+		 * @param {{ peerEntityHash: string, peerLiveId: string, bridgeOrigin?: string }} target 对端
+		 * @returns {Promise<object>} 连线结果
+		 */
+		async inviteLiveLink(liveId, target = {}) {
+			const { inviteLiveLink } = await import('../../live/link.mjs')
+			return inviteLiveLink(apiContext.username, apiContext.entityHash, liveId, target)
+		},
+		/**
+		 * @param {string} liveId 本端直播
+		 * @returns {Promise<object>} 结果
+		 */
+		async stopLiveLink(liveId) {
+			const { tearDownLiveLink } = await import('../../live/link.mjs')
+			return tearDownLiveLink(apiContext.username, apiContext.entityHash, liveId)
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/notifications.mjs
+++ b/src/public/parts/shells/social/src/api/client/notifications.mjs
@@ -1,0 +1,44 @@
+import { getNotificationsSeenAt, parseNotificationTypesFilter, setNotificationsSeenAt } from '../../inbox.mjs'
+import { buildNotifications } from '../../notifications.mjs'
+
+import { makeViewerOptions } from './helpers.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} 通知方法
+ */
+export function createNotificationsMethods(apiContext) {
+	const viewerOptions = makeViewerOptions(apiContext)
+	return {
+		/**
+		 * @param {{ limit?: number, cursor?: string, types?: string | string[] }} [options] 通知选项
+		 * @returns {Promise<object>} 通知页
+		 */
+		async notifications(options = {}) {
+			const types = Array.isArray(options.types)
+				? options.types
+				: parseNotificationTypesFilter(options.types)
+			return buildNotifications(apiContext.username, {
+				...viewerOptions(),
+				limit: options.limit,
+				cursor: options.cursor,
+				types,
+			})
+		},
+		/**
+		 * @returns {Promise<number>} 已读水位
+		 */
+		async notificationsSeenAt() {
+			return getNotificationsSeenAt(apiContext.username, apiContext.entityHash)
+		},
+		/**
+		 * @param {number} [ts] 水位；缺省 = now
+		 * @returns {Promise<number>} 写入后的水位
+		 */
+		async setNotificationsSeenAt(ts) {
+			const at = Number(ts) || Date.now()
+			setNotificationsSeenAt(apiContext.username, apiContext.entityHash, at)
+			return at
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/posts.mjs
+++ b/src/public/parts/shells/social/src/api/client/posts.mjs
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto'
+
+import { httpError } from '../../../../../../../scripts/http_error.mjs'
+import { primaryLocaleForUser } from '../../../../../../../scripts/locale.mjs'
+import { resolveSocialEntity } from '../../federation/hosting.mjs'
+import { buildPostFeedItem } from '../../feed/buildItem.mjs'
+import { createFeedItemBuildContext } from '../../feed/iterate.mjs'
+import { ensureEntitySocialReady } from '../../lib/bootstrap.mjs'
+import { buildEmojiMediaRefsForPost } from '../../lib/emojiPostEmbed.mjs'
+import { isKnownSocialTarget } from '../../lib/entityTarget.mjs'
+import { sanitizeMediaRefs, resolveSensitiveMedia } from '../../lib/mediaRefs.mjs'
+import { normalizePollDraft } from '../../lib/poll.mjs'
+import {
+	minVisibilitySpec,
+	normalizeVisibilitySpec,
+	visibilitySpecToContentFields,
+} from '../../lib/visibilitySpec.mjs'
+import { commitTimelineEvent } from '../../timeline/append.mjs'
+import { getTimelineMaterialized } from '../../timeline/materialize.mjs'
+import { maybeDecryptPostContent, maybeEncryptPostContent } from '../../vault_crypto/vault.mjs'
+import { pushFeedUpdate } from '../../ws/feedHub.mjs'
+import { createPost } from '../post.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} 发帖 / 取帖 / 定时帖方法
+ */
+export function createPostsMethods(apiContext) {
+	return {
+		/**
+		 * 发帖或按 id 取帖：`post({ text })` → Post；`post(entityHash, postId)` → Post。
+		 * @param {object | string} arg1 发帖草稿或作者 entityHash
+		 * @param {string} [postId] 取帖时的 postId
+		 * @returns {Promise<object>} Post
+		 */
+		async post(arg1, postId) {
+			if (typeof arg1 === 'string')
+				return this.getPost(arg1, postId)
+			return createTimelinePost(apiContext, arg1 || {})
+		},
+		/**
+		 * @param {string} entityHash 作者
+		 * @param {string} id 帖 id
+		 * @returns {Promise<object>} Post
+		 */
+		async getPost(entityHash, id) {
+			const owner = String(entityHash).toLowerCase()
+			const view = await getTimelineMaterialized(apiContext.username, owner)
+			const row = view.postById[String(id)]
+			const content = row
+				? await maybeDecryptPostContent(apiContext.username, owner, row.content, apiContext.entityHash) || row.content
+				: null
+			if (row) {
+				const { pullPostReactions } = await import('../../federation/reaction/pull.mjs')
+				void pullPostReactions(apiContext.username, owner, String(id)).catch(() => null)
+			}
+			return createPost(apiContext, owner, id, { content, event: row || null })
+		},
+		/**
+		 * @returns {Promise<object[]>} 定时发帖列表
+		 */
+		async listScheduledPosts() {
+			const { listScheduledPosts } = await import('../../lib/scheduledPosts.mjs')
+			return listScheduledPosts(apiContext.username, apiContext.entityHash)
+		},
+		/**
+		 * @param {string} scheduledId id
+		 * @returns {Promise<object | null>} 取消项
+		 */
+		async cancelScheduledPost(scheduledId) {
+			const { cancelScheduledPost } = await import('../../lib/scheduledPosts.mjs')
+			const { cancelScheduledPostTimer } = await import('../../lib/scheduledPostWatcher.mjs')
+			const removed = cancelScheduledPost(apiContext.username, apiContext.entityHash, scheduledId)
+			if (removed) cancelScheduledPostTimer(apiContext.username, apiContext.entityHash, scheduledId)
+			return removed
+		},
+	}
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext 上下文
+ * @param {object} draft 发帖草稿
+ * @returns {Promise<object>} Post
+ */
+async function createTimelinePost(apiContext, draft) {
+	await ensureEntitySocialReady(apiContext.username, apiContext.entityHash)
+	const resolved = await resolveSocialEntity(apiContext.entityHash, apiContext.username)
+	const charPartName = draft.charPartName
+		|| apiContext.charPartName
+		|| (resolved?.kind === 'agent' ? resolved.charPartName : null)
+
+	const publishAt = draft.publishAt != null ? Number(draft.publishAt) : NaN
+	if (Number.isFinite(publishAt) && publishAt > Date.now()) {
+		const { enqueueScheduledPost } = await import('../../lib/scheduledPosts.mjs')
+		const { scheduleOneScheduledPost } = await import('../../lib/scheduledPostWatcher.mjs')
+		const storedDraft = { ...draft }
+		delete storedDraft.publishAt
+		const row = enqueueScheduledPost(apiContext.username, apiContext.entityHash, storedDraft, publishAt)
+		scheduleOneScheduledPost(apiContext.username, apiContext.entityHash, row)
+		return { scheduled: true, scheduledId: row.scheduledId, publishAt: row.publishAt }
+	}
+
+	const albumIds = [...new Set(
+		(Array.isArray(draft.albumIds) ? draft.albumIds : [])
+			.map(id => String(id || '').trim())
+			.filter(id => id && id !== 'default'),
+	)]
+	let visibilitySpec = normalizeVisibilitySpec(draft)
+	if (albumIds.length) {
+		const view = await getTimelineMaterialized(apiContext.username, apiContext.entityHash)
+		const albumSpecs = []
+		for (const albumId of albumIds) {
+			const album = view.albums?.[albumId]
+			if (!album) throw httpError(400, `unknown album: ${albumId}`)
+			albumSpecs.push(album)
+		}
+		visibilitySpec = minVisibilitySpec(albumSpecs) || visibilitySpec
+	}
+	const { normalizeReplyPolicy, normalizeReplyDisplay, canReplyUnderPolicy, loadPostReplyGate } = await import('../../lib/replyPolicy.mjs')
+	const replyPolicy = normalizeReplyPolicy(draft.replyPolicy)
+	const replyDisplay = normalizeReplyDisplay(draft.replyDisplay)
+
+	if (draft.replyTo?.entityHash && draft.replyTo?.postId) {
+		const targetOwner = String(draft.replyTo.entityHash).toLowerCase()
+		if (!await isKnownSocialTarget(apiContext.username, targetOwner))
+			throw httpError(400, 'unknown entity')
+		const gate = await loadPostReplyGate(apiContext.username, targetOwner, String(draft.replyTo.postId))
+		if (!gate) throw httpError(404, 'reply target not found')
+		const allowed = await canReplyUnderPolicy({
+			username: apiContext.username,
+			authorEntityHash: targetOwner,
+			replierEntityHash: apiContext.entityHash,
+			replyPolicy: gate.replyPolicy,
+		})
+		if (!allowed) throw httpError(403, 'reply not allowed by author policy')
+	}
+
+	const draftContent = {
+		text: String(draft.text ?? ''),
+		mediaRefs: sanitizeMediaRefs([
+			...draft.mediaRefs ?? [],
+			...await buildEmojiMediaRefsForPost(apiContext.username, String(draft.text ?? '')),
+		]),
+		replyTo: draft.replyTo,
+		quoteRef: draft.quoteRef,
+		groupRef: draft.groupRef,
+		locale: draft.locale || primaryLocaleForUser(apiContext.username),
+		...visibilitySpecToContentFields(visibilitySpec),
+		...replyPolicy !== 'everyone' ? { replyPolicy } : {},
+		...replyDisplay !== 'all' ? { replyDisplay } : {},
+		...draft.contentWarning ? { contentWarning: String(draft.contentWarning).trim().slice(0, 200) } : {},
+		...resolveSensitiveMedia(draft.sensitiveMedia, draft.contentWarning) ? { sensitiveMedia: true } : {},
+	}
+	if (Array.isArray(draft.tags)) {
+		const tags = [...new Set(draft.tags.map(t => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 16)
+		if (tags.length) draftContent.tags = tags
+	}
+	if (draft.poll)
+		draftContent.poll = normalizePollDraft(draft.poll)
+
+	const signed = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+		type: 'post',
+		charPartName,
+		content: await maybeEncryptPostContent(
+			apiContext.username,
+			apiContext.entityHash,
+			randomUUID(),
+			draftContent,
+			visibilitySpec,
+		),
+	})
+	for (const albumId of albumIds) 
+		await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+			type: 'album_post_add',
+			content: { albumId, postId: signed.id },
+		})
+	
+	const itemContext = await createFeedItemBuildContext(apiContext.username, new Set([apiContext.entityHash]), apiContext.entityHash)
+	const item = await buildPostFeedItem(apiContext.username, apiContext.entityHash, { ...signed, postId: signed.id }, itemContext)
+	pushFeedUpdate(apiContext.username, { type: 'post', item })
+	return createPost(apiContext, apiContext.entityHash, signed.id, { event: signed, content: draftContent })
+}

--- a/src/public/parts/shells/social/src/api/client/profile.mjs
+++ b/src/public/parts/shells/social/src/api/client/profile.mjs
@@ -1,0 +1,180 @@
+import {
+	loadPersonalBlockEntries,
+	loadPersonalHideEntries,
+} from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { listKnownFollowersOf } from '../../federation/follower/index.mjs'
+import { buildLikedFeedItems, buildProfileFeedItems, buildSinglePostFeedItem, listReplies } from '../../feed/home.mjs'
+import { loadFollowingForActor } from '../../following.mjs'
+import { createAuthorProfileLoader } from '../../lib/authorProfileSummary.mjs'
+import { ensureEntitySocialReady } from '../../lib/bootstrap.mjs'
+import { getEntityProfile } from '../../lib/entityProfile.mjs'
+import { loadMutedKeywords, replaceMutedKeywords } from '../../mutedKeywords.mjs'
+import { updateSocialMeta } from '../../socialMeta.mjs'
+import { getTimelineMaterialized } from '../../timeline/materialize.mjs'
+
+import { makeViewerOptions } from './helpers.mjs'
+
+/**
+ * 物化 following 去掉自引用后的计数。
+ * @param {string[]} following 关注列表
+ * @param {string} entityHash 主体
+ * @returns {number} 计数
+ */
+function countFollowing(following, entityHash) {
+	const self = entityHash.toLowerCase()
+	return (following || []).filter(hash => String(hash).toLowerCase() !== self).length
+}
+
+/**
+ * @param {string} username replica
+ * @param {Iterable<string>} hashes 实体列表
+ * @param {string} [skip] 跳过的 hash（通常是资料主体）
+ * @returns {Promise<object[]>} { entityHash, profile }[]
+ */
+async function entitiesWithProfiles(username, hashes, skip = '') {
+	const loadProfile = createAuthorProfileLoader(username)
+	const self = String(skip || '').toLowerCase()
+	const seen = new Set()
+	const rows = []
+	for (const hash of hashes) {
+		const id = String(hash || '').toLowerCase()
+		if (!id || id === self || seen.has(id)) continue
+		seen.add(id)
+		rows.push({ entityHash: id, profile: await loadProfile(id) })
+	}
+	return rows
+}
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {object} 资料 / 列表 / 屏蔽词方法
+ */
+export function createProfileMethods(apiContext) {
+	const viewerOptions = makeViewerOptions(apiContext)
+	return {
+		/**
+		 * @param {{ hideFromDiscovery?: boolean }} patch meta 补丁
+		 * @returns {Promise<object>} 更新后的 socialMeta
+		 */
+		async updateMeta(patch = {}) {
+			await ensureEntitySocialReady(apiContext.username, apiContext.entityHash)
+			return updateSocialMeta(apiContext.username, apiContext.entityHash, patch)
+		},
+		/**
+		 * @param {string} entityHash 目标实体
+		 * @returns {Promise<object>} 资料卡
+		 */
+		async profile(entityHash) {
+			const hash = String(entityHash).toLowerCase()
+			const profile = await getEntityProfile(apiContext.username, hash)
+			const view = await getTimelineMaterialized(apiContext.username, hash)
+			const { following } = await loadFollowingForActor(apiContext.username, apiContext.entityHash)
+			const knownFollowers = await listKnownFollowersOf(hash)
+			return {
+				entityHash: hash,
+				profile,
+				postCount: view.posts.length,
+				followingCount: countFollowing(view.following || [], hash),
+				followerCount: knownFollowers.length,
+				isFollowing: following.includes(hash),
+				socialMeta: view.socialMeta,
+			}
+		},
+		/**
+		 * @param {string} entityHash 目标实体
+		 * @param {{ limit?: number, cursor?: string }} [options] 分页
+		 * @returns {Promise<object>} 时间线帖
+		 */
+		async profilePosts(entityHash, options = {}) {
+			return buildProfileFeedItems(apiContext.username, String(entityHash).toLowerCase(), { ...options, ...viewerOptions() })
+		},
+		/**
+		 * @param {string} entityHash 目标实体
+		 * @returns {Promise<object>} 点赞流
+		 */
+		async profileLikes(entityHash) {
+			return buildLikedFeedItems(apiContext.username, String(entityHash).toLowerCase(), viewerOptions())
+		},
+		/**
+		 * @param {string} entityHash 目标实体
+		 * @returns {Promise<{ following: object[] }>} 关注列表（含资料摘要）
+		 */
+		async profileFollowing(entityHash) {
+			const owner = String(entityHash).toLowerCase()
+			const view = await getTimelineMaterialized(apiContext.username, owner)
+			return { following: await entitiesWithProfiles(apiContext.username, view.following || [], owner) }
+		},
+		/**
+		 * @param {string} entityHash 目标实体
+		 * @returns {Promise<{ followers: object[] }>} 已知粉丝列表（含资料摘要）
+		 */
+		async profileFollowers(entityHash) {
+			const owner = String(entityHash).toLowerCase()
+			const known = await listKnownFollowersOf(owner)
+			return {
+				followers: await entitiesWithProfiles(
+					apiContext.username,
+					known.map(row => row.entityHash),
+					owner,
+				),
+			}
+		},
+		/**
+		 * @param {string} entityHash 作者
+		 * @param {string} postId 帖 id
+		 * @returns {Promise<object | null>} 单帖 feed item
+		 */
+		async postFeedItem(entityHash, postId) {
+			return buildSinglePostFeedItem(
+				apiContext.username,
+				String(entityHash).toLowerCase(),
+				String(postId),
+				viewerOptions(),
+			)
+		},
+		/**
+		 * @param {string} entityHash 作者
+		 * @param {string} postId 帖 id
+		 * @returns {Promise<{ replies: object[] }>} 回复列表
+		 */
+		async profileReplies(entityHash, postId) {
+			return {
+				replies: await listReplies(apiContext.username, String(entityHash).toLowerCase(), String(postId), viewerOptions()),
+			}
+		},
+		/**
+		 * @returns {Promise<{ entries: object[] }>} 本实体 block/hide 列表
+		 */
+		async personalLists() {
+			const [blockedEntries, hiddenEntries] = await Promise.all([
+				loadPersonalBlockEntries(apiContext.entityHash),
+				loadPersonalHideEntries(apiContext.entityHash),
+			])
+			return {
+				entries: [
+					...blockedEntries.map(entry => ({ ...entry, kind: 'block' })),
+					...hiddenEntries.map(entry => ({ ...entry, kind: 'hide' })),
+				],
+			}
+		},
+		/**
+		 * 本地关键词/标签屏蔽（不联邦）。
+		 */
+		mutedKeywords: {
+			/**
+			 * @returns {Promise<{ entries: object[] }>} 屏蔽词表
+			 */
+			async list() {
+				return loadMutedKeywords(apiContext.username, apiContext.entityHash)
+			},
+			/**
+			 * @param {object[]} entries 条目
+			 * @returns {Promise<{ entries: object[] }>} 写入结果
+			 */
+			async replace(entries) {
+				return replaceMutedKeywords(apiContext.username, apiContext.entityHash, entries)
+			},
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/saved.mjs
+++ b/src/public/parts/shells/social/src/api/client/saved.mjs
@@ -1,0 +1,73 @@
+import {
+	addSavedPost,
+	createSavedFolder,
+	deleteSavedFolder,
+	enrichSavedPosts,
+	loadSavedPosts,
+	removeSavedPost,
+	renameSavedFolder,
+	searchSavedPosts,
+} from '../../savedPosts.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {{ saved: object }} 收藏命名空间
+ */
+export function createSavedMethods(apiContext) {
+	return {
+		saved: {
+			/**
+			 * @returns {Promise<object>} 收藏结构（含预览）
+			 */
+			async list() {
+				return enrichSavedPosts(apiContext.username, await loadSavedPosts(apiContext.username, apiContext.entityHash))
+			},
+			/**
+			 * @param {{ entityHash: string, postId: string }} ref 帖引用
+			 * @param {string | null} [folderId] 文件夹
+			 * @returns {Promise<object>} 写入后结构
+			 */
+			async add(ref, folderId = null) {
+				return addSavedPost(apiContext.username, apiContext.entityHash, ref, folderId)
+			},
+			/**
+			 * @param {{ entityHash: string, postId: string }} ref 帖引用
+			 * @param {string} [folderId] 文件夹；省略则全局移除
+			 * @returns {Promise<object>} 写入后结构
+			 */
+			async remove(ref, folderId) {
+				return removeSavedPost(apiContext.username, apiContext.entityHash, ref, folderId)
+			},
+			/**
+			 * @param {string} name 文件夹名
+			 * @returns {Promise<object>} 写入后结构
+			 */
+			async createFolder(name) {
+				return createSavedFolder(apiContext.username, apiContext.entityHash, name)
+			},
+			/**
+			 * @param {string} folderId 文件夹 id
+			 * @param {string} name 新名
+			 * @returns {Promise<object>} 写入后结构
+			 */
+			async renameFolder(folderId, name) {
+				return renameSavedFolder(apiContext.username, apiContext.entityHash, folderId, name)
+			},
+			/**
+			 * @param {string} folderId 文件夹 id
+			 * @returns {Promise<object>} 写入后结构
+			 */
+			async deleteFolder(folderId) {
+				return deleteSavedFolder(apiContext.username, apiContext.entityHash, folderId)
+			},
+			/**
+			 * @param {string} query 搜索串
+			 * @param {{ limit?: number }} [options] 选项
+			 * @returns {Promise<object>} 匹配收藏
+			 */
+			async search(query, options = {}) {
+				return searchSavedPosts(apiContext.username, apiContext.entityHash, query, options)
+			},
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/taste.mjs
+++ b/src/public/parts/shells/social/src/api/client/taste.mjs
@@ -1,0 +1,87 @@
+import { primaryLocaleForUser } from '../../../../../../../scripts/locale.mjs'
+import { rebuildTaste } from '../../taste/cluster.mjs'
+import { revokeTasteAlias } from '../../taste/mergeClaims.mjs'
+import { listTasteTags, publishTagName } from '../../taste/nameClaims.mjs'
+import { collapseTasteWeights, loadTaste, mutateTaste } from '../../taste/store.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {{ taste: object }} taste 命名空间
+ */
+export function createTasteMethods(apiContext) {
+	return {
+		taste: {
+			/**
+			 * @param {{ locale?: string }} [options] 选项
+			 * @returns {Promise<object>} 偏好与标签列表
+			 */
+			async get(options = {}) {
+				const locale = String(options.locale || primaryLocaleForUser(apiContext.username))
+				const store = await loadTaste(apiContext.username, apiContext.entityHash)
+				const tags = await listTasteTags(apiContext.username, apiContext.entityHash, locale)
+				return {
+					privacy: store.privacy,
+					clusteredAt: store.clusteredAt,
+					aliases: store.aliases,
+					tags,
+				}
+			},
+			/**
+			 * @param {{ privacy?: { publishPreferences?: boolean, publishReactions?: boolean }, tags?: Record<string, number> }} patch 补丁
+			 * @returns {Promise<object>} 更新后偏好摘要
+			 */
+			async update(patch = {}) {
+				const store = await mutateTaste(apiContext.username, apiContext.entityHash, draft => {
+					if (patch.privacy && typeof patch.privacy === 'object')
+						draft.privacy = {
+							publishPreferences: patch.privacy.publishPreferences !== false,
+							publishReactions: patch.privacy.publishReactions !== false,
+						}
+					if (patch.tags && typeof patch.tags === 'object')
+						for (const [tag, weight] of Object.entries(patch.tags)) {
+							const key = String(tag).trim().toLowerCase()
+							if (!key) continue
+							const value = Number(weight)
+							if (!Number.isFinite(value)) continue
+							if (value === 0) delete draft.manual[key]
+							else draft.manual[key] = value
+						}
+					return draft
+				})
+				return {
+					privacy: store.privacy,
+					computed: store.computed,
+					manual: store.manual,
+					aliases: store.aliases,
+					tagCount: collapseTasteWeights(store).size,
+				}
+			},
+			/**
+			 * @returns {Promise<object>} 重建结果
+			 */
+			async rebuild() {
+				const store = await rebuildTaste(apiContext.username, apiContext.entityHash)
+				return {
+					clusteredAt: store.clusteredAt,
+					tagCount: collapseTasteWeights(store).size,
+				}
+			},
+			/**
+			 * @param {{ tagHash: string, label: string, locale?: string }} input 命名
+			 * @returns {Promise<object>} 命名事件
+			 */
+			async setName(input) {
+				const event = await publishTagName(apiContext.username, apiContext.entityHash, input)
+				return { event }
+			},
+			/**
+			 * @param {string} fromTag 源 tag
+			 * @returns {Promise<object>} 别名表
+			 */
+			async revokeAlias(fromTag) {
+				const store = await revokeTasteAlias(apiContext.username, apiContext.entityHash, fromTag)
+				return { aliases: store.aliases }
+			},
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/client/vault.mjs
+++ b/src/public/parts/shells/social/src/api/client/vault.mjs
@@ -1,0 +1,41 @@
+import { getVaultFileByShareId, registerVaultFile } from '../../socialVaultIndex.mjs'
+import { commitTimelineEvent } from '../../timeline/append.mjs'
+
+/**
+ * @param {import('./helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {{ vault: object }} vault 命名空间
+ */
+export function createVaultMethods(apiContext) {
+	return {
+		vault: {
+			/**
+			 * @param {object} manifest 文件清单
+			 * @returns {Promise<{ entry: object, event: object }>} 注册结果
+			 */
+			async registerFile(manifest) {
+				const entry = await registerVaultFile(apiContext.username, apiContext.entityHash, manifest)
+				const event = await commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+					type: 'file_share',
+					content: {
+						shareId: entry.shareId,
+						fileId: entry.fileId,
+						name: entry.name,
+						mimeType: entry.mimeType,
+						size: entry.size,
+						visibility: entry.visibility,
+					},
+				}, { fanout: false })
+				return { entry, event }
+			},
+			/**
+			 * @param {string} shareId 分享 id
+			 * @param {string} [ownerEntityHash] 缺省 = 本实体
+			 * @returns {Promise<object | null>} vault 索引项
+			 */
+			async getFile(shareId, ownerEntityHash) {
+				const owner = String(ownerEntityHash || apiContext.entityHash).toLowerCase()
+				return getVaultFileByShareId(apiContext.username, owner, String(shareId))
+			},
+		},
+	}
+}

--- a/src/public/parts/shells/social/src/api/post.mjs
+++ b/src/public/parts/shells/social/src/api/post.mjs
@@ -1,0 +1,230 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { primaryLocaleForUser } from '../../../../../../scripts/locale.mjs'
+import { getEntityProfile } from '../lib/entityProfile.mjs'
+import { isKnownSocialTarget } from '../lib/entityTarget.mjs'
+import { sanitizeMediaRefs, resolveSensitiveMedia } from '../lib/mediaRefs.mjs'
+import { assertPollVoteAllowed } from '../lib/poll.mjs'
+import { loadTaste } from '../taste/store.mjs'
+import { commitTimelineEvent } from '../timeline/append.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { maybeDecryptPostContent, maybeEncryptPostContent } from '../vault_crypto/vault.mjs'
+
+/**
+ * @param {import('./client/helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @returns {Promise<boolean>} 是否公开反应
+ */
+async function shouldPublishReactions(apiContext) {
+	const taste = await loadTaste(apiContext.username, apiContext.entityHash)
+	return taste.privacy.publishReactions !== false
+}
+
+/**
+ * @param {import('./client/helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @param {string} type 事件类型
+ * @param {string} owner 帖作者
+ * @param {string} id 帖 id
+ * @returns {Promise<object>} 签名事件
+ */
+async function commitReaction(apiContext, type, owner, id) {
+	await assertKnownPostTarget(apiContext, owner)
+	const fanout = await shouldPublishReactions(apiContext)
+	return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+		type,
+		content: { targetEntityHash: owner, targetPostId: id },
+	}, { fanout })
+}
+
+/**
+ * 构造绑定到某帖的 Post 鸭子类型。
+ * @param {import('./client/helpers.mjs').SocialApiContext} apiContext API 上下文
+ * @param {string} entityHash 帖作者 entityHash
+ * @param {string} postId 帖 id
+ * @param {object} [snapshot] 可选已知快照（event / content）
+ * @returns {object} Post
+ */
+export function createPost(apiContext, entityHash, postId, snapshot = null) {
+	const owner = String(entityHash).toLowerCase()
+	const id = String(postId)
+
+	return {
+		entityHash: owner,
+		postId: id,
+		event: snapshot?.event || null,
+		content: snapshot?.content || null,
+		/**
+		 * @returns {Promise<object>} like 事件
+		 */
+		async like() {
+			return commitReaction(apiContext, 'like', owner, id)
+		},
+		/**
+		 * @returns {Promise<object>} unlike 事件
+		 */
+		async unlike() {
+			return commitReaction(apiContext, 'unlike', owner, id)
+		},
+		/**
+		 * @returns {Promise<object>} dislike 事件（与 like 互斥，reducer 侧清 like）
+		 */
+		async dislike() {
+			return commitReaction(apiContext, 'dislike', owner, id)
+		},
+		/**
+		 * @returns {Promise<object>} undislike 事件
+		 */
+		async undislike() {
+			return commitReaction(apiContext, 'undislike', owner, id)
+		},
+		/**
+		 * @param {string} [comment] 转发附言
+		 * @returns {Promise<object>} repost 事件
+		 */
+		async repost(comment = '') {
+			await assertKnownPostTarget(apiContext, owner)
+			return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+				type: 'repost',
+				content: {
+					targetEntityHash: owner,
+					targetPostId: id,
+					comment: String(comment || ''),
+				},
+			})
+		},
+		/**
+		 * 编辑帖子：作者自签，或作者所属主人以自身钥签到作者时间线。
+		 * @param {{ text?: string, mediaRefs?: object[], locale?: string, contentWarning?: string }} patch 编辑补丁
+		 * @returns {Promise<object>} post_edit 事件
+		 */
+		async edit(patch = {}) {
+			const view = await getTimelineMaterialized(apiContext.username, owner)
+			const post = view.postById[id]
+			if (!post) throw httpError(404, 'post not found')
+			const signerOpts = await resolveOwnerContentSigner(apiContext, owner)
+			const decrypted = await maybeDecryptPostContent(apiContext.username, owner, post.content) || post.content || {}
+			const visibility = decrypted.visibility || post.content?.visibility || 'public'
+			const draftContent = {
+				targetPostId: id,
+				text: String(patch.text ?? decrypted.text ?? ''),
+				mediaRefs: sanitizeMediaRefs(patch.mediaRefs ?? decrypted.mediaRefs),
+				locale: patch.locale || decrypted.locale || primaryLocaleForUser(apiContext.username),
+				...patch.contentWarning !== undefined
+					? { contentWarning: String(patch.contentWarning).trim().slice(0, 200) }
+					: decrypted.contentWarning ? { contentWarning: decrypted.contentWarning } : {},
+				...resolveSensitiveMedia(
+					patch.sensitiveMedia !== undefined ? patch.sensitiveMedia : decrypted.sensitiveMedia,
+					patch.contentWarning !== undefined ? patch.contentWarning : decrypted.contentWarning,
+				) ? { sensitiveMedia: true } : {},
+			}
+			return commitTimelineEvent(apiContext.username, owner, {
+				type: 'post_edit',
+				content: await maybeEncryptPostContent(apiContext.username, owner, id, draftContent, visibility),
+			}, signerOpts)
+		},
+		/**
+		 * 删除帖子：作者自签，或作者所属主人以自身钥签到作者时间线。
+		 * @returns {Promise<object>} post_delete 事件
+		 */
+		async delete() {
+			const view = await getTimelineMaterialized(apiContext.username, owner)
+			if (!view.postById[id]) throw httpError(404, 'post not found')
+			const signerOpts = await resolveOwnerContentSigner(apiContext, owner)
+			return commitTimelineEvent(apiContext.username, owner, {
+				type: 'post_delete',
+				content: { targetPostId: id },
+			}, signerOpts)
+		},
+		/**
+		 * @param {number[]} optionIds 投票选项下标
+		 * @returns {Promise<object>} poll_vote 事件
+		 */
+		async pollVote(optionIds) {
+			await assertKnownPostTarget(apiContext, owner)
+			const choices = await assertPollVoteAllowed(apiContext.username, owner, id, optionIds)
+			return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+				type: 'poll_vote',
+				content: { targetEntityHash: owner, targetPostId: id, choices },
+			})
+		},
+		/**
+		 * @param {string} text 补充正文
+		 * @returns {Promise<object>} post_note 事件
+		 */
+		async addNote(text) {
+			await assertKnownPostTarget(apiContext, owner)
+			const cleaned = String(text || '').trim().slice(0, 2000)
+			if (!cleaned) throw httpError(400, 'note text required')
+			return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+				type: 'post_note',
+				content: { targetEntityHash: owner, targetPostId: id, text: cleaned },
+			})
+		},
+		/**
+		 * @param {string} noteEventId 补充事件 id
+		 * @param {boolean} helpful 是否有用
+		 * @returns {Promise<object>} note_vote 事件
+		 */
+		async voteNote(noteEventId, helpful) {
+			await assertKnownPostTarget(apiContext, owner)
+			const noteId = String(noteEventId || '').trim().toLowerCase()
+			if (!noteId) throw httpError(400, 'noteEventId required')
+			return commitTimelineEvent(apiContext.username, apiContext.entityHash, {
+				type: 'note_vote',
+				content: {
+					targetEntityHash: owner,
+					targetPostId: id,
+					noteEventId: noteId,
+					helpful: helpful === true,
+				},
+			})
+		},
+		/**
+		 * @returns {Promise<{ notes: object[], topNote: object | null }>} 补充信息汇总
+		 */
+		async notes() {
+			const { summarizeNotes } = await import('../federation/note/index.mjs')
+			const { pullPostNotes } = await import('../federation/note/pull.mjs')
+			await pullPostNotes(apiContext.username, owner, id).catch(() => null)
+			return summarizeNotes(apiContext.username, owner, id)
+		},
+		/**
+		 * 作者精选 / 取消精选回复。
+		 * @param {{ replierEntityHash: string, replyPostId: string, feature?: boolean }} options 选项
+		 * @returns {Promise<object>} 事件
+		 */
+		async featureReply(options = {}) {
+			const signerOpts = await resolveOwnerContentSigner(apiContext, owner)
+			const replierEntityHash = String(options.replierEntityHash || '').trim().toLowerCase()
+			const replyPostId = String(options.replyPostId || '').trim()
+			if (!replierEntityHash || !replyPostId) throw httpError(400, 'replierEntityHash and replyPostId required')
+			return commitTimelineEvent(apiContext.username, owner, {
+				type: options.feature === false ? 'reply_unfeature' : 'reply_feature',
+				content: { targetPostId: id, replierEntityHash, replyPostId },
+			}, signerOpts)
+		},
+	}
+}
+
+/**
+ * @param {import('./client/helpers.mjs').SocialApiContext} apiContext 上下文
+ * @param {string} owner 作者 entityHash
+ * @returns {Promise<void>}
+ */
+async function assertKnownPostTarget(apiContext, owner) {
+	if (!await isKnownSocialTarget(apiContext.username, owner))
+		throw httpError(400, 'unknown entity')
+}
+
+/**
+ * 作者自签 → 空 options；所属主人外签 → `{ signerEntityHash }`。
+ * @param {import('./client/helpers.mjs').SocialApiContext} apiContext 上下文
+ * @param {string} postOwner 帖作者 entityHash
+ * @returns {Promise<{ signerEntityHash?: string }>} commit 选项
+ */
+async function resolveOwnerContentSigner(apiContext, postOwner) {
+	if (apiContext.entityHash === postOwner) return {}
+	const profile = await getEntityProfile(apiContext.username, postOwner)
+	const ownerEntity = String(profile?.ownerEntityHash || '').trim().toLowerCase()
+	if (!ownerEntity || ownerEntity !== apiContext.entityHash)
+		throw httpError(403, 'can only manage own posts or owned entity posts')
+	return { signerEntityHash: apiContext.entityHash }
+}

--- a/src/public/parts/shells/social/src/discover/local.mjs
+++ b/src/public/parts/shells/social/src/discover/local.mjs
@@ -1,0 +1,123 @@
+import { formatHashShort } from 'fount/public/parts/shells/chat/public/shared/entityHash.mjs'
+import { customProfileAvatar } from 'fount/public/parts/shells/chat/public/shared/hashAvatar.mjs'
+
+import { getProfile } from '../../../chat/src/entity/profile.mjs'
+import { isPublicDiscoverable } from '../lib/visibilitySpec.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { listLocalTimelineDirs } from '../timeline/ownerIndex.mjs'
+
+/** 每个 owner 最多纳入探索候选的帖子数（物化视图已按新→旧）。 */
+const POSTS_PER_OWNER = 20
+
+/**
+ * 探索页推荐公开账户（跳过受保护时间线）。
+ * @param {string} username 用户
+ * @param {object} [options] 探索选项
+ * @param {number} [options.n=20] 返回账户数
+ * @param {string} [options.cursor] 分页游标（entityHash）
+ * @param {string | null} [options.nodeHashPrefix] 仅该 nodeHash 托管的 entity；缺省为全部已知 owner
+ * @returns {Promise<{ accounts: object[], nextCursor: string | null }>} 推荐账户
+ */
+export async function discoverAccounts(username, options = {}) {
+	const accountLimit = Math.min(Math.max(Number(options.n) || 20, 1), 100)
+	const cursor = (options.cursor || '').toLowerCase()
+	const nodeHashPrefix = (options.nodeHashPrefix || '').trim().toLowerCase() || null
+	const owners = await listLocalTimelineDirs(username, { nodeHashPrefix })
+	const start = cursor ? Math.max(0, owners.indexOf(cursor) + 1) : 0
+	const slice = owners.slice(start, start + accountLimit)
+	/** @type {object[]} */
+	const accounts = []
+	for (const entityHash of slice) {
+		const view = await getTimelineMaterialized(username, entityHash)
+		if (view.socialMeta?.hideFromDiscovery) continue
+		if (!view.posts?.length && !view.socialMeta?.createdAt) continue
+		const profile = await getProfile(entityHash, username)
+		const bio = String(profile?.description_markdown || profile?.description || profile?.bio || '')
+			.trim()
+			.slice(0, 160)
+		accounts.push({
+			entityHash,
+			name: profile?.name || formatHashShort(entityHash, { headLen: 8, tailLen: 0, ellipsis: false }),
+			handle: profile?.handle || '',
+			bio,
+			avatarUrl: customProfileAvatar(profile) || null,
+		})
+	}
+	const nextIndex = start + slice.length
+	return {
+		accounts,
+		nextCursor: nextIndex < owners.length ? owners[nextIndex] : null,
+	}
+}
+
+/**
+ * @param {string} username 用户
+ * @param {object} [options] 探索选项
+ * @param {number} [options.n=20] 返回帖子数
+ * @param {boolean} [options.mediaOnly=false] 仅含媒体
+ * @param {string | null} [options.nodeHashPrefix] 仅该 nodeHash 托管的 entity；缺省为全部已知 owner
+ * @returns {Promise<{ posts: object[] }>} 按时间新→旧的公开帖
+ */
+export async function discoverPosts(username, options = {}) {
+	const postLimit = Math.min(Math.max(Number(options.n) || 20, 1), 100)
+	const mediaOnly = Boolean(options.mediaOnly)
+	const nodeHashPrefix = (options.nodeHashPrefix || '').trim().toLowerCase() || null
+	const owners = await listLocalTimelineDirs(username, { nodeHashPrefix })
+	/** @type {object[]} */
+	const posts = []
+
+	for (const entityHash of owners) {
+		const view = await getTimelineMaterialized(username, entityHash)
+		if (view.socialMeta?.hideFromDiscovery) continue
+		const profile = await getProfile(entityHash, username)
+		const authorProfile = {
+			name: profile?.name || null,
+			handle: profile?.handle || '',
+			avatar: customProfileAvatar(profile) || null,
+		}
+		let taken = 0
+		for (const post of view.posts) {
+			if (!isPublicDiscoverable(post.content)) continue
+			if (mediaOnly && !post.content?.mediaRefs?.length) continue
+			posts.push({
+				entityHash,
+				postId: post.id,
+				textSnippet: (post.content?.text || '').slice(0, 280),
+				mediaThumbs: post.content?.mediaRefs?.slice(0, 4) || [],
+				hlc: post.hlc,
+				authorProfile,
+			})
+			if (++taken >= POSTS_PER_OWNER) break
+		}
+	}
+
+	posts.sort((earlier, later) => {
+		const earlierWall = earlier.hlc?.wall || 0
+		const laterWall = later.hlc?.wall || 0
+		if (earlierWall !== laterWall) return laterWall - earlierWall
+		return String(later.postId).localeCompare(String(earlier.postId))
+	})
+
+	return { posts: posts.slice(0, postLimit) }
+}
+
+/**
+ * 读取指定 entity 的 following 列表（本地物化视图；受保护账户对外 RPC 返回空）。
+ * @param {string} username 用户
+ * @param {string} entityHash 目标
+ * @param {{ requesterNodeHash?: string | null }} [ingress] 联邦入站
+ * @returns {Promise<string[]>} 本地可见 following 列表
+ */
+export async function discoverFollowGraph(username, entityHash, ingress = {}) {
+	const id = entityHash.toLowerCase()
+	const view = await getTimelineMaterialized(username, id)
+	if (view.socialMeta?.hideFromDiscovery) {
+		const { getNodeHash } = await import('npm:@steve02081504/fount-p2p/node/identity')
+		const { resolveOperatorEntityHashForUser } = await import('../../../chat/src/entity/identity.mjs')
+		const requesterNode = (ingress.requesterNodeHash || '').trim().toLowerCase()
+		const operator = await resolveOperatorEntityHashForUser(username)
+		const isOwnerRequest = requesterNode === getNodeHash() || operator?.toLowerCase() === id
+		if (!isOwnerRequest) return []
+	}
+	return view.following
+}

--- a/src/public/parts/shells/social/src/discover/network.mjs
+++ b/src/public/parts/shells/social/src/discover/network.mjs
@@ -1,0 +1,37 @@
+import { collectSocialRpcMerged } from '../federation/rpc/wire.mjs'
+import { loadViewerContext } from '../feed/home.mjs'
+
+import { handleSocialRpc } from './rpc.mjs'
+
+/**
+ * 探索页：合并本地 + 邻居 RPC 结果。
+ * @param {string} username 用户
+ * @param {object} rpc RPC 请求体
+ * @param {{ viewerEntityHash?: string | null }} [options] 观看者实体
+ * @returns {Promise<object>} 合并结果
+ */
+export async function discoverWithNetwork(username, rpc, options = {}) {
+	const local = await handleSocialRpc(username, rpc, {})
+	const { data: remote, errors: remoteErrors } = await collectSocialRpcMerged(username, rpc)
+	if (remoteErrors.length)
+		console.warn('social: neighbor RPC errors', { type: rpc.type, count: remoteErrors.length })
+	const merged = { ...local }
+	if (rpc.type === 'social_discover_request') {
+		const accountMap = new Map((local.accounts || []).map(account => [account.entityHash, account]))
+		for (const row of remote)
+			for (const account of row.accounts || [])
+				accountMap.set(account.entityHash, account)
+		const { following } = await loadViewerContext(username, options.viewerEntityHash || null)
+		merged.accounts = [...accountMap.values()]
+			.filter(account => !following.has(String(account.entityHash).toLowerCase()))
+			.slice(0, rpc.n || 20)
+	}
+	if (rpc.type === 'social_post_discover_request') {
+		const postMap = new Map((local.posts || []).map(post => [`${post.entityHash}:${post.postId}`, post]))
+		for (const row of remote)
+			for (const post of row.posts || [])
+				postMap.set(`${post.entityHash}:${post.postId}`, post)
+		merged.posts = [...postMap.values()].slice(0, rpc.n || 20)
+	}
+	return merged
+}

--- a/src/public/parts/shells/social/src/discover/postDiscover.mjs
+++ b/src/public/parts/shells/social/src/discover/postDiscover.mjs
@@ -1,0 +1,80 @@
+/**
+ * 多跳帖文发现 part_query（无查询词，newest-first，带完整签名 event）。
+ */
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { queryNetwork } from 'npm:@steve02081504/fount-p2p/wire/part_query'
+
+import { federatedPostQueryRow, federatedPostRowKey, sanitizeFederatedPostQueryRow } from '../federation/postQueryRow.mjs'
+import { isPublicDiscoverable } from '../lib/visibilitySpec.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { discoverPosts } from './local.mjs'
+
+/**
+ *
+ */
+export const POST_DISCOVER_KIND = 'post_discover'
+
+/**
+ * @param {{ replicaUsername?: string }} inboundContext 入站上下文
+ * @param {unknown} query 查询
+ * @returns {Promise<object[]>} 行
+ */
+export async function localPostDiscoverHandler(inboundContext, query) {
+	const username = String(inboundContext.replicaUsername || '').trim()
+	if (!username) return []
+	const limit = Math.min(Math.max(Number(
+		query && typeof query === 'object' ? /** @type {{ limit?: unknown }} */query.limit : 20,
+	) || 20, 1), 32)
+	const mediaOnly = query && typeof query === 'object'
+		&& /** @type {{ mediaOnly?: unknown }} */query.mediaOnly === true
+	const { posts } = await discoverPosts(username, { n: limit, mediaOnly })
+	const nodeHash = String(getNodeHash() || '').toLowerCase()
+	/** @type {object[]} */
+	const rows = []
+	for (const row of posts) {
+		const entityHash = String(row.entityHash || '').toLowerCase()
+		const postId = String(row.postId || '')
+		if (!entityHash || !postId) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		const post = view.postById?.[postId]
+		if (!post || !isPublicDiscoverable(post.content)) continue
+		const federated = federatedPostQueryRow(post, entityHash, nodeHash)
+		if (federated) rows.push(federated)
+	}
+	return rows
+}
+
+/**
+ * 多跳收集公开帖并返回可 ingest 的条目。
+ * @param {string} username replica
+ * @param {{ limit?: number, mediaOnly?: boolean, ttl?: number }} [options] 选项
+ * @returns {Promise<{ items: { entityHash: string, postId: string, event: object }[] }>} 附近发现
+ */
+export async function collectNearbyPostDiscover(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 20, 1), 50)
+	const mediaOnly = options.mediaOnly === true
+	const rows = await queryNetwork(username, getShellPartpath('social'), POST_DISCOVER_KIND, {
+		limit,
+		mediaOnly,
+	}, {
+		ttl: Number(options.ttl) || 3,
+		maxHits: 64,
+		rowKey: federatedPostRowKey,
+	})
+
+	/** @type {{ entityHash: string, postId: string, event: object }[]} */
+	const items = []
+	for (const raw of rows) {
+		const cleaned = sanitizeFederatedPostQueryRow(raw, { mediaOnly })
+		if (!cleaned) continue
+		items.push({
+			entityHash: cleaned.entityHash,
+			postId: cleaned.postId,
+			event: cleaned.event,
+		})
+		if (items.length >= limit) break
+	}
+	return { items }
+}

--- a/src/public/parts/shells/social/src/discover/rpc.mjs
+++ b/src/public/parts/shells/social/src/discover/rpc.mjs
@@ -1,0 +1,136 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+
+import { SOCIAL_RPC_REQUEST_TYPES } from '../federation/namespace.mjs'
+import { listNoteEvents, NOTE_PULL_BATCH } from '../federation/note/index.mjs'
+import { listReactionEvents, normalizeReactionTarget, REACTION_PULL_BATCH } from '../federation/reaction/index.mjs'
+import { buildFederatedTimelinePullResponse } from '../timeline/sync.mjs'
+
+import { discoverAccounts, discoverFollowGraph, discoverPosts } from './local.mjs'
+
+/**
+ * P2P RPC 处理器（供联邦层调用）。
+ * @param {string} username 本地用户
+ * @param {object} rpc RPC 体
+ * @param {{ requesterNodeHash?: string | null }} [ingress] 联邦入站
+ * @returns {Promise<object | null>} RPC 响应体
+ */
+export async function handleSocialRpc(username, rpc, ingress = {}) {
+	if (!SOCIAL_RPC_REQUEST_TYPES.has(rpc?.type)) return null
+	switch (rpc?.type) {
+		case 'social_discover_request': {
+			const scoped = ingress.requesterNodeHash
+				? { ...rpc, nodeHashPrefix: getNodeHash() }
+				: rpc
+			return { type: 'social_discover_response', ...await discoverAccounts(username, scoped) }
+		}
+		case 'social_post_discover_request': {
+			const scoped = ingress.requesterNodeHash
+				? { ...rpc, nodeHashPrefix: getNodeHash() }
+				: rpc
+			return { type: 'social_post_discover_response', ...await discoverPosts(username, scoped) }
+		}
+		case 'social_follow_graph_request':
+			return {
+				type: 'social_follow_graph_response',
+				entityHash: rpc.entityHash,
+				following: await discoverFollowGraph(username, String(rpc.entityHash), ingress),
+			}
+		case 'social_timeline_pull_request': {
+			const entityHash = (rpc.entityHash || '').toLowerCase()
+			const events = await buildFederatedTimelinePullResponse(
+				username,
+				entityHash,
+				rpc.afterEventId,
+				ingress.requesterNodeHash,
+			)
+			return {
+				type: 'social_timeline_pull_response',
+				entityHash,
+				events,
+			}
+		}
+		case 'social_reaction_pull_request': {
+			const ids = normalizeReactionTarget(rpc.targetEntityHash, rpc.postId)
+			if (!ids) 
+				return {
+					type: 'social_reaction_pull_response',
+					targetEntityHash: String(rpc.targetEntityHash || '').toLowerCase(),
+					postId: String(rpc.postId || '').trim(),
+					events: [],
+				}
+			
+			const afterReactor = rpc.afterReactor
+				? String(rpc.afterReactor).trim().toLowerCase()
+				: null
+			if (afterReactor && !parseEntityHash(afterReactor)) 
+				return {
+					type: 'social_reaction_pull_response',
+					targetEntityHash: ids.target,
+					postId: ids.postId,
+					events: [],
+				}
+			
+			const events = await listReactionEvents(
+				username,
+				ids.target,
+				ids.postId,
+				afterReactor,
+				rpc.limit ?? REACTION_PULL_BATCH,
+			)
+			return {
+				type: 'social_reaction_pull_response',
+				targetEntityHash: ids.target,
+				postId: ids.postId,
+				events,
+			}
+		}
+		case 'social_note_pull_request': {
+			const target = String(rpc.targetEntityHash || '').toLowerCase()
+			const postId = String(rpc.postId || '').trim()
+			const afterAuthor = rpc.afterAuthor
+				? String(rpc.afterAuthor).trim().toLowerCase()
+				: null
+			if (!parseEntityHash(target) || (afterAuthor && !parseEntityHash(afterAuthor)))
+				return {
+					type: 'social_note_pull_response',
+					targetEntityHash: target,
+					postId,
+					events: [],
+				}
+			const events = await listNoteEvents(
+				username,
+				target,
+				postId,
+				afterAuthor,
+				rpc.limit ?? NOTE_PULL_BATCH,
+			)
+			return {
+				type: 'social_note_pull_response',
+				targetEntityHash: target,
+				postId,
+				events,
+			}
+		}
+		case 'social_tag_merge_claim': {
+			const { ingestTagMergeClaim } = await import('../taste/mergeClaims.mjs')
+			return {
+				type: 'social_tag_merge_claim_response',
+				...await ingestTagMergeClaim(username, rpc.claim, ingress),
+			}
+		}
+		case 'social_post_notify': {
+			const { processSocialPostNotifyRpc } = await import('../dispatch.mjs')
+			return {
+				type: 'social_post_notify_response',
+				...await processSocialPostNotifyRpc(username, rpc),
+			}
+		}
+		case 'live_link_invite': {
+			const { handleLiveLinkInviteRpc } = await import('../live/link.mjs')
+			return handleLiveLinkInviteRpc(username, rpc)
+		}
+		default:
+			return null
+	}
+}

--- a/src/public/parts/shells/social/src/dispatch.mjs
+++ b/src/public/parts/shells/social/src/dispatch.mjs
@@ -1,0 +1,276 @@
+/**
+ * Social 入站 post 分发：本机 agent OnMessage + operator care 通知 + 跨节点 post 推送。
+ */
+import { formatHashShort } from 'fount/public/parts/shells/chat/public/shared/entityHash.mjs'
+import { mentionsEntity, extractMentionEntityHashes } from 'fount/public/parts/shells/chat/public/shared/mentions.mjs'
+import { isCaredBy } from 'fount/public/parts/shells/chat/src/chat/lib/care.mjs'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { primaryLocaleForUser } from '../../../../../scripts/locale.mjs'
+import { loadPart } from '../../../../../server/parts_loader.mjs'
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../chat/src/entity/identity.mjs'
+
+import { listLocalAgentEntities, resolveSocialEntity } from './federation/hosting.mjs'
+import { applyMentionNetworkHint } from './federation/network_hints.mjs'
+import { SOCIAL_REP_HIDE_THRESHOLD } from './federation/reputation/index.mjs'
+import { withDecryptedPostContent } from './feed/buildItem.mjs'
+import { loadViewerContext } from './feed/home.mjs'
+import { canViewPost } from './feedVisibility.mjs'
+import { ensureEntitySocialReady } from './lib/bootstrap.mjs'
+import { getEntityProfile } from './lib/entityProfile.mjs'
+import { mentionSourceText, postTextForNotification } from './lib/postMentionText.mjs'
+import { replyViaChat } from './lib/replyViaChat.mjs'
+
+/** @type {Set<string>} (agentHash, postId) 与 care 去重 */
+const dispatchedPostKeys = new Set()
+
+/** @type {Map<string, { tokens: number }>} */
+const socialReplyBuckets = new Map()
+
+const SOCIAL_THROTTLE_SETTINGS = { enabled: true, burst: 2, refill: 0.5 }
+
+/**
+ * @param {string} bucketKey agent 节流键
+ * @param {{ enabled: boolean, burst: number, refill: number }} settings 桶配置
+ * @returns {{ allowed: boolean }} 是否允许消耗
+ */
+function consumeSocialReplyToken(bucketKey, settings) {
+	if (!settings.enabled) return { allowed: true }
+	const row = socialReplyBuckets.get(bucketKey) || { tokens: settings.burst }
+	row.tokens = Math.min(settings.burst, row.tokens + settings.refill)
+	if (row.tokens < 1) {
+		socialReplyBuckets.set(bucketKey, row)
+		return { allowed: false }
+	}
+	row.tokens = Math.max(0, row.tokens - 1)
+	socialReplyBuckets.set(bucketKey, row)
+	return { allowed: true }
+}
+
+/**
+ * @param {string} entityHash 128 位 entityHash
+ * @param {string} [replicaUsername] 查询 profile 的 replica
+ * @returns {Promise<string>} 展示名或 hash 缩写
+ */
+async function displayNameForEntity(entityHash, replicaUsername) {
+	const profile = replicaUsername ? await getEntityProfile(replicaUsername, entityHash) : null
+	return profile?.name || formatHashShort(entityHash, { headLen: 8, tailLen: 4 })
+}
+
+/**
+ * 以指定实体身份发布公开回复并联邦 fanout。
+ * @param {string} username 代写时间线的 replica 登录名
+ * @param {string} authorEntityHash 回复作者 entityHash
+ * @param {object} content 帖子 content
+ * @param {string | null} [charPartName] 本地 agent 时 chars 目录名
+ * @returns {Promise<object>} 签名 post 事件
+ */
+async function publishEntityReply(username, authorEntityHash, content, charPartName = null) {
+	await ensureEntitySocialReady(username, authorEntityHash)
+	const { commitTimelineEvent } = await import('./timeline/append.mjs')
+	return commitTimelineEvent(username, authorEntityHash, {
+		type: 'post',
+		charPartName,
+		content,
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} authorEntityHash 作者
+ * @param {object} post 签名 post
+ * @param {string} authorLabel 作者展示名
+ * @returns {Promise<void>}
+ */
+async function dispatchCarePostIfNeeded(username, authorEntityHash, post, authorLabel) {
+	const operator = await resolveOperatorEntityHash(username)
+	if (!operator) return
+	const author = authorEntityHash.toLowerCase()
+	if (author === operator) return
+	const careKey = `care:${operator}:${post.id}`
+	if (dispatchedPostKeys.has(careKey)) return
+	if (!await isCaredBy(username, operator, author)) return
+	dispatchedPostKeys.add(careKey)
+	const snippet = postTextForNotification(post) ?? (authorLabel ? `${authorLabel} 发了新帖` : null)
+	const { appendCarePostInboxRow } = await import('./inbox.mjs')
+	await appendCarePostInboxRow(username, operator, author, post, snippet)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} authorEntityHash 作者
+ * @param {object} post 签名 post
+ * @param {{ entityHashes: string[] }} mentions mention 结构
+ * @param {string} authorLabel 作者展示名
+ * @param {string} locale 语言/地区
+ * @returns {Promise<void>}
+ */
+async function dispatchLocalAgents(username, authorEntityHash, post, mentions, authorLabel, locale) {
+	const author = authorEntityHash.toLowerCase()
+	const replyTo = post.content?.replyTo
+
+	for (const { entityHash: agentHash, charPartName } of listLocalAgentEntities(username)) {
+		const viewerHash = agentHash.toLowerCase()
+		if (viewerHash === author) continue
+
+		const dedupeKey = `agent:${viewerHash}:${post.id}`
+		if (dispatchedPostKeys.has(dedupeKey)) continue
+
+		const viewerContext = await loadViewerContext(username, viewerHash)
+		if (!canViewPost({ entityHash: author, content: post.content }, viewerContext)) continue
+
+		const decrypted = await withDecryptedPostContent(username, author, post)
+		if (!decrypted.content && post.content?.scheme === 'gsh') continue
+
+		dispatchedPostKeys.add(dedupeKey)
+
+		const postText = postTextForNotification({ content: decrypted.content }) ?? ''
+		const mentioned = mentionsEntity(mentions, viewerHash)
+		if (!mentioned) {
+			const { allowed } = consumeSocialReplyToken(`social\0${viewerHash}`, SOCIAL_THROTTLE_SETTINGS)
+			if (!allowed) continue
+		}
+
+		const char = await loadPart(username, `chars/${charPartName}`).catch(() => null)
+		if (!char) continue
+
+		const messageEvent = {
+			post,
+			authorEntityHash: author,
+			authorDisplayName: authorLabel,
+			postText,
+			replyTo,
+			mentions,
+			viewerEntityHash: viewerHash,
+			username,
+			charPartName,
+			locale,
+		}
+
+		const OnMessage = char.interfaces?.social?.OnMessage
+		const wantsReply = OnMessage
+			? await OnMessage(messageEvent)
+			: mentioned
+		if (!wantsReply) continue
+
+		const text = await replyViaChat(username, charPartName, char, messageEvent)
+		if (!text) continue
+
+		await publishEntityReply(
+			username,
+			viewerHash,
+			{ text, replyTo: replyTo || { entityHash: author, postId: post.id }, visibility: 'public', locale },
+			charPartName,
+		)
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} authorEntityHash 作者
+ * @param {object} post 签名 post
+ * @param {string[]} mentionHashes @ 实体列表
+ * @returns {Promise<void>}
+ */
+async function dispatchRemoteMentionPush(username, authorEntityHash, post, mentionHashes) {
+	const author = authorEntityHash.toLowerCase()
+	const authorRep = pickNodeScore(author.slice(0, 64))
+	if (authorRep < SOCIAL_REP_HIDE_THRESHOLD) return
+
+	for (const targetHash of mentionHashes) {
+		if (targetHash === author) continue
+		applyMentionNetworkHint(username, targetHash)
+		const target = await resolveSocialEntity(targetHash)
+		if (target?.local && target.kind === 'agent' && target.replicaUsername === username) continue
+
+		const { collectSocialRpcResponses } = await import('./federation/rpc/wire.mjs')
+		void collectSocialRpcResponses(username, {
+			type: 'social_post_notify',
+			authorEntityHash: author,
+			posterUsername: username,
+			post,
+		}).catch(err => console.error('social_rpc social_post_notify failed', err))
+	}
+}
+
+/**
+ * 新帖入账分发：本机 agent OnMessage、operator care、跨节点 @ 推送。
+ * @param {string} username 入账 replica
+ * @param {string} authorEntityHash 作者 entityHash
+ * @param {object} post 签名 post
+ * @returns {Promise<void>}
+ */
+export async function dispatchSocialMessage(username, authorEntityHash, post) {
+	if (post.type !== 'post') return
+	const author = String(authorEntityHash).trim().toLowerCase()
+	const mentionHashes = extractMentionEntityHashes(mentionSourceText(post))
+	const mentions = { entityHashes: mentionHashes }
+	const authorLabel = await displayNameForEntity(author, username)
+
+	await dispatchCarePostIfNeeded(username, author, post, authorLabel)
+	await dispatchLocalAgents(username, author, post, mentions, authorLabel, post.content?.locale || primaryLocaleForUser(username))
+	if (mentionHashes.length)
+		await dispatchRemoteMentionPush(username, author, post, mentionHashes)
+}
+
+/**
+ * 联邦 RPC 入站：验签后走同一分发（不落盘；落盘由 timeline pull/ingest）。
+ * @param {string} hostingUsername 托管 replica
+ * @param {object} rpc RPC 体
+ * @returns {Promise<{ ok: boolean }>} RPC 处理结果
+ */
+export async function processSocialPostNotifyRpc(hostingUsername, rpc) {
+	const post = rpc.post
+	const authorEntityHash = String(rpc.authorEntityHash || '').trim().toLowerCase()
+	if (post?.type !== 'post' || !authorEntityHash) return { ok: false }
+
+	const { isRemoteTimelinePushAdmitted } = await import('./federation/push_admission.mjs')
+	if (!await isRemoteTimelinePushAdmitted(hostingUsername, authorEntityHash))
+		return { ok: false }
+
+	const { readJsonl } = await import('npm:@steve02081504/fount-p2p/dag/storage')
+	const { validateRemoteTimelineEvent } = await import('./federation/ingest/remote.mjs')
+	const { timelineEventsPath } = await import('./paths.mjs')
+	const { canonicalizeSignedTimelineEvent } = await import('./timeline/canonicalizeEvent.mjs')
+	const priorEvents = await readJsonl(timelineEventsPath(hostingUsername, authorEntityHash))
+	const validated = await validateRemoteTimelineEvent(post, authorEntityHash, {
+		canonicalize: canonicalizeSignedTimelineEvent,
+		priorEvents,
+		username: hostingUsername,
+	})
+	if (!validated.accepted) return { ok: false }
+
+	await dispatchSocialMessage(rpc.posterUsername || hostingUsername, authorEntityHash, validated.row)
+	return { ok: true }
+}
+
+/**
+ * 新关注事件：目标为本地 agent 时调用 OnFollow。
+ * @param {string} followerUsername 关注者 replica
+ * @param {string} followerEntityHash 关注者 entityHash
+ * @param {string} targetEntityHash 被关注 entityHash
+ * @returns {Promise<void>}
+ */
+export async function dispatchFollowEvent(followerUsername, followerEntityHash, targetEntityHash) {
+	const target = await resolveSocialEntity(targetEntityHash)
+	if (!target?.local || target.kind !== 'agent' || !target.replicaUsername || !target.charPartName)
+		return
+
+	const char = await loadPart(target.replicaUsername, `chars/${target.charPartName}`)
+	const handler = char?.interfaces?.social?.OnFollow
+	if (!handler) return
+
+	await handler({
+		username: target.replicaUsername,
+		charPartName: target.charPartName,
+		followerEntityHash,
+		followerUsername,
+		targetEntityHash: target.entityHash,
+	})
+}
+
+/** @internal 测试用：清空去重集 */
+export function resetSocialDispatchDedupForTests() {
+	dispatchedPostKeys.clear()
+	socialReplyBuckets.clear()
+}

--- a/src/public/parts/shells/social/src/drafts.mjs
+++ b/src/public/parts/shells/social/src/drafts.mjs
@@ -1,0 +1,211 @@
+/**
+ * 实体私有发帖草稿箱（本机 JSON，不联邦）。
+ */
+import { randomUUID } from 'node:crypto'
+
+import { httpError } from '../../../../../scripts/http_error.mjs'
+
+import { loadEntityJson, saveEntityJson } from './lib/entityJson.mjs'
+import { stripTransientMediaFields } from './lib/mediaRefs.mjs'
+import { draftsPath } from './paths.mjs'
+
+const MAX_DRAFTS = 100
+
+/**
+ * @returns {{ drafts: object[] }} 空草稿箱（每次新对象）
+ */
+function emptyDrafts() {
+	return { drafts: [] }
+}
+
+/**
+ * 清洗发帖草稿 body（与 POST /posts 字段对齐）。
+ * @param {object} raw 原始 body
+ * @returns {object} 可持久化 body
+ */
+export function sanitizeDraftBody(raw = {}) {
+	const body = {}
+	const text = String(raw.text ?? '').trim()
+	if (text) body.text = text
+	const mediaRefs = stripTransientMediaFields(raw.mediaRefs)
+	if (mediaRefs.length) body.mediaRefs = mediaRefs
+	if (raw.visibility) body.visibility = String(raw.visibility)
+	if (Array.isArray(raw.allow) && raw.allow.length)
+		body.allow = raw.allow.map(v => String(v).trim().toLowerCase()).filter(Boolean)
+	if (Array.isArray(raw.except) && raw.except.length)
+		body.except = raw.except.map(v => String(v).trim().toLowerCase()).filter(Boolean)
+	if (Array.isArray(raw.albumIds) && raw.albumIds.length)
+		body.albumIds = [...new Set(raw.albumIds.map(id => String(id).trim()).filter(Boolean))]
+	if (raw.locale) body.locale = String(raw.locale).trim().slice(0, 32)
+	if (raw.contentWarning) body.contentWarning = String(raw.contentWarning).trim().slice(0, 200)
+	if (raw.sensitiveMedia) body.sensitiveMedia = true
+	if (raw.quoteRef?.entityHash && raw.quoteRef?.postId)
+		body.quoteRef = {
+			entityHash: String(raw.quoteRef.entityHash).toLowerCase(),
+			postId: String(raw.quoteRef.postId),
+		}
+	if (raw.groupRef?.groupId)
+		body.groupRef = {
+			groupId: String(raw.groupRef.groupId),
+			channelId: String(raw.groupRef.channelId || 'default'),
+		}
+	if (raw.poll && typeof raw.poll === 'object') body.poll = structuredClone(raw.poll)
+	if (raw.replyPolicy) body.replyPolicy = String(raw.replyPolicy)
+	if (raw.replyDisplay) body.replyDisplay = String(raw.replyDisplay)
+	if (raw.publishAt != null) {
+		const ms = Number(raw.publishAt)
+		if (Number.isFinite(ms) && ms > Date.now()) body.publishAt = ms
+	}
+	if (Array.isArray(raw.tags) && raw.tags.length) {
+		const tags = [...new Set(raw.tags.map(t => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 16)
+		if (tags.length) body.tags = tags
+	}
+	return body
+}
+
+/**
+ * 草稿是否有可发布内容。
+ * @param {object} body 草稿 body
+ * @returns {boolean} 非空
+ */
+function isNonEmptyDraft(body) {
+	return Boolean(body.text || body.mediaRefs?.length || body.poll)
+}
+
+/**
+ * 列表预览摘要。
+ * @param {object} body 草稿 body
+ * @returns {string} 预览
+ */
+function draftPreview(body) {
+	if (body.text) return String(body.text).slice(0, 120)
+	if (body.mediaRefs?.length) return '[media]'
+	if (body.poll) return '[poll]'
+	return ''
+}
+
+/**
+ * @param {object} row 原始草稿行
+ * @returns {object} 带 preview 的行
+ */
+function withPreview(row) {
+	return {
+		draftId: row.draftId,
+		createdAt: row.createdAt,
+		updatedAt: row.updatedAt,
+		preview: draftPreview(row.body || {}),
+		body: row.body || {},
+	}
+}
+
+/**
+ * 读取实体草稿箱。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {Promise<{ drafts: object[] }>} 草稿箱
+ */
+export async function loadDrafts(username, entityHash) {
+	try {
+		return await loadEntityJson(draftsPath(username, entityHash), emptyDrafts, raw => ({
+			drafts: Array.isArray(raw?.drafts) ? raw.drafts.filter(row => row?.draftId && row?.body) : [],
+		}))
+	}
+	catch {
+		return emptyDrafts()
+	}
+}
+
+/**
+ * 持久化草稿箱。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {{ drafts: object[] }} data 草稿箱
+ * @returns {Promise<{ drafts: object[] }>} 写入后结构
+ */
+async function saveDrafts(username, entityHash, data) {
+	return saveEntityJson(draftsPath(username, entityHash), data)
+}
+
+/**
+ * 列出草稿（按 updatedAt 降序，含 preview）。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {Promise<{ drafts: object[] }>} 列表
+ */
+export async function listDrafts(username, entityHash) {
+	const data = await loadDrafts(username, entityHash)
+	const drafts = data.drafts
+		.map(withPreview)
+		.sort((a, b) => Number(b.updatedAt) - Number(a.updatedAt))
+	return { drafts }
+}
+
+/**
+ * 读取单条草稿。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} draftId id
+ * @returns {Promise<object>} 草稿行
+ */
+export async function getDraft(username, entityHash, draftId) {
+	const id = String(draftId || '').trim()
+	const data = await loadDrafts(username, entityHash)
+	const row = data.drafts.find(item => item.draftId === id)
+	if (!row) throw httpError(404, 'draft not found')
+	return withPreview(row)
+}
+
+/**
+ * 创建或更新草稿。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {object} raw body；可选 draftId 表示更新
+ * @returns {Promise<object>} 写入后的草稿行
+ */
+export async function upsertDraft(username, entityHash, raw = {}) {
+	const body = sanitizeDraftBody(raw)
+	if (!isNonEmptyDraft(body))
+		throw httpError(400, 'draft is empty')
+	const data = await loadDrafts(username, entityHash)
+	const now = Date.now()
+	const draftId = String(raw.draftId || '').trim()
+	if (draftId) {
+		const idx = data.drafts.findIndex(row => row.draftId === draftId)
+		if (idx < 0) throw httpError(404, 'draft not found')
+		data.drafts[idx] = {
+			...data.drafts[idx],
+			updatedAt: now,
+			body,
+		}
+		await saveDrafts(username, entityHash, data)
+		return withPreview(data.drafts[idx])
+	}
+	if (data.drafts.length >= MAX_DRAFTS)
+		throw httpError(400, `draft limit ${MAX_DRAFTS}`)
+	const row = {
+		draftId: randomUUID(),
+		createdAt: now,
+		updatedAt: now,
+		body,
+	}
+	data.drafts.push(row)
+	await saveDrafts(username, entityHash, data)
+	return withPreview(row)
+}
+
+/**
+ * 删除草稿。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} draftId id
+ * @returns {Promise<{ drafts: object[] }>} 删除后列表
+ */
+export async function deleteDraft(username, entityHash, draftId) {
+	const id = String(draftId || '').trim()
+	const data = await loadDrafts(username, entityHash)
+	const next = data.drafts.filter(row => row.draftId !== id)
+	if (next.length === data.drafts.length)
+		throw httpError(404, 'draft not found')
+	await saveDrafts(username, entityHash, { drafts: next })
+	return listDrafts(username, entityHash)
+}

--- a/src/public/parts/shells/social/src/endpoints.mjs
+++ b/src/public/parts/shells/social/src/endpoints.mjs
@@ -1,0 +1,53 @@
+/**
+ * 【文件】social/src/endpoints.mjs
+ * 【职责】Social shell HTTP/WS 路由聚合入口。
+ */
+import { authenticate } from '../../../../../server/auth/index.mjs'
+
+import { registerAlbumsRoutes } from './endpoints/albums.mjs'
+import { registerDiscoverRoutes } from './endpoints/discover.mjs'
+import { registerDraftsRoutes } from './endpoints/drafts.mjs'
+import { registerExploreRoutes } from './endpoints/explore.mjs'
+import { registerFeedRoutes } from './endpoints/feed.mjs'
+import { registerLiveRoutes } from './endpoints/live.mjs'
+import { registerNotificationRoutes } from './endpoints/notifications.mjs'
+import { registerPostsRoutes } from './endpoints/posts.mjs'
+import { registerProfileRoutes } from './endpoints/profile.mjs'
+import { registerRelationshipsRoutes } from './endpoints/relationships.mjs'
+import { registerSavedRoutes } from './endpoints/saved.mjs'
+import { registerSearchRoutes } from './endpoints/search.mjs'
+import { registerSignalsRoutes } from './endpoints/signals.mjs'
+import { registerTasteRoutes } from './endpoints/taste.mjs'
+import { registerTestSeedRoutes } from './endpoints/testSeed.mjs'
+import { registerTopicsRoutes } from './endpoints/topics.mjs'
+import { registerTranslateRoutes } from './endpoints/translate.mjs'
+import { registerVaultRoutes } from './endpoints/vault.mjs'
+import { registerVideosRoutes } from './endpoints/videos.mjs'
+
+/**
+ * 注册 Social shell 全部 HTTP/WS 路由。
+ * @param {import('npm:websocket-express').Router} router Express 路由
+ * @returns {void}
+ */
+export function setEndpoints(router) {
+	registerFeedRoutes(router)
+	registerExploreRoutes(router)
+	registerDiscoverRoutes(router)
+	registerSearchRoutes(router)
+	registerTopicsRoutes(router)
+	registerVideosRoutes(router)
+	registerLiveRoutes(router)
+	registerNotificationRoutes(router)
+	registerTranslateRoutes(router)
+	registerProfileRoutes(router)
+	registerPostsRoutes(router)
+	registerAlbumsRoutes(router)
+	registerRelationshipsRoutes(router)
+	registerSavedRoutes(router)
+	registerDraftsRoutes(router)
+	registerTasteRoutes(router)
+	registerSignalsRoutes(router)
+	registerVaultRoutes(router)
+	if (process.env.FOUNT_TEST === '1' || process.env.FOUNT_TEST_ISOLATED === '1')
+		registerTestSeedRoutes(router, authenticate)
+}

--- a/src/public/parts/shells/social/src/endpoints/albums.mjs
+++ b/src/public/parts/shells/social/src/endpoints/albums.mjs
@@ -1,0 +1,71 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { routeEntityHash, socialClientFromReq } from './shared.mjs'
+
+/**
+ * 注册相册路由（SocialClient 薄封装）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerAlbumsRoutes(router) {
+	router.get('/api/parts/shells\\:social/albums', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const entityHash = String(req.query.entityHash || client.entityHash).trim().toLowerCase()
+		res.status(200).json({ albums: await client.albums.list(entityHash) })
+	})
+
+	router.get('/api/parts/shells\\:social/albums/:entityHash', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		res.status(200).json({ albums: await client.albums.list(routeEntityHash(req.params)) })
+	})
+
+	router.get('/api/parts/shells\\:social/albums/:entityHash/:albumId', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const detail = await client.albums.get(routeEntityHash(req.params), String(req.params.albumId || ''))
+		res.status(200).json(detail)
+	})
+
+	router.post('/api/parts/shells\\:social/albums', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		res.status(200).json(await client.albums.create(req.body || {}))
+	})
+
+	router.post('/api/parts/shells\\:social/albums/:albumId/update', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		res.status(200).json(await client.albums.update(String(req.params.albumId || ''), req.body || {}))
+	})
+
+	router.delete('/api/parts/shells\\:social/albums/:albumId', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const deletePosts = req.body?.deletePosts === true || req.query.deletePosts === '1'
+		res.status(200).json(await client.albums.delete(String(req.params.albumId || ''), { deletePosts }))
+	})
+
+	router.post('/api/parts/shells\\:social/albums/:albumId/posts', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const postId = String(req.body?.postId || '')
+		if (!postId) throw httpError(400, 'postId required')
+		res.status(200).json(await client.albums.addPost(String(req.params.albumId || ''), postId))
+	})
+
+	router.delete('/api/parts/shells\\:social/albums/:albumId/posts/:postId', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		res.status(200).json(await client.albums.removePost(
+			String(req.params.albumId || ''),
+			String(req.params.postId || ''),
+		))
+	})
+
+	router.post('/api/parts/shells\\:social/albums/move-post', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const postId = String(req.body?.postId || '')
+		const toAlbumId = String(req.body?.toAlbumId || '')
+		if (!postId || !toAlbumId) throw httpError(400, 'postId and toAlbumId required')
+		res.status(200).json(await client.albums.movePost(
+			postId,
+			String(req.body?.fromAlbumId || ''),
+			toAlbumId,
+		))
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/discover.mjs
+++ b/src/public/parts/shells/social/src/endpoints/discover.mjs
@@ -1,0 +1,26 @@
+import { authenticate, getUserByReq } from '../../../../../../server/auth/index.mjs'
+import { suggestMentions } from '../lib/mentionSuggest.mjs'
+import { buildTrendingHashtags } from '../trending/hashtags.mjs'
+import { buildNearbyTrendingHashtags } from '../trending/network.mjs'
+
+/**
+ * 注册趋势与 @ 建议路由。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerDiscoverRoutes(router) {
+	router.get('/api/parts/shells\\:social/hashtags/trending', authenticate, async (req, res) => {
+		const { username } = getUserByReq(req)
+		const scope = String(req.query.scope || 'local').toLowerCase()
+		const options = { limit: Number(req.query.limit) || 12 }
+		if (scope === 'nearby')
+			res.status(200).json(await buildNearbyTrendingHashtags(username, options))
+		else
+			res.status(200).json({ ...await buildTrendingHashtags(username, options), scope: 'local' })
+	})
+
+	router.get('/api/parts/shells\\:social/mentions/suggest', authenticate, async (req, res) => {
+		const { username } = getUserByReq(req)
+		res.status(200).json(await suggestMentions(username, String(req.query.q || ''), Number(req.query.limit) || 20))
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/drafts.mjs
+++ b/src/public/parts/shells/social/src/endpoints/drafts.mjs
@@ -1,0 +1,28 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册发帖草稿箱路由（client.drafts.*）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerDraftsRoutes(router) {
+	router.get('/api/parts/shells\\:social/drafts', authenticate, socialJson((_req, { client }) => client.drafts.list()))
+
+	router.get('/api/parts/shells\\:social/drafts/:draftId', authenticate, socialJson(async (req, { client }) => {
+		const draftId = String(req.params.draftId || '').trim()
+		if (!draftId) throw httpError(400, 'draftId required')
+		return client.drafts.get(draftId)
+	}))
+
+	router.post('/api/parts/shells\\:social/drafts', authenticate, socialJson((req, { client }) =>
+		client.drafts.upsert(req.body || {})))
+
+	router.delete('/api/parts/shells\\:social/drafts/:draftId', authenticate, socialJson(async (req, { client }) => {
+		const draftId = String(req.params.draftId || '').trim()
+		if (!draftId) throw httpError(400, 'draftId required')
+		return client.drafts.delete(draftId)
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/explore.mjs
+++ b/src/public/parts/shells/social/src/endpoints/explore.mjs
@@ -1,0 +1,19 @@
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册探索页路由（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerExploreRoutes(router) {
+	router.get('/api/parts/shells\\:social/explore', authenticate, socialJson((req, { client }) =>
+		client.explore({ limit: Number(req.query.limit) || 20 })))
+
+	router.get('/api/parts/shells\\:social/explore/posts', authenticate, socialJson((req, { client }) =>
+		client.explorePosts({
+			limit: Number(req.query.limit) || 20,
+			mediaOnly: req.query.mediaOnly === 'true',
+		})))
+}

--- a/src/public/parts/shells/social/src/endpoints/feed.mjs
+++ b/src/public/parts/shells/social/src/endpoints/feed.mjs
@@ -1,0 +1,30 @@
+import { authenticate, getUserByReq } from '../../../../../../server/auth/index.mjs'
+import { registerFeedSocket } from '../ws/feedHub.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册 feed 与 WebSocket 相关路由（读侧经 SocialClient；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerFeedRoutes(router) {
+	router.get('/api/parts/shells\\:social/feed', authenticate, socialJson((req, { client }) => {
+		const ranking = String(req.query.ranking || 'latest').toLowerCase()
+		return client.feed({
+			mode: ranking === 'for_you' ? 'forYou' : 'home',
+			ranking,
+			limit: Number(req.query.limit) || 50,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+		})
+	}))
+
+	router.post('/api/parts/shells\\:social/feed/sync', authenticate, socialJson((_req, { client }) =>
+		client.syncFollowing()))
+
+	router.ws('/ws/parts/shells\\:social/feed', authenticate, async (ws, req) => {
+		const { username } = getUserByReq(req)
+		registerFeedSocket(username, ws)
+		ws.send(JSON.stringify({ type: 'hello' }))
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/live.mjs
+++ b/src/public/parts/shells/social/src/endpoints/live.mjs
@@ -1,0 +1,220 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+import { startWhipIngest, stopWhipIngest } from '../../../chat/src/chat/whip/ingest.mjs'
+import {
+	injectAvRelayControl,
+	injectAvRelayFrame,
+	registerAvRelaySocket,
+	subscribeAvRelayFrames,
+	subscribeAvRelayControls,
+} from '../../../chat/src/chat/ws/avRelay.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+import {
+	canJoinLiveRoom,
+	ingestBridgedLiveSignal,
+	registerLiveSignalSocket,
+} from '../live/hub.mjs'
+import { loadLiveSession, verifyLiveBridgeToken } from '../live/session.mjs'
+
+import { socialClientFromReq } from './shared.mjs'
+
+/**
+ * 直播 HTTP / WS 路由。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerLiveRoutes(router) {
+	router.post('/api/parts/shells\\:social/live/start', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const body = { ...req.body || {} }
+		if (!body.bridgeOrigin) {
+			const proto = req.headers['x-forwarded-proto'] || req.protocol || 'http'
+			const host = req.headers['x-forwarded-host'] || req.headers.host
+			if (host) body.bridgeOrigin = `${proto}://${host}`
+		}
+		res.status(200).json(await client.startLive(body))
+	})
+
+	router.post('/api/parts/shells\\:social/live/stop', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		const liveId = String(req.body?.liveId || '').trim()
+		if (!liveId) throw httpError(400, 'liveId required')
+		res.status(200).json(await client.stopLive(liveId))
+	})
+
+	router.get('/api/parts/shells\\:social/live/feed', authenticate, async (req, res) => {
+		const { client } = await socialClientFromReq(req)
+		res.status(200).json(await client.liveFeed({
+			limit: Number(req.query.limit) || 20,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+			scope: req.query.scope ? String(req.query.scope) : 'local',
+		}))
+	})
+
+	router.get('/api/parts/shells\\:social/live/:entityHash/:liveId', authenticate, async (req, res) => {
+		const { username } = await socialClientFromReq(req)
+		const entityHash = String(req.params.entityHash || '').toLowerCase()
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const session = loadLiveSession(username, entityHash, liveId)
+		if (!session) throw httpError(404, 'live not found')
+		res.status(200).json({ live: session })
+	})
+
+	router.post('/api/parts/shells\\:social/live/:liveId/whip', authenticate, async (req, res) => {
+		const { client, username } = await socialClientFromReq(req)
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const session = loadLiveSession(username, client.entityHash, liveId)
+		if (!session || session.status !== 'live') throw httpError(404, 'live not found')
+		const auth = String(req.headers.authorization || '')
+		const token = auth.startsWith('Bearer ') ? auth.slice(7).trim() : ''
+		if (!session.ingestSecret || token !== session.ingestSecret) throw httpError(403, 'bad ingest token')
+		const offerSdp = typeof req.body === 'string' ? req.body : String(req.body || '')
+		if (!offerSdp.includes('v=0')) throw httpError(400, 'sdp required')
+		const avRoomId = session.avRoomId || `social:${client.entityHash}:${liveId}`
+		const { answerSdp } = await startWhipIngest(avRoomId, offerSdp)
+		const location = `/api/parts/shells:social/live/${liveId}/whip`
+		res.setHeader('Location', location)
+		res.status(201).type('application/sdp').send(answerSdp)
+	})
+
+	router.delete('/api/parts/shells\\:social/live/:liveId/whip', authenticate, async (req, res) => {
+		const { client, username } = await socialClientFromReq(req)
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const session = loadLiveSession(username, client.entityHash, liveId)
+		if (!session) throw httpError(404, 'live not found')
+		const avRoomId = session.avRoomId || `social:${client.entityHash}:${liveId}`
+		stopWhipIngest(avRoomId)
+		res.status(200).json({ ok: true })
+	})
+
+	router.post('/api/parts/shells\\:social/live/:liveId/link/invite', authenticate, async (req, res) => {
+		const { client, username } = await socialClientFromReq(req)
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const { inviteLiveLink } = await import('../live/link.mjs')
+		res.status(200).json(await inviteLiveLink(username, client.entityHash, liveId, req.body || {}))
+	})
+
+	router.post('/api/parts/shells\\:social/live/:liveId/link/stop', authenticate, async (req, res) => {
+		const { client, username } = await socialClientFromReq(req)
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const { tearDownLiveLink } = await import('../live/link.mjs')
+		res.status(200).json(await tearDownLiveLink(username, client.entityHash, liveId) || { ok: true })
+	})
+
+	router.ws('/ws/parts/shells\\:social/live/:entityHash/:liveId', authenticate, async (ws, req) => {
+		const { client, username } = await socialClientFromReq(req)
+		const entityHash = String(req.params.entityHash || '').toLowerCase()
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		let session = loadLiveSession(username, entityHash, liveId)
+		if ((!session || session.status !== 'live') && req.query?.proxy === '1') {
+			const { ensureFederatedLiveProxy } = await import('../live/viewerProxy.mjs')
+			session = await ensureFederatedLiveProxy(username, entityHash, liveId, {
+				bridgeOrigin: String(req.query.bridgeOrigin || ''),
+				watchSecret: String(req.query.watchSecret || ''),
+				nodeHash: String(req.query.nodeHash || ''),
+			})
+		}
+		if (!session || session.status !== 'live') {
+			ws.close(4004, 'not_live')
+			return
+		}
+		if (session.visibility === 'followers') {
+			const { following } = await loadFollowingForActor(username, client.entityHash)
+			if (!following.includes(entityHash) && client.entityHash !== entityHash) {
+				ws.close(4003, 'followers_only')
+				return
+			}
+		}
+		if (!canJoinLiveRoom(username, entityHash, liveId) && !session.federatedProxy) {
+			ws.close(4004, 'not_live')
+			return
+		}
+		registerLiveSignalSocket(entityHash, liveId, ws, {
+			username,
+			viewerEntityHash: client.entityHash,
+		})
+		ws.send(JSON.stringify({
+			type: 'hello',
+			liveId,
+			entityHash,
+			likeCount: session.likeCount || 0,
+			link: session.link || null,
+		}))
+	})
+
+	router.ws('/ws/parts/shells\\:social/live-av/:entityHash/:liveId', authenticate, async (ws, req) => {
+		const { client, username } = await socialClientFromReq(req)
+		const entityHash = String(req.params.entityHash || '').toLowerCase()
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		let session = loadLiveSession(username, entityHash, liveId)
+		if ((!session || session.status !== 'live') && req.query?.proxy === '1') {
+			const { ensureFederatedLiveProxy } = await import('../live/viewerProxy.mjs')
+			session = await ensureFederatedLiveProxy(username, entityHash, liveId, {
+				bridgeOrigin: String(req.query.bridgeOrigin || ''),
+				watchSecret: String(req.query.watchSecret || ''),
+				nodeHash: String(req.query.nodeHash || ''),
+			})
+		}
+		if (!session || session.status !== 'live') {
+			ws.close(4004, 'not_live')
+			return
+		}
+		if (session.visibility === 'followers') {
+			const { following } = await loadFollowingForActor(username, client.entityHash)
+			if (!following.includes(entityHash) && client.entityHash !== entityHash) {
+				ws.close(4003, 'followers_only')
+				return
+			}
+		}
+		registerAvRelaySocket(session.avRoomId || `social:${entityHash}:${liveId}`, ws)
+	})
+
+	// 跨节点连线 / 观众代理：token = HMAC(linkSecret)；公开观看代理用 session.publicWatchSecret
+	router.ws('/ws/parts/shells\\:social/live-bridge/:entityHash/:liveId', async (ws, req) => {
+		const entityHash = String(req.params.entityHash || '').toLowerCase()
+		const liveId = String(req.params.liveId || '').toLowerCase()
+		const token = String(req.query?.token || '')
+		const { getAllUserNames } = await import('../../../../../../server/auth/index.mjs')
+		let matched = null
+		let matchedUser = null
+		for (const username of getAllUserNames()) {
+			const session = loadLiveSession(username, entityHash, liveId)
+			if (!session || session.status !== 'live') continue
+			const secret = session.link?.linkSecret || session.publicWatchSecret
+			if (secret && verifyLiveBridgeToken(token, secret, entityHash, liveId)) {
+				matched = session
+				matchedUser = username
+				break
+			}
+		}
+		if (!matched) {
+			ws.close(4003, 'bad_token')
+			return
+		}
+		const avRoomId = matched.avRoomId || `social:${entityHash}:${liveId}`
+		const unsub = subscribeAvRelayFrames(avRoomId, buf => {
+			if (ws.readyState !== 1) return
+			try { ws.send(buf, { binary: true }) } catch { /* skip */ }
+		})
+		const unsubCtrl = subscribeAvRelayControls(avRoomId, text => {
+			if (ws.readyState !== 1) return
+			try { ws.send(text) } catch { /* skip */ }
+		})
+		ws.on('message', (data, isBinary) => {
+			if (isBinary) {
+				injectAvRelayFrame(avRoomId, data)
+				return
+			}
+			let wireMessage
+			try { wireMessage = JSON.parse(String(data)) }
+			catch { return }
+			if (wireMessage?.type === 'publish_meta' || wireMessage?.type === 'publish_meta_revoke') {
+				injectAvRelayControl(avRoomId, wireMessage)
+				return
+			}
+			ingestBridgedLiveSignal(matchedUser, entityHash, liveId, wireMessage)
+		})
+		ws.on('close', () => { unsub(); unsubCtrl() })
+		ws.send(JSON.stringify({ type: 'hello', bridge: true, entityHash, liveId }))
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/notifications.mjs
+++ b/src/public/parts/shells/social/src/endpoints/notifications.mjs
@@ -1,0 +1,29 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册通知路由（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerNotificationRoutes(router) {
+	router.get('/api/parts/shells\\:social/notifications', authenticate, socialJson((req, { client }) =>
+		client.notifications({
+			limit: Number(req.query.limit) || 30,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+			types: req.query.types,
+		})))
+
+	router.get('/api/parts/shells\\:social/notifications/seen', authenticate, socialJson(async (_req, { client }) => ({
+		seenAt: await client.notificationsSeenAt(),
+		viewerEntityHash: client.entityHash,
+	})))
+
+	router.put('/api/parts/shells\\:social/notifications/seen', authenticate, socialJson(async (req, { client }) => {
+		if (!client.entityHash) throw httpError(400, 'identity required')
+		const seenAt = await client.setNotificationsSeenAt(req.body?.at)
+		return { seenAt, viewerEntityHash: client.entityHash }
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/posts.mjs
+++ b/src/public/parts/shells/social/src/endpoints/posts.mjs
@@ -1,0 +1,118 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { routeEntityHash, socialJson } from './shared.mjs'
+
+/**
+ * @param {import('npm:express').Request} req 请求
+ * @param {object} client SocialClient
+ * @returns {Promise<object>} post handle
+ */
+function postFromParams(req, client) {
+	return client.post(routeEntityHash(req.params), String(req.params.postId))
+}
+
+/**
+ * 注册帖文创建、删除与互动路由（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerPostsRoutes(router) {
+	router.get('/api/parts/shells\\:social/posts/:entityHash/:postId', authenticate, socialJson(async (req, { client }) => {
+		const item = await client.postFeedItem(routeEntityHash(req.params), String(req.params.postId))
+		if (!item) throw httpError(404, 'post not found')
+		return { item }
+	}))
+
+	router.post('/api/parts/shells\\:social/posts', authenticate, socialJson(async (req, { client }) => {
+		const post = await client.post(req.body || {})
+		if (post?.scheduled)
+			return { scheduled: true, scheduledId: post.scheduledId, publishAt: post.publishAt }
+		return { event: post.event }
+	}))
+
+	router.get('/api/parts/shells\\:social/posts/scheduled', authenticate, socialJson(async (_req, { client }) => ({
+		items: await client.listScheduledPosts(),
+	})))
+
+	router.delete('/api/parts/shells\\:social/posts/scheduled/:scheduledId', authenticate, socialJson(async (req, { client }) => {
+		const removed = await client.cancelScheduledPost(String(req.params.scheduledId || ''))
+		if (!removed) throw httpError(404, 'scheduled post not found')
+		return { cancelled: true, scheduledId: removed.scheduledId }
+	}))
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/feature-reply', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return {
+			event: await post.featureReply({
+				replierEntityHash: req.body?.replierEntityHash,
+				replyPostId: req.body?.replyPostId,
+				feature: req.body?.feature !== false,
+			}),
+		}
+	}))
+
+	router.delete('/api/parts/shells\\:social/posts', authenticate, socialJson(async (req, { client }) => {
+		const postId = String(req.body?.postId || '')
+		if (!postId) throw httpError(400, 'postId required')
+		const entityHash = String(req.body?.entityHash || client.entityHash).trim().toLowerCase()
+		const post = await client.post(entityHash, postId)
+		return { event: await post.delete() }
+	}))
+
+	for (const { path, flag, on, off } of [
+		{ path: 'like', flag: 'like', on: 'like', off: 'unlike' },
+		{ path: 'dislike', flag: 'dislike', on: 'dislike', off: 'undislike' },
+	]) 
+		router.post(`/api/parts/shells\\:social/posts/:entityHash/:postId/${path}`, authenticate, socialJson(async (req, { client }) => {
+			const post = await postFromParams(req, client)
+			return {
+				event: req.body?.[flag] === false ? await post[off]() : await post[on](),
+			}
+		}))
+	
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/repost', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return { event: await post.repost(req.body?.comment) }
+	}))
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/poll-vote', authenticate, socialJson(async (req, { client }) => {
+		try {
+			const post = await postFromParams(req, client)
+			return { event: await post.pollVote(req.body?.choices) }
+		}
+		catch (err) {
+			throw httpError(400, err?.message || 'invalid poll vote')
+		}
+	}))
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/edit', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return {
+			event: await post.edit({
+				text: req.body?.text,
+				mediaRefs: req.body?.mediaRefs,
+				locale: req.body?.locale,
+				contentWarning: req.body?.contentWarning,
+			}),
+		}
+	}))
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/notes', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return { event: await post.addNote(req.body?.text) }
+	}))
+
+	router.get('/api/parts/shells\\:social/posts/:entityHash/:postId/notes', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return post.notes()
+	}))
+
+	router.post('/api/parts/shells\\:social/posts/:entityHash/:postId/notes/:noteEventId/vote', authenticate, socialJson(async (req, { client }) => {
+		const post = await postFromParams(req, client)
+		return {
+			event: await post.voteNote(String(req.params.noteEventId), req.body?.helpful !== false),
+		}
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/profile.mjs
+++ b/src/public/parts/shells/social/src/endpoints/profile.mjs
@@ -1,0 +1,49 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { routeEntityHash, socialJson } from './shared.mjs'
+
+/**
+ * 注册资料读路由与 meta 更新（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerProfileRoutes(router) {
+	// 静态段必须在 :entityHash 之前，否则 muted-keywords 会被当成 entityHash → 400
+	router.get('/api/parts/shells\\:social/profile/muted-keywords', authenticate, socialJson((_req, { client }) =>
+		client.mutedKeywords.list()))
+
+	router.put('/api/parts/shells\\:social/profile/muted-keywords', authenticate, socialJson((req, { client }) =>
+		client.mutedKeywords.replace(req.body?.entries || [])))
+
+	router.post('/api/parts/shells\\:social/profile/meta', authenticate, socialJson(async (req, { client }) => ({
+		socialMeta: await client.updateMeta({ hideFromDiscovery: req.body?.hideFromDiscovery }),
+	})))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash', authenticate, socialJson((req, { client }) =>
+		client.profile(routeEntityHash(req.params))))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash/posts', authenticate, socialJson((req, { client }) =>
+		client.profilePosts(routeEntityHash(req.params), {
+			limit: Number(req.query.limit) || 30,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+		})))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash/likes', authenticate, socialJson((req, { client }) =>
+		client.profileLikes(routeEntityHash(req.params))))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash/following', authenticate, socialJson((req, { client }) =>
+		client.profileFollowing(routeEntityHash(req.params))))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash/followers', authenticate, socialJson((req, { client }) =>
+		client.profileFollowers(routeEntityHash(req.params))))
+
+	router.get('/api/parts/shells\\:social/profile/:entityHash/replies/:postId', authenticate, socialJson(async (req, { client }) => {
+		const postId = String(req.params.postId)
+		if (!postId) throw httpError(400, 'invalid params')
+		return client.profileReplies(routeEntityHash(req.params), postId)
+	}))
+
+	router.post('/api/parts/shells\\:social/timeline/:entityHash/maintain', authenticate, socialJson((req, { client }) =>
+		client.maintainTimeline(routeEntityHash(req.params))))
+}

--- a/src/public/parts/shells/social/src/endpoints/relationships.mjs
+++ b/src/public/parts/shells/social/src/endpoints/relationships.mjs
@@ -1,0 +1,35 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/** @type {{ path: string, flag: string, on: string, off: string }[]} */
+const TOGGLE_RELATIONSHIPS = [
+	{ path: 'follow', flag: 'follow', on: 'follow', off: 'unfollow' },
+	{ path: 'block', flag: 'block', on: 'block', off: 'unblock' },
+	{ path: 'hide', flag: 'hide', on: 'hide', off: 'unhide' },
+	{ path: 'mute', flag: 'mute', on: 'mute', off: 'unmute' },
+]
+
+/**
+ * 注册关注、拉黑等关系写路由（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerRelationshipsRoutes(router) {
+	for (const { path, flag, on, off } of TOGGLE_RELATIONSHIPS) 
+		router.post(`/api/parts/shells\\:social/relationships/${path}`, authenticate, socialJson(async (req, { client }) => {
+			const target = req.body?.entityHash
+			if (!target) throw httpError(400, 'entityHash required')
+			return req.body?.[flag] === false
+				? await client[off](target)
+				: await client[on](target)
+		}))
+	
+
+	router.post('/api/parts/shells\\:social/relationships/follow-approve', authenticate, socialJson(async (req, { client }) => {
+		const followerPubKeyHex = String(req.body?.followerPubKeyHex || '')
+		if (!followerPubKeyHex) throw httpError(400, 'invalid request')
+		return { event: await client.approveFollow(followerPubKeyHex) }
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/saved.mjs
+++ b/src/public/parts/shells/social/src/endpoints/saved.mjs
@@ -1,0 +1,51 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册收藏帖与文件夹相关路由（client.saved.*）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerSavedRoutes(router) {
+	router.get('/api/parts/shells\\:social/saved-posts', authenticate, socialJson((_req, { client }) => client.saved.list()))
+
+	router.get('/api/parts/shells\\:social/saved-posts/search', authenticate, socialJson((req, { client }) => {
+		const q = String(req.query?.q || '')
+		const limit = req.query?.limit != null ? Number(req.query.limit) : undefined
+		return client.saved.search(q, { limit })
+	}))
+
+	router.post('/api/parts/shells\\:social/saved-posts/add', authenticate, socialJson((req, { client }) => {
+		const body = req.body || {}
+		return client.saved.add(body, body.folderId || null)
+	}))
+
+	router.post('/api/parts/shells\\:social/saved-posts/folders', authenticate, socialJson(async (req, { client }) => {
+		const name = String(req.body?.name || '').trim()
+		if (!name) throw httpError(400, 'name required')
+		return client.saved.createFolder(name)
+	}))
+
+	router.post('/api/parts/shells\\:social/saved-posts/remove', authenticate, socialJson((req, { client }) => {
+		const body = req.body || {}
+		const folderId = body.folderId !== undefined && body.folderId !== ''
+			? String(body.folderId)
+			: undefined
+		return client.saved.remove(body, folderId)
+	}))
+
+	router.post('/api/parts/shells\\:social/saved-posts/folders/rename', authenticate, socialJson(async (req, { client }) => {
+		const folderId = String(req.body?.folderId || '')
+		const name = String(req.body?.name || '').trim()
+		if (!folderId || !name) throw httpError(400, 'folderId and name required')
+		return client.saved.renameFolder(folderId, name)
+	}))
+
+	router.post('/api/parts/shells\\:social/saved-posts/folders/delete', authenticate, socialJson(async (req, { client }) => {
+		const folderId = String(req.body?.folderId || '')
+		if (!folderId) throw httpError(400, 'folderId required')
+		return client.saved.deleteFolder(folderId)
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/search.mjs
+++ b/src/public/parts/shells/social/src/endpoints/search.mjs
@@ -1,0 +1,30 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册搜索路由（SocialClient 薄封装；仅 operator）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerSearchRoutes(router) {
+	router.get('/api/parts/shells\\:social/search', authenticate, socialJson(async (req, { client }) => {
+		const searchQuery = String(req.query.q || '').trim()
+		const hasFilter = Boolean(req.query.author || req.query.media || req.query.tag || req.query.scope)
+		if (searchQuery.length < 2 && !hasFilter)
+			throw httpError(400, 'query must be at least 2 characters')
+		return client.search(searchQuery || String(req.query.tag || req.query.media || 'media'), {
+			limit: Number(req.query.limit) || 30,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+			author: req.query.author ? String(req.query.author) : undefined,
+			media: req.query.media ? String(req.query.media) : undefined,
+			tag: req.query.tag ? String(req.query.tag) : undefined,
+			before: req.query.before ? Number(req.query.before) : undefined,
+			after: req.query.after ? Number(req.query.after) : undefined,
+			sort: req.query.sort ? String(req.query.sort) : undefined,
+			scope: req.query.scope ? String(req.query.scope) : undefined,
+			q: searchQuery,
+		})
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/shared.mjs
+++ b/src/public/parts/shells/social/src/endpoints/shared.mjs
@@ -1,0 +1,37 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { getUserByReq } from '../../../../../../server/auth/index.mjs'
+
+/**
+ * @param {import('npm:express').Request['params']} params 路由 params
+ * @returns {string} 小写 entityHash
+ */
+export function routeEntityHash(params) {
+	const hash = String(params.entityHash).toLowerCase()
+	if (!isEntityHash128(hash))
+		throw httpError(400, 'invalid entityHash')
+	return hash
+}
+
+/**
+ * 从请求解析会话用户并以 operator 身份取得 SocialClient（HTTP 永不接受 acting 覆盖）。
+ * @param {import('npm:express').Request} req Express 请求
+ * @returns {Promise<{ username: string, client: object }>} 用户名与 client
+ */
+export async function socialClientFromReq(req) {
+	const { username } = getUserByReq(req)
+	const { getSocialClient } = await import('../api/client/index.mjs')
+	return { username, client: await getSocialClient(username) }
+}
+
+/**
+ * SocialClient JSON 路由薄包装：解析 client → 跑 handler → 200 JSON。
+ * @param {(req: import('npm:express').Request, session: { username: string, client: object }) => Promise<unknown>} handler 业务
+ * @returns {import('npm:express').RequestHandler} Express 处理器
+ */
+export function socialJson(handler) {
+	return async (req, res) => {
+		res.status(200).json(await handler(req, await socialClientFromReq(req)))
+	}
+}

--- a/src/public/parts/shells/social/src/endpoints/signals.mjs
+++ b/src/public/parts/shells/social/src/endpoints/signals.mjs
@@ -1,0 +1,16 @@
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+import { appendDwellSignals } from '../engagement/dwell.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 本地隐私信号路由（不联邦）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerSignalsRoutes(router) {
+	router.post('/api/parts/shells\\:social/signals/dwell', authenticate, socialJson((req, { username, client }) => {
+		const rows = Array.isArray(req.body?.entries) ? req.body.entries : Array.isArray(req.body) ? req.body : []
+		return appendDwellSignals(username, client.entityHash, rows.slice(0, 50))
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/taste.mjs
+++ b/src/public/parts/shells/social/src/endpoints/taste.mjs
@@ -1,0 +1,32 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { primaryLocaleForUser } from '../../../../../../scripts/locale.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 偏好 / 口味标签 HTTP（人与 agent 同入口；HTTP 固定 operator，agent 用 SocialClient）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerTasteRoutes(router) {
+	router.get('/api/parts/shells\\:social/taste', authenticate, socialJson((req, { username, client }) =>
+		client.taste.get({ locale: String(req.query.locale || primaryLocaleForUser(username)) })))
+
+	router.put('/api/parts/shells\\:social/taste', authenticate, socialJson((req, { client }) =>
+		client.taste.update(req.body || {})))
+
+	router.post('/api/parts/shells\\:social/taste/rebuild', authenticate, socialJson((_req, { client }) =>
+		client.taste.rebuild()))
+
+	router.post('/api/parts/shells\\:social/taste/names', authenticate, socialJson(async (req, { username, client }) => {
+		const tagHash = String(req.body?.tagHash || '').trim()
+		const label = String(req.body?.label || '').trim()
+		const locale = String(req.body?.locale || primaryLocaleForUser(username)).trim()
+		if (!tagHash || !label) throw httpError(400, 'tagHash and label required')
+		return client.taste.setName({ tagHash, label, locale })
+	}))
+
+	router.delete('/api/parts/shells\\:social/taste/aliases/:fromTag', authenticate, socialJson((req, { client }) =>
+		client.taste.revokeAlias(String(req.params.fromTag || ''))))
+}

--- a/src/public/parts/shells/social/src/endpoints/testSeed.mjs
+++ b/src/public/parts/shells/social/src/endpoints/testSeed.mjs
@@ -1,0 +1,129 @@
+/**
+ * FOUNT_TEST 专用：Playwright / live 探针注入联邦互动通知。
+ */
+import { cp, mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { ensureLocalAgentEntityHash } from 'fount/public/parts/shells/chat/src/entity/member.mjs'
+import { encodeEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pubKeyHash, publicKeyFromSeed } from 'npm:@steve02081504/fount-p2p/crypto'
+import { appendJsonlSynced } from 'npm:@steve02081504/fount-p2p/dag/storage'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { getUserByReq, getUserDictionary } from '../../../../../../server/auth/index.mjs'
+import { resolveOperatorEntityHashForUser } from '../../../chat/src/entity/identity.mjs'
+import { seedRemoteTimeline, randomSeed } from '../../test/federation/remote_timeline.mjs'
+import { FOREIGN_FE_AUTHOR_HASH, FOREIGN_FE_SEED } from '../../test/seedForeignFeedAuthor.mjs'
+import { inboxEventsPath } from '../inbox.mjs'
+import { ensureEntitySocialReady } from '../lib/bootstrap.mjs'
+
+/**
+ * @returns {void}
+ */
+function assertTestMode() {
+	if (process.env.FOUNT_TEST !== '1' && process.env.FOUNT_TEST_ISOLATED !== '1')
+		throw httpError(404, 'not found')
+}
+
+/**
+ * @param {import('npm:express').Router} router Express 路由
+ * @param {import('npm:express').RequestHandler} authenticate 鉴权
+ * @returns {void}
+ */
+export function registerTestSeedRoutes(router, authenticate) {
+	router.post('/api/parts/shells\\:social/test/foreign-like', authenticate, async (req, res) => {
+		assertTestMode()
+		const { username } = getUserByReq(req)
+		const targetEntityHash = String(req.body?.targetEntityHash || '').trim().toLowerCase()
+		const targetPostId = String(req.body?.targetPostId || '').trim()
+		if (!targetEntityHash || !targetPostId)
+			throw httpError(400, 'targetEntityHash and targetPostId required')
+		await seedRemoteTimeline(username, FOREIGN_FE_SEED, FOREIGN_FE_AUTHOR_HASH, [
+			{ type: 'like', content: { targetEntityHash, targetPostId } },
+		])
+		res.status(200).json({})
+	})
+
+	router.post('/api/parts/shells\\:social/test/inbox-likes', authenticate, async (req, res) => {
+		assertTestMode()
+		const { username } = getUserByReq(req)
+		const targetEntityHash = String(req.body?.targetEntityHash || '').trim().toLowerCase()
+		const targetPostId = String(req.body?.targetPostId || '').trim()
+		const count = Math.min(Math.max(Number(req.body?.count) || 2, 1), 200)
+		if (!targetEntityHash || !targetPostId)
+			throw httpError(400, 'targetEntityHash and targetPostId required')
+		const eventsPath = inboxEventsPath(username, targetEntityHash)
+		for (let index = 0; index < count; index++) {
+			const seed = randomSeed()
+			const actor = encodeEntityHash('4'.repeat(64), pubKeyHash(publicKeyFromSeed(seed)))
+			await appendJsonlSynced(eventsPath, {
+				type: 'like',
+				actorEntityHash: actor,
+				postId: null,
+				targetPostId,
+				targetEntityHash,
+				snippet: 'aggregated like target',
+				at: Date.now() - index,
+			})
+		}
+		res.status(200).json({ count })
+	})
+
+	router.post('/api/parts/shells\\:social/test/inbox-mentions', authenticate, async (req, res) => {
+		assertTestMode()
+		const { username } = getUserByReq(req)
+		const count = Math.min(Math.max(Number(req.body?.count) || 41, 1), 200)
+		const viewerEntityHash = (await resolveOperatorEntityHashForUser(username))?.toLowerCase()
+		if (!viewerEntityHash)
+			throw httpError(400, 'identity required')
+		const eventsPath = inboxEventsPath(username, viewerEntityHash)
+		for (let index = 0; index < count; index++) {
+			const seed = randomSeed()
+			const actor = encodeEntityHash('4'.repeat(64), pubKeyHash(publicKeyFromSeed(seed)))
+			await appendJsonlSynced(eventsPath, {
+				type: 'mention',
+				actorEntityHash: actor,
+				postId: `seed-mention-${index}`,
+				targetPostId: null,
+				snippet: `seed mention ${index}`,
+				at: Date.now() - index,
+			})
+		}
+		res.status(200).json({ count })
+	})
+
+	router.post('/api/parts/shells\\:social/test/seed-local-agent', authenticate, async (req, res) => {
+		assertTestMode()
+		const { username } = getUserByReq(req)
+		const charPartName = String(req.body?.charPartName || 'social_on_message_probe').trim()
+		const fixturesRoot = join(dirname(fileURLToPath(import.meta.url)), '../../test/fixtures/chars')
+		const from = join(fixturesRoot, charPartName)
+		const to = join(getUserDictionary(username), 'chars', charPartName)
+		await mkdir(to, { recursive: true })
+		await cp(from, to, { recursive: true })
+		const entityHash = await ensureLocalAgentEntityHash(username, charPartName)
+		await ensureEntitySocialReady(username, entityHash)
+		res.status(200).json({ entityHash, charPartName })
+	})
+
+	router.post('/api/parts/shells\\:social/test/inbox-mention-for', authenticate, async (req, res) => {
+		assertTestMode()
+		const { username } = getUserByReq(req)
+		const recipientEntityHash = String(req.body?.recipientEntityHash || '').trim().toLowerCase()
+		if (!recipientEntityHash)
+			throw httpError(400, 'recipientEntityHash required')
+		const seed = randomSeed()
+		const actor = encodeEntityHash('4'.repeat(64), pubKeyHash(publicKeyFromSeed(seed)))
+		const postId = String(req.body?.postId || `seed-mention-${Date.now()}`)
+		await appendJsonlSynced(inboxEventsPath(username, recipientEntityHash), {
+			type: 'mention',
+			actorEntityHash: actor,
+			postId,
+			targetPostId: null,
+			snippet: String(req.body?.snippet || 'agent acting mention'),
+			at: Date.now(),
+		})
+		res.status(200).json({ postId, recipientEntityHash })
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/topics.mjs
+++ b/src/public/parts/shells/social/src/endpoints/topics.mjs
@@ -1,0 +1,29 @@
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 话题订阅与话题帖流。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerTopicsRoutes(router) {
+	router.post('/api/parts/shells\\:social/topics/follow', authenticate, socialJson(async (req, { client }) => {
+		const tag = String(req.body?.tag || '').trim()
+		if (!tag) throw httpError(400, 'tag required')
+		return client.followTopic(tag, req.body?.follow !== false)
+	}))
+
+	router.get('/api/parts/shells\\:social/topics/followed', authenticate, socialJson((_req, { client }) =>
+		client.followedTopics()))
+
+	router.get('/api/parts/shells\\:social/topics/:tag/posts', authenticate, socialJson(async (req, { client }) => {
+		const tag = String(req.params.tag || '').trim()
+		if (!tag) throw httpError(400, 'tag required')
+		return client.topicPosts(tag, {
+			limit: Number(req.query.limit) || 30,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+		})
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/translate.mjs
+++ b/src/public/parts/shells/social/src/endpoints/translate.mjs
@@ -1,0 +1,22 @@
+import { primaryLocaleForUser } from '../../../../../../scripts/locale.mjs'
+import { authenticate, getUserByReq } from '../../../../../../server/auth/index.mjs'
+import { cacheTranslation, getCachedTranslation, translatePostText } from '../translate.mjs'
+
+/**
+ * 注册翻译路由。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerTranslateRoutes(router) {
+	router.post('/api/parts/shells\\:social/translate', authenticate, async (req, res) => {
+		const { username } = getUserByReq(req)
+		const text = String(req.body?.text || '')
+		const targetLang = String(req.body?.targetLang || primaryLocaleForUser(username))
+		const cacheKey = `${targetLang}:${text.slice(0, 2000)}`
+		const cached = getCachedTranslation(username, cacheKey)
+		if (cached) return res.status(200).json({ translated: cached, cached: true })
+		const translated = await translatePostText(text, targetLang)
+		cacheTranslation(username, cacheKey, translated)
+		res.status(200).json({ translated, cached: false })
+	})
+}

--- a/src/public/parts/shells/social/src/endpoints/vault.mjs
+++ b/src/public/parts/shells/social/src/endpoints/vault.mjs
@@ -1,0 +1,24 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 注册 vault 文件相关路由（client.vault.*）。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerVaultRoutes(router) {
+	router.post('/api/parts/shells\\:social/files', authenticate, socialJson((req, { client }) =>
+		client.vault.registerFile(req.body)))
+
+	router.get('/api/parts/shells\\:social/files/:shareId', authenticate, socialJson(async (req, { client }) => {
+		const owner = String(req.query.owner || client.entityHash || '').toLowerCase()
+		if (!isEntityHash128(owner)) throw httpError(400, 'invalid owner')
+		const entry = await client.vault.getFile(String(req.params.shareId), owner)
+		if (!entry) throw httpError(404, 'not found')
+		return { entry }
+	}))
+}

--- a/src/public/parts/shells/social/src/endpoints/videos.mjs
+++ b/src/public/parts/shells/social/src/endpoints/videos.mjs
@@ -1,0 +1,16 @@
+import { authenticate } from '../../../../../../server/auth/index.mjs'
+
+import { socialJson } from './shared.mjs'
+
+/**
+ * 短视频流路由。
+ * @param {import('npm:express').Router} router Express 路由
+ * @returns {void}
+ */
+export function registerVideosRoutes(router) {
+	router.get('/api/parts/shells\\:social/videos/feed', authenticate, socialJson((req, { client }) =>
+		client.videosFeed({
+			limit: Number(req.query.limit) || 20,
+			cursor: req.query.cursor ? String(req.query.cursor) : undefined,
+		})))
+}

--- a/src/public/parts/shells/social/src/engagement/dwell.mjs
+++ b/src/public/parts/shells/social/src/engagement/dwell.mjs
@@ -1,0 +1,125 @@
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { getUserDictionary } from '../../../../../../server/auth/index.mjs'
+import {
+	AUTHOR_BOOST_PER_DWELL,
+	normalizeDwellEntry,
+	TAG_WEIGHT_PER_DWELL,
+} from '../lib/dwellSignal.mjs'
+import { extractHashtagsFromText } from '../lib/hashtags.mjs'
+
+/**
+ *
+ */
+export {
+	AUTHOR_BOOST_PER_DWELL,
+	DWELL_MIN_MS,
+	normalizeDwellEntry,
+	TAG_WEIGHT_PER_DWELL,
+} from '../lib/dwellSignal.mjs'
+
+const DWELL_RETENTION_MS = 30 * 86_400_000
+const DWELL_MAX_LINES = 5000
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 观看者
+ * @returns {string} dwell.jsonl 路径
+ */
+export function dwellLogPath(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return path.join(getUserDictionary(username), 'shells/social/taste/dwell', `${hash}.jsonl`)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 观看者
+ * @returns {Promise<object[]>} 未过期条目
+ */
+export async function loadDwellEntries(username, entityHash) {
+	const filePath = dwellLogPath(username, entityHash)
+	try {
+		const text = await readFile(filePath, 'utf8')
+		const cutoff = Date.now() - DWELL_RETENTION_MS
+		const entries = []
+		for (const line of text.split('\n')) {
+			if (!line.trim()) continue
+			try {
+				const entry = normalizeDwellEntry(JSON.parse(line))
+				if (!entry || entry.at < cutoff) continue
+				entries.push(entry)
+			}
+			catch { /* skip bad line */ }
+		}
+		return entries.slice(-DWELL_MAX_LINES)
+	}
+	catch (err) {
+		if (err?.code === 'ENOENT') return []
+		throw err
+	}
+}
+
+/**
+ * 追加停留信号并滚动裁剪旧数据。
+ * @param {string} username replica
+ * @param {string} entityHash 观看者
+ * @param {object[]} rows 信号列表
+ * @returns {Promise<{ accepted: number }>} 写入统计
+ */
+export async function appendDwellSignals(username, entityHash, rows) {
+	const accepted = []
+	for (const raw of rows || []) {
+		const entry = normalizeDwellEntry(raw)
+		if (entry) accepted.push(entry)
+	}
+	if (!accepted.length) return { accepted: 0 }
+	const filePath = dwellLogPath(username, entityHash)
+	await mkdir(path.dirname(filePath), { recursive: true })
+	const payload = `${accepted.map(entry => JSON.stringify(entry)).join('\n')}\n`
+	await appendFile(filePath, payload, 'utf8')
+
+	const all = await loadDwellEntries(username, entityHash)
+	if (all.length > DWELL_MAX_LINES * 0.9) {
+		const kept = all.slice(-Math.floor(DWELL_MAX_LINES * 0.8))
+		await writeFile(filePath, `${kept.map(entry => JSON.stringify(entry)).join('\n')}\n`, 'utf8')
+	}
+	return { accepted: accepted.length }
+}
+
+/**
+ * 作者亲和弱加权（每次有效停留 +0.25）。
+ * @param {string} username replica
+ * @param {string} entityHash 观看者
+ * @returns {Promise<Map<string, number>>} 作者 → dwell 亲和加成
+ */
+export async function loadDwellAuthorBoosts(username, entityHash) {
+	/** @type {Map<string, number>} */
+	const boosts = new Map()
+	for (const entry of await loadDwellEntries(username, entityHash))
+		boosts.set(entry.author, (boosts.get(entry.author) || 0) + AUTHOR_BOOST_PER_DWELL)
+	return boosts
+}
+
+/**
+ * 标签弱证据（每次有效停留对帖标签 +0.15）。
+ * @param {string} username replica
+ * @param {string} entityHash 观看者
+ * @returns {Promise<Map<string, number>>} tag → 权重增量
+ */
+export async function loadDwellTagBoosts(username, entityHash) {
+	/** @type {Map<string, number>} */
+	const boosts = new Map()
+	for (const entry of await loadDwellEntries(username, entityHash))
+		for (const tag of entry.tags)
+			boosts.set(tag, (boosts.get(tag) || 0) + TAG_WEIGHT_PER_DWELL)
+	return boosts
+}
+
+/**
+ * @param {string} text 正文
+ * @returns {string[]} 标签
+ */
+export function tagsFromPostText(text) {
+	return extractHashtagsFromText(text)
+}

--- a/src/public/parts/shells/social/src/federation/backfill.mjs
+++ b/src/public/parts/shells/social/src/federation/backfill.mjs
@@ -1,0 +1,77 @@
+/**
+ * Feed 空/不足时的联邦补给：一跳关注 sync → 一跳 discover+sync → 多跳 post_discover ingest。
+ */
+import { discoverWithNetwork } from '../discover/network.mjs'
+import { collectNearbyPostDiscover } from '../discover/postDiscover.mjs'
+import { ingestRemoteTimelineEvent, syncFollowingTimelines, syncTimelineForEntity } from '../timeline/sync.mjs'
+
+/** @type {Map<string, Promise<object>>} */
+const inFlight = new Map()
+
+/**
+ * @param {string} username replica
+ * @param {object} [options] 选项
+ * @param {string} [options.viewerEntityHash] 观看者
+ * @param {boolean} [options.mediaOnly] 仅媒体帖
+ * @param {() => Promise<boolean> | boolean} [options.enough] 本地是否已足够（每步后检查）
+ * @returns {Promise<{ phase: string, imported: number }>} 补给结果
+ */
+export async function backfillPosts(username, options = {}) {
+	const mediaOnly = options.mediaOnly === true
+	const key = `${username}:${mediaOnly ? 'media' : 'all'}`
+	const existing = inFlight.get(key)
+	if (existing) return existing
+
+	const promise = runBackfill(username, options).finally(() => {
+		if (inFlight.get(key) === promise) inFlight.delete(key)
+	})
+	inFlight.set(key, promise)
+	return promise
+}
+
+/**
+ * @param {string} username replica
+ * @param {object} options 选项
+ * @returns {Promise<{ phase: string, imported: number }>} 结果
+ */
+async function runBackfill(username, options) {
+	const enough = typeof options.enough === 'function'
+		? options.enough
+		: async () => false
+	let imported = 0
+
+	if (await enough()) return { phase: 'skip', imported: 0 }
+
+	const syncStats = await syncFollowingTimelines(username)
+	imported += Number(syncStats.imported) || 0
+	if (await enough()) return { phase: 'following', imported }
+
+	const discovered = await discoverWithNetwork(username, {
+		type: 'social_post_discover_request',
+		n: 20,
+		mediaOnly: options.mediaOnly === true,
+	}, { viewerEntityHash: options.viewerEntityHash || null })
+
+	const entityHashes = [...new Set(
+		(discovered.posts || [])
+			.map(row => String(row.entityHash || '').toLowerCase())
+			.filter(Boolean),
+	)].slice(0, 16)
+
+	const discoverResults = await Promise.allSettled(
+		entityHashes.map(entityHash => syncTimelineForEntity(username, entityHash)),
+	)
+	for (const result of discoverResults)
+		if (result.status === 'fulfilled') imported += result.value
+	if (await enough()) return { phase: 'discover', imported }
+
+	const { items } = await collectNearbyPostDiscover(username, {
+		limit: 24,
+		mediaOnly: options.mediaOnly === true,
+		ttl: 3,
+	})
+	for (const item of items)
+		if (await ingestRemoteTimelineEvent(username, item.entityHash, item.event))
+			imported++
+	return { phase: 'multihop', imported }
+}

--- a/src/public/parts/shells/social/src/federation/entity_key_auth.mjs
+++ b/src/public/parts/shells/social/src/federation/entity_key_auth.mjs
@@ -1,0 +1,78 @@
+/**
+ * Social 时间线实体写授权（含 social_meta 创世语义）。
+ */
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import {
+	activeSenderHashFromPubKeyHex,
+	foldEntityKeyHistoryFromEvents as foldRotateRevokeHistory,
+	isRecoverySender,
+	isValidActiveSender,
+	resolveActiveKeyAtGeneration,
+	isActiveGenerationRevoked,
+} from 'npm:@steve02081504/fount-p2p/federation/entity_key_chain'
+
+/**
+ * 折叠时间线事件中的 recovery 公钥与实体密钥链（含 social_meta）。
+ * @param {object[]} events 时间线事件（拓扑序）
+ * @returns {{ recoveryPubKeyHex: string | null, entityKeyHistory: import('npm:@steve02081504/fount-p2p/federation/entity_key_chain').EntityKeyHistoryEntry[] }} 实体密钥链折叠结果
+ */
+export function foldEntityKeyHistoryFromEvents(events) {
+	let recoveryPubKeyHex = null
+	for (const event of events || []) {
+		if (event.type === 'social_meta' && isHex64(normalizeHex64(event.content?.recoveryPubKeyHex || '')))
+			recoveryPubKeyHex = normalizeHex64(event.content.recoveryPubKeyHex)
+		// gen0 rotate 的 senderPubKey 即 recovery 公钥（无 social_meta 时的引导落点）
+		if (!recoveryPubKeyHex && event.type === 'entity_key_rotate' && Number(event.content?.generation) === 0) {
+			const pk = normalizeHex64(event.senderPubKey || '')
+			if (isHex64(pk)) recoveryPubKeyHex = pk
+		}
+	}
+
+	const folded = foldRotateRevokeHistory(events)
+	return {
+		recoveryPubKeyHex: recoveryPubKeyHex ?? folded.recoveryPubKeyHex,
+		entityKeyHistory: folded.entityKeyHistory,
+	}
+}
+
+/**
+ * @param {object} params 授权参数
+ * @param {string} params.entityHash 时间线 owner
+ * @param {string} params.sender 事件 sender pubKeyHash
+ * @param {string} params.eventType 事件 type
+ * @param {object} [params.eventContent] 事件 content
+ * @param {string | null} params.recoveryPubKeyHex recovery 公钥
+ * @param {import('npm:@steve02081504/fount-p2p/federation/entity_key_chain').EntityKeyHistoryEntry[]} params.entityKeyHistory 密钥历史
+ * @returns {boolean} 是否授权写入
+ */
+export function isEntityTimelineWriteAuthorized({
+	entityHash,
+	sender,
+	eventType,
+	eventContent,
+	recoveryPubKeyHex,
+	entityKeyHistory,
+}) {
+	void entityHash
+	const normalizedSender = normalizeHex64(sender)
+	if (!isHex64(normalizedSender) || !recoveryPubKeyHex) return false
+
+	if (eventType === 'entity_key_rotate') {
+		const generation = Number(eventContent?.generation)
+		if (generation === 0)
+			return isRecoverySender(recoveryPubKeyHex, normalizedSender)
+		const prevGen = Number(eventContent?.prevGeneration ?? generation - 1)
+		const prevActive = resolveActiveKeyAtGeneration(entityKeyHistory, prevGen)
+		if (!prevActive || isActiveGenerationRevoked(entityKeyHistory, prevGen)) return false
+		return activeSenderHashFromPubKeyHex(prevActive) === normalizedSender
+	}
+
+	if (eventType === 'entity_key_revoke')
+		return isRecoverySender(recoveryPubKeyHex, normalizedSender)
+
+	if (eventType === 'social_meta')
+		return isRecoverySender(recoveryPubKeyHex, normalizedSender)
+			|| isValidActiveSender(entityKeyHistory, recoveryPubKeyHex, normalizedSender)
+
+	return isValidActiveSender(entityKeyHistory, recoveryPubKeyHex, normalizedSender)
+}

--- a/src/public/parts/shells/social/src/federation/follower/index.mjs
+++ b/src/public/parts/shells/social/src/federation/follower/index.mjs
@@ -1,0 +1,297 @@
+import path from 'node:path'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { writeJsonAtomic } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { getNodeDir } from 'npm:@steve02081504/fount-p2p/node/instance'
+import { withAsyncMutex } from 'npm:@steve02081504/fount-p2p/utils/async_mutex'
+import { createLruMap } from 'npm:@steve02081504/fount-p2p/utils/lru'
+
+import { resolveSocialEntity } from '../hosting.mjs'
+
+import { getReplicaUsernamesProvider } from './registry.mjs'
+
+const FOLLOWER_ENTRY_CACHE_MAX = 512
+const BUCKET_HEX_PREFIX_LEN = 2
+
+/** @typedef {{ replicaUsername: string, entityHash: string }} FollowerIndexEntry */
+
+/** @type {ReturnType<typeof createLruMap<string, FollowerIndexEntry[]>>} */
+const followerEntryCache = createLruMap(FOLLOWER_ENTRY_CACHE_MAX)
+
+/**
+ * @param {FollowerIndexEntry} row 索引行
+ * @returns {string} 去重键
+ */
+function followerEntryKey(row) {
+	return `${row.replicaUsername}\0${row.entityHash}`
+}
+
+/**
+ * @param {string} target targetEntityHash
+ * @param {() => Promise<void>} task 突变
+ * @returns {Promise<void>}
+ */
+function queueFollowerIndexMutation(target, task) {
+	return withAsyncMutex(`follower-index:${target}`, () => task().catch(err => {
+		console.error('follower_index: mutation failed', err)
+	}))
+}
+
+/**
+ * @returns {string} follower 索引根目录
+ */
+function followerIndexDir() {
+	return path.join(getNodeDir(), 'social', 'follower_index')
+}
+
+/**
+ * @returns {string} 按 hash 前两字符分桶的目录
+ */
+function followerBucketsDir() {
+	return path.join(followerIndexDir(), 'buckets')
+}
+
+/**
+ * @param {string} targetEntityHash 128 hex
+ * @returns {string} 分桶 id（hex 前缀）
+ */
+function followerBucketId(targetEntityHash) {
+	return targetEntityHash.slice(0, BUCKET_HEX_PREFIX_LEN)
+}
+
+/**
+ * @param {string} bucketId 分桶 id
+ * @returns {string} 桶文件路径（多 target 合并为单 JSON，避免百万 inode）
+ */
+function followerBucketPath(bucketId) {
+	return path.join(followerBucketsDir(), `${bucketId}.json`)
+}
+
+/**
+ * @param {unknown} row 桶内条目
+ * @returns {FollowerIndexEntry | null} 规范化 follower 行
+ */
+function normalizeFollowerEntry(row) {
+	if (!row?.replicaUsername) return null
+	return {
+		replicaUsername: String(row.replicaUsername),
+		entityHash: String(row.entityHash || '').trim().toLowerCase(),
+	}
+}
+
+/**
+ * @param {string} bucketId 分桶 id
+ * @returns {Promise<Record<string, FollowerIndexEntry[]>>} target → follower 列表
+ */
+async function readFollowerBucket(bucketId) {
+	const { readFile } = await import('node:fs/promises')
+	try {
+		const raw = JSON.parse(await readFile(followerBucketPath(bucketId), 'utf8'))
+		/** @type {Record<string, FollowerIndexEntry[]>} */
+		const bucket = {}
+		for (const [target, rows] of Object.entries(raw)) {
+			if (!Array.isArray(rows)) continue
+			const list = rows.map(normalizeFollowerEntry).filter(Boolean)
+			if (list.length) bucket[target] = list
+		}
+		return bucket
+	}
+	catch (err) {
+		if (err?.code !== 'ENOENT') throw err
+		return {}
+	}
+}
+
+/**
+ * @param {string} bucketId 分桶 id
+ * @param {Record<string, FollowerIndexEntry[]>} bucket target → followers
+ * @returns {Promise<void>}
+ */
+async function writeFollowerBucket(bucketId, bucket) {
+	const { mkdir, unlink } = await import('node:fs/promises')
+	const dir = followerBucketsDir()
+	await mkdir(dir, { recursive: true })
+	const keys = Object.keys(bucket)
+	if (!keys.length) {
+		try {
+			await unlink(followerBucketPath(bucketId))
+		}
+		catch { /* missing */ }
+		return
+	}
+	await writeJsonAtomic(followerBucketPath(bucketId), bucket)
+}
+
+/**
+ * @param {FollowerIndexEntry[]} followers follower 列表
+ * @returns {FollowerIndexEntry[]} 去重后列表
+ */
+function dedupeFollowerEntries(followers) {
+	/** @type {Map<string, FollowerIndexEntry>} */
+	const map = new Map()
+	for (const row of followers) {
+		const entry = normalizeFollowerEntry(row)
+		if (!entry?.replicaUsername || !entry.entityHash) continue
+		map.set(followerEntryKey(entry), entry)
+	}
+	return [...map.values()]
+}
+
+/**
+ * @param {string} target 128 hex
+ * @returns {Promise<FollowerIndexEntry[]>} 关注该 target 的本机 entity（缓存数组勿原地修改）
+ */
+async function readFollowerEntry(target) {
+	const cached = followerEntryCache.get(target)
+	if (cached) {
+		followerEntryCache.touch(target, cached)
+		return cached
+	}
+	const bucket = await readFollowerBucket(followerBucketId(target))
+	const followers = bucket[target] ? [...bucket[target]] : []
+	followerEntryCache.touch(target, followers)
+	return followers
+}
+
+/**
+ * @param {string} target 128 hex
+ * @param {FollowerIndexEntry[]} followers follower 列表
+ * @returns {Promise<void>}
+ */
+async function writeFollowerEntry(target, followers) {
+	const bucketId = followerBucketId(target)
+	const bucket = await readFollowerBucket(bucketId)
+	const list = dedupeFollowerEntries(followers)
+	if (!list.length) {
+		delete bucket[target]
+		followerEntryCache.delete(target)
+	}
+	else {
+		bucket[target] = list
+		followerEntryCache.touch(target, list)
+	}
+	await writeFollowerBucket(bucketId, bucket)
+}
+
+/**
+ * follow/unfollow 后更新反向索引（本机 entity 时间线为真相源，此为查询投影）。
+ * @param {string} username replica 登录名
+ * @param {string} targetEntityHash 被关注实体
+ * @param {boolean} follow true=关注
+ * @param {string} followerEntityHash 关注者 entityHash
+ * @returns {Promise<void>}
+ */
+export async function updateFollowerIndex(username, targetEntityHash, follow, followerEntityHash) {
+	const target = targetEntityHash.toLowerCase()
+	const follower = String(followerEntityHash || '').trim().toLowerCase()
+	if (!follower) return
+	await queueFollowerIndexMutation(target, async () => {
+		const list = dedupeFollowerEntries(await readFollowerEntry(target))
+		const key = followerEntryKey({ replicaUsername: username, entityHash: follower })
+		if (follow) {
+			if (!list.some(row => followerEntryKey(row) === key))
+				list.push({ replicaUsername: username, entityHash: follower })
+		}
+		else {
+			const next = list.filter(row => followerEntryKey(row) !== key)
+			await writeFollowerEntry(target, next)
+			return
+		}
+		await writeFollowerEntry(target, list)
+	})
+}
+
+/**
+ * 时间线 follow/unfollow 写入或入站后更新反向索引（本地与已同步远程时间线均可）。
+ * @param {string} replicaUsername replica 登录名
+ * @param {string} timelineOwnerEntityHash 时间线 owner（关注者）
+ * @param {object} event 签名事件
+ * @returns {Promise<void>}
+ */
+export async function projectFollowerIndexFromTimelineEvent(replicaUsername, timelineOwnerEntityHash, event) {
+	if (!['follow', 'unfollow'].includes(event.type)) return
+	const owner = timelineOwnerEntityHash.toLowerCase()
+	if (!parseEntityHash(owner)) return
+	const target = String(event.content?.targetEntityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(target) || target === owner) return
+	await updateFollowerIndex(
+		replicaUsername,
+		target,
+		event.type === 'follow',
+		owner,
+	)
+}
+
+/**
+ * 本 replica 已知的关注者（含已同步远程时间线投影；资料粉丝列表用）。
+ * @param {string} entityHash 被关注实体
+ * @returns {Promise<FollowerIndexEntry[]>} replica + follower entityHash
+ */
+export async function listKnownFollowersOf(entityHash) {
+	const target = entityHash.toLowerCase()
+	if (!parseEntityHash(target)) return []
+	return dedupeFollowerEntries(await readFollowerEntry(target))
+}
+
+/**
+ * 本机托管 entity 中关注了 target 的条目（通知/直播投递用，勿把远程实体当收件人）。
+ * @param {string} entityHash 被关注实体
+ * @returns {Promise<FollowerIndexEntry[]>} replica + follower entityHash
+ */
+export async function listLocalFollowersOf(entityHash) {
+	const known = await listKnownFollowersOf(entityHash)
+	/** @type {FollowerIndexEntry[]} */
+	const local = []
+	for (const row of known) {
+		const resolved = await resolveSocialEntity(row.entityHash, row.replicaUsername)
+		if (!resolved?.local || resolved.replicaUsername !== row.replicaUsername) continue
+		local.push(row)
+	}
+	return local
+}
+
+/**
+ * 冷启动：扫描本实例全部 replica 已知时间线 owner（含远程副本），重建 follower 投影。
+ * @returns {Promise<void>}
+ */
+export async function rebuildFollowerIndex() {
+	const listUsers = getReplicaUsernamesProvider()
+	if (!listUsers) return
+	const { getTimelineOwnerIndex } = await import('../../timeline/ownerIndex.mjs')
+	const { getTimelineMaterialized } = await import('../../timeline/materialize.mjs')
+	/** @type {Record<string, Record<string, Map<string, FollowerIndexEntry>>>} */
+	const scratch = {}
+	for (const username of listUsers())
+		for (const owner of (await getTimelineOwnerIndex(username)).all) {
+			const ownerKey = String(owner || '').toLowerCase()
+			if (!parseEntityHash(ownerKey)) continue
+			const view = await getTimelineMaterialized(username, ownerKey)
+			for (const rawTarget of view.following || []) {
+				const target = rawTarget.toLowerCase()
+				if (!parseEntityHash(target) || target === ownerKey) continue
+				const bucketId = followerBucketId(target)
+				scratch[bucketId] ??= {}
+				scratch[bucketId][target] ??= new Map()
+				const entry = { replicaUsername: username, entityHash: ownerKey }
+				scratch[bucketId][target].set(followerEntryKey(entry), entry)
+			}
+		}
+
+	const { mkdir, readdir, unlink } = await import('node:fs/promises')
+	const bucketsDir = followerBucketsDir()
+	await mkdir(bucketsDir, { recursive: true })
+	for (const name of await readdir(bucketsDir).catch(() => [])) {
+		if (!name.endsWith('.json')) continue
+		await unlink(path.join(bucketsDir, name)).catch(() => {})
+	}
+	followerEntryCache.clear()
+	for (const [bucketId, targets] of Object.entries(scratch)) {
+		/** @type {Record<string, FollowerIndexEntry[]>} */
+		const bucket = {}
+		for (const [target, map] of Object.entries(targets))
+			bucket[target] = [...map.values()]
+		await writeFollowerBucket(bucketId, bucket)
+		for (const [target, list] of Object.entries(bucket))
+			followerEntryCache.touch(target, list)
+	}
+}

--- a/src/public/parts/shells/social/src/federation/follower/registry.mjs
+++ b/src/public/parts/shells/social/src/federation/follower/registry.mjs
@@ -1,0 +1,71 @@
+/** @type {((username: string) => Promise<string[]>) | null} */
+let scanFollowingForUser = null
+
+/** @type {(() => Iterable<string>) | null} */
+let listReplicaUsernames = null
+
+/** @type {((username: string) => Promise<string | null>) | null} */
+let resolveOperatorEntityHash = null
+
+/**
+ * Social Load 时注册：从 operator 时间线物化读取 following。
+ * @param {(username: string) => Promise<string[]>} provider 扫描函数
+ * @returns {void}
+ */
+export function registerFollowingScanProvider(provider) {
+	scanFollowingForUser = provider
+}
+
+/**
+ * Social Load 时注册：枚举本实例 replica 登录名。
+ * @param {() => Iterable<string>} provider 用户名枚举
+ * @returns {void}
+ */
+export function registerReplicaUsernamesProvider(provider) {
+	listReplicaUsernames = provider
+}
+
+/**
+ * Social Load 时注册：由 server 解析 operator entityHash。
+ * @param {(username: string) => Promise<string | null>} provider 解析函数
+ * @returns {void}
+ */
+export function registerOperatorEntityHashProvider(provider) {
+	resolveOperatorEntityHash = provider
+}
+
+/** @returns {void} */
+export function unregisterFollowingScanProvider() {
+	scanFollowingForUser = null
+}
+
+/** @returns {void} */
+export function unregisterReplicaUsernamesProvider() {
+	listReplicaUsernames = null
+}
+
+/** @returns {void} */
+export function unregisterOperatorEntityHashProvider() {
+	resolveOperatorEntityHash = null
+}
+
+/**
+ * @returns {(username: string) => Promise<string[]> | null} 已注册扫描器
+ */
+export function getFollowingScanProvider() {
+	return scanFollowingForUser
+}
+
+/**
+ * @returns {(() => Iterable<string>) | null} 已注册 replica 枚举
+ */
+export function getReplicaUsernamesProvider() {
+	return listReplicaUsernames
+}
+
+/**
+ * @returns {((username: string) => Promise<string | null>) | null} 已注册解析器
+ */
+export function getOperatorEntityHashProvider() {
+	return resolveOperatorEntityHash
+}

--- a/src/public/parts/shells/social/src/federation/hosting.mjs
+++ b/src/public/parts/shells/social/src/federation/hosting.mjs
@@ -1,0 +1,104 @@
+/**
+ * Social 实体托管解析：本机 replica 上的 user/agent entity。
+ */
+import { isEntityHash128, parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+
+import {
+	listLocalAgentEntities as scanLocalAgentEntities,
+	resolveAgentCharPartNameForUser,
+} from '../../../chat/src/entity/agentHost.mjs'
+
+import { getOperatorEntityHashProvider, getReplicaUsernamesProvider } from './follower/registry.mjs'
+
+/**
+ * @typedef {'user' | 'agent' | 'unknown'} SocialEntityKind
+ * @typedef {object} ResolvedSocialEntity
+ * @property {string} entityHash 128 hex
+ * @property {SocialEntityKind} kind
+ * @property {boolean} local 是否托管在本 replica 节点
+ * @property {string | null} replicaUsername 本机托管该实体时的 replica 登录名
+ * @property {string | null} charPartName 本地 agent 时 chars/ 下目录名
+ */
+
+/**
+ * @param {string} replicaUsername replica 登录名
+ * @returns {{ entityHash: string, charPartName: string }[]} 本地 agent 列表
+ */
+export function listLocalAgentEntities(replicaUsername) {
+	return scanLocalAgentEntities(replicaUsername)
+}
+
+/**
+ * @param {string} entityHash 128 位 entityHash
+ * @returns {Promise<string | null>} replica 登录名
+ */
+export async function findHostingReplicaUsername(entityHash) {
+	if (!isEntityHash128(entityHash)) return null
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return null
+
+	const listReplicas = getReplicaUsernamesProvider()
+	const resolveOperator = getOperatorEntityHashProvider()
+	if (!listReplicas || !resolveOperator) return null
+
+	for (const username of listReplicas()) {
+		if (parsed.nodeHash !== getNodeHash()) continue
+		const operator = await resolveOperator(username)
+		if (operator?.toLowerCase() === parsed.entityHash) return username
+		if (resolveAgentCharPartNameForUser(username, parsed.entityHash)) return username
+	}
+	return null
+}
+
+/**
+ * @param {string} entityHash 128 位 entityHash
+ * @param {string | null} [hintReplicaUsername] 已知 replica 时可省略全量扫描
+ * @returns {Promise<ResolvedSocialEntity | null>} 解析结果
+ */
+export async function resolveSocialEntity(entityHash, hintReplicaUsername = null) {
+	const raw = String(entityHash || '').trim().toLowerCase()
+	if (!isEntityHash128(raw)) return null
+	const parsed = parseEntityHash(raw)
+	if (!parsed) return null
+
+	const replicaUsername = hintReplicaUsername || await findHostingReplicaUsername(parsed.entityHash)
+	const local = !!replicaUsername
+	if (!local)
+		return {
+			entityHash: parsed.entityHash,
+			kind: 'unknown',
+			local: false,
+			replicaUsername: null,
+			charPartName: null,
+		}
+
+	const resolveOperator = getOperatorEntityHashProvider()
+	const operator = resolveOperator ? await resolveOperator(replicaUsername) : null
+	if (operator?.toLowerCase() === parsed.entityHash)
+		return {
+			entityHash: parsed.entityHash,
+			kind: 'user',
+			local: true,
+			replicaUsername,
+			charPartName: null,
+		}
+
+	const charPartName = resolveAgentCharPartNameForUser(replicaUsername, parsed.entityHash) ?? null
+	if (charPartName)
+		return {
+			entityHash: parsed.entityHash,
+			kind: 'agent',
+			local: true,
+			replicaUsername,
+			charPartName,
+		}
+
+	return {
+		entityHash: parsed.entityHash,
+		kind: 'unknown',
+		local: true,
+		replicaUsername: null,
+		charPartName: null,
+	}
+}

--- a/src/public/parts/shells/social/src/federation/ingest/remote.mjs
+++ b/src/public/parts/shells/social/src/federation/ingest/remote.mjs
@@ -1,0 +1,38 @@
+/**
+ * Social 时间线远程入站验证链（不含磁盘写入）。
+ */
+import { computeEventId, eventBodyForSign } from 'npm:@steve02081504/fount-p2p/dag/index'
+import { isPubKeyHashBlocked } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import { verifyTimelineRemoteSignature } from 'npm:@steve02081504/fount-p2p/timeline/verify_remote'
+
+import { SOCIAL_TIMELINE_EVENT_TYPES, timelineGroupId } from '../namespace.mjs'
+import { isTimelineWriteAuthorized } from '../write_auth.mjs'
+
+/**
+ * @param {object} event 签名事件
+ * @param {string} entityHash 时间线 owner
+ * @param {{ canonicalize: (event: object) => object, priorEvents?: object[], username?: string }} deps 规范化依赖
+ * @returns {Promise<{ accepted: true, row: object } | { accepted: false }>} 验证结果
+ */
+export async function validateRemoteTimelineEvent(event, entityHash, { canonicalize, priorEvents = [], username } = {}) {
+	if (!SOCIAL_TIMELINE_EVENT_TYPES.has(event.type)) return { accepted: false }
+	if (event.groupId !== timelineGroupId(entityHash)) return { accepted: false }
+	const sender = event.sender.trim().toLowerCase()
+	if (isPubKeyHashBlocked(sender)) return { accepted: false }
+	const body = eventBodyForSign(event)
+	if (computeEventId(body) !== event.id) return { accepted: false }
+	if (!await verifyTimelineRemoteSignature(event)) return { accepted: false }
+	if (!await isTimelineWriteAuthorized(entityHash, sender, {
+		eventType: event.type,
+		eventContent: event.content,
+		priorEvents,
+		username,
+		senderPubKeyHex: event.senderPubKey,
+	})) return { accepted: false }
+	try {
+		return { accepted: true, row: canonicalize(event) }
+	}
+	catch {
+		return { accepted: false }
+	}
+}

--- a/src/public/parts/shells/social/src/federation/namespace.mjs
+++ b/src/public/parts/shells/social/src/federation/namespace.mjs
@@ -1,0 +1,109 @@
+/**
+ * Social 时间线 / vault 命名空间（复用 DAG groupId 字段）。
+ */
+const ENTITY_HASH_RE = /^[\da-f]{128}$/u
+
+/**
+ * @param {string} entityHash 128 hex
+ * @returns {string} 规范化 entityHash
+ */
+function normalizeEntityHash(entityHash) {
+	const normalized = String(entityHash).trim().toLowerCase()
+	if (!ENTITY_HASH_RE.test(normalized)) throw new Error('invalid entityHash')
+	return normalized
+}
+
+/**
+ * @param {string} entityHash 128 hex
+ * @param {string} prefix 命名空间前缀
+ * @returns {string} DAG groupId
+ */
+function socialGroupId(entityHash, prefix) {
+	return `${prefix}:${normalizeEntityHash(entityHash)}`
+}
+
+/**
+ * @param {string} entityHash 128 hex
+ * @returns {string} DAG groupId
+ */
+export function timelineGroupId(entityHash) {
+	return socialGroupId(entityHash, 'social-timeline')
+}
+
+/**
+ * @param {string} entityHash 128 hex
+ * @returns {string} vault 逻辑库 groupId
+ */
+export function vaultGroupId(entityHash) {
+	return socialGroupId(entityHash, 'social-vault')
+}
+
+/** @type {Set<string>} */
+export const SOCIAL_TIMELINE_EVENT_TYPES = new Set([
+	'social_meta',
+	'post',
+	'post_edit',
+	'post_delete',
+	'post_visibility_set',
+	'poll_vote',
+	'post_note',
+	'note_vote',
+	'repost',
+	'like',
+	'unlike',
+	'dislike',
+	'undislike',
+	'tag_name',
+	'follow',
+	'unfollow',
+	'tag_follow',
+	'tag_unfollow',
+	'reply_feature',
+	'reply_unfeature',
+	'live_start',
+	'live_end',
+	'block',
+	'unblock',
+	'file_share',
+	'follow_approve',
+	'entity_key_rotate',
+	'entity_key_revoke',
+	'state_summary',
+	'album_create',
+	'album_update',
+	'album_delete',
+	'album_post_add',
+	'album_post_remove',
+])
+
+/** @type {Set<string>} */
+export const SOCIAL_RPC_REQUEST_TYPES = new Set([
+	'social_discover_request',
+	'social_post_discover_request',
+	'social_follow_graph_request',
+	'social_post_notify',
+	'social_timeline_pull_request',
+	'social_reaction_pull_request',
+	'social_note_pull_request',
+	'social_tag_merge_claim',
+	'live_link_invite',
+])
+
+/** @type {Set<string>} */
+export const SOCIAL_RPC_RESPONSE_TYPES = new Set([
+	'social_discover_response',
+	'social_post_discover_response',
+	'social_follow_graph_response',
+	'social_post_notify_response',
+	'social_timeline_pull_response',
+	'social_reaction_pull_response',
+	'social_note_pull_response',
+	'social_tag_merge_claim_response',
+	'live_link_accept',
+])
+
+/** @type {Set<string>} */
+export const SOCIAL_RPC_TYPES = new Set([
+	...SOCIAL_RPC_REQUEST_TYPES,
+	...SOCIAL_RPC_RESPONSE_TYPES,
+])

--- a/src/public/parts/shells/social/src/federation/network_hints.mjs
+++ b/src/public/parts/shells/social/src/federation/network_hints.mjs
@@ -1,0 +1,41 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { applyNetworkHint } from 'npm:@steve02081504/fount-p2p/node/network'
+
+/**
+ * 关注/取关后为被关注实体的 nodeHash 写入 explore 扩边 hint。
+ * @param {string} username replica 登录名
+ * @param {string} targetEntityHash 128 hex
+ * @param {boolean} follow true=关注
+ * @returns {void}
+ */
+export function applyFollowNetworkHints(username, targetEntityHash, follow) {
+	if (!follow) return
+	const parsed = parseEntityHash(targetEntityHash)
+	if (!parsed) return
+	applyNetworkHint({
+		nodeHash: parsed.nodeHash,
+		source: 'social:follow',
+		kind: 'follow',
+		weight: 0.25,
+	})
+	import('npm:@steve02081504/fount-p2p/transport/remote_user_room').then(({ ensureRemoteUserRoom }) =>
+		ensureRemoteUserRoom(username, parsed.nodeHash),
+	).catch(err => console.warn('social: ensureRemoteUserRoom after follow failed', err))
+}
+
+/**
+ * 帖子 @ 提及后为被提及实体的 nodeHash 写入 explore 扩边 hint。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 128 hex
+ * @returns {void}
+ */
+export function applyMentionNetworkHint(username, entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return
+	applyNetworkHint({
+		nodeHash: parsed.nodeHash,
+		source: 'social:mention',
+		kind: 'mention',
+		weight: 0.15,
+	})
+}

--- a/src/public/parts/shells/social/src/federation/note/index.mjs
+++ b/src/public/parts/shells/social/src/federation/note/index.mjs
@@ -1,0 +1,179 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+
+import { noteHelpfulScore } from '../../lib/noteScore.mjs'
+import { createPostScopedJsonStore, normalizePostTarget } from '../postScopedJsonStore.mjs'
+
+const NOTE_TEXT_MAX = 2000
+
+/**
+ *
+ */
+export const NOTE_PULL_BATCH = 200
+
+const store = createPostScopedJsonStore({
+	dirName: 'note_tally',
+	mutexPrefix: 'note-index',
+	/**
+	 * @returns {{ notes: Record<string, object>, votes: Record<string, Record<string, boolean>> }} 空投影
+	 */
+	empty: () => ({ notes: {}, votes: {} }),
+	/**
+	 * @param {object | null | undefined} raw 原始
+	 * @returns {{ notes: Record<string, object>, votes: Record<string, Record<string, boolean>> }} 规范化
+	 */
+	normalize: raw => ({
+		notes: raw?.notes && typeof raw.notes === 'object' ? raw.notes : {},
+		votes: raw?.votes && typeof raw.votes === 'object' ? raw.votes : {},
+	}),
+})
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {string} 投影路径
+ */
+export function noteIndexPath(username, targetEntityHash, postId) {
+	return store.filePath(username, targetEntityHash, postId)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ notes: Record<string, object>, votes: Record<string, Record<string, boolean>> }>} 投影
+ */
+export async function readNoteIndex(username, targetEntityHash, postId) {
+	return store.read(username, targetEntityHash, postId)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string} noteEventId note 事件 id
+ * @param {object} entry note 条目
+ * @returns {Promise<void>}
+ */
+export async function upsertNote(username, targetEntityHash, postId, noteEventId, entry) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	const noteId = normalizeHex64(String(noteEventId || '').trim())
+	if (!ids || !isHex64(noteId)) return
+	await store.withMutex(ids.target, ids.postId, async () => {
+		const current = await store.read(username, ids.target, ids.postId)
+		await store.write(username, ids.target, ids.postId, {
+			notes: {
+				...current.notes,
+				[noteId]: {
+					noteEventId: noteId,
+					authorEntityHash: String(entry.authorEntityHash || '').toLowerCase(),
+					text: String(entry.text || '').trim().slice(0, NOTE_TEXT_MAX),
+					at: Number(entry.at) || Date.now(),
+					...entry.event ? { event: entry.event } : {},
+				},
+			},
+			votes: current.votes,
+		})
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string} noteEventId note id
+ * @param {string} voterEntityHash 投票者
+ * @param {boolean} helpful 是否有用
+ * @returns {Promise<void>}
+ */
+export async function upsertNoteVote(username, targetEntityHash, postId, noteEventId, voterEntityHash, helpful) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	const noteId = normalizeHex64(String(noteEventId || '').trim())
+	const voter = String(voterEntityHash || '').trim().toLowerCase()
+	if (!ids || !isHex64(noteId) || !parseEntityHash(voter)) return
+	await store.withMutex(ids.target, ids.postId, async () => {
+		const current = await store.read(username, ids.target, ids.postId)
+		const voteMap = { ...current.votes[noteId] || {} }
+		voteMap[voter] = helpful === true
+		await store.write(username, ids.target, ids.postId, {
+			notes: current.notes,
+			votes: { ...current.votes, [noteId]: voteMap },
+		})
+	})
+}
+
+/**
+ * @param {string} replicaUsername replica
+ * @param {string} timelineOwnerEntityHash 事件作者
+ * @param {object} event 签名事件
+ * @returns {Promise<void>}
+ */
+export async function projectNoteFromTimelineEvent(replicaUsername, timelineOwnerEntityHash, event) {
+	if (event.type === 'post_note') {
+		await upsertNote(
+			replicaUsername,
+			event.content?.targetEntityHash,
+			event.content?.targetPostId,
+			event.id,
+			{
+				authorEntityHash: timelineOwnerEntityHash,
+				text: event.content?.text,
+				at: Number(event.hlc?.wall) || Number(event.timestamp) || Date.now(),
+				event,
+			},
+		)
+		return
+	}
+	if (event.type === 'note_vote')
+		await upsertNoteVote(
+			replicaUsername,
+			event.content?.targetEntityHash,
+			event.content?.targetPostId,
+			event.content?.noteEventId,
+			timelineOwnerEntityHash,
+			event.content?.helpful === true,
+		)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string | null} [afterAuthor] 游标作者 hash（不含）
+ * @param {number} [limit] 返回上限
+ * @returns {Promise<object[]>} 签名 post_note 事件
+ */
+export async function listNoteEvents(username, targetEntityHash, postId, afterAuthor = null, limit = NOTE_PULL_BATCH) {
+	const index = await readNoteIndex(username, targetEntityHash, postId)
+	const rows = Object.values(index.notes)
+		.filter(note => note?.event && note.authorEntityHash)
+		.sort((a, b) => String(a.authorEntityHash).localeCompare(String(b.authorEntityHash)))
+	const filtered = afterAuthor
+		? rows.filter(note => note.authorEntityHash > afterAuthor)
+		: rows
+	return filtered.slice(0, limit).map(note => note.event)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ notes: object[], topNote: object | null }>} 汇总
+ */
+export async function summarizeNotes(username, targetEntityHash, postId) {
+	const index = await readNoteIndex(username, targetEntityHash, postId)
+	const notes = Object.values(index.notes).map(note => {
+		const votes = index.votes[note.noteEventId] || {}
+		const score = noteHelpfulScore(note, votes)
+		const { event: _event, ...rest } = note
+		return {
+			...rest,
+			score,
+			helpfulCount: Object.values(votes).filter(Boolean).length,
+			unhelpfulCount: Object.values(votes).filter(v => !v).length,
+		}
+	}).sort((a, b) => b.score - a.score || b.at - a.at)
+	const topNote = notes.find(note => note.score > 0) || null
+	return { notes, topNote }
+}

--- a/src/public/parts/shells/social/src/federation/note/pull.mjs
+++ b/src/public/parts/shells/social/src/federation/note/pull.mjs
@@ -1,0 +1,76 @@
+/**
+ * 经 TrustGraph 拉取某帖的签名补充信息事件。
+ */
+import { ingestRemoteTimelineEvent } from '../../timeline/sync.mjs'
+import { timelineGroupId } from '../namespace.mjs'
+import { collectSocialRpcMerged } from '../rpc/wire.mjs'
+
+import { NOTE_PULL_BATCH } from './index.mjs'
+
+const NOTE_PULL_MAX_ROUNDS = 8
+
+/**
+ * @param {object} event 签名事件
+ * @returns {string | null} 作者 entityHash
+ */
+function authorFromNoteEvent(event) {
+	const expectedPrefix = 'social-timeline:'
+	const groupId = String(event?.groupId || '')
+	if (!groupId.startsWith(expectedPrefix)) return null
+	const hash = groupId.slice(expectedPrefix.length).toLowerCase()
+	return hash.length === 128 ? hash : null
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ attempted: number, imported: number }>} 同步统计
+ */
+export async function pullPostNotes(username, targetEntityHash, postId) {
+	const target = String(targetEntityHash).toLowerCase()
+	const id = String(postId).trim()
+	let afterAuthor = null
+	let imported = 0
+	let attempted = 0
+
+	for (let round = 0; round < NOTE_PULL_MAX_ROUNDS; round++) {
+		const { data: responses, errors } = await collectSocialRpcMerged(username, {
+			type: 'social_note_pull_request',
+			targetEntityHash: target,
+			postId: id,
+			afterAuthor,
+			limit: NOTE_PULL_BATCH,
+		}, 3000, 8)
+		if (errors.length)
+			console.warn('social: note pull neighbor errors', { targetEntityHash: target, postId: id, count: errors.length })
+
+		/** @type {object[]} */
+		const batch = []
+		for (const row of responses)
+			for (const event of row.events || [])
+				batch.push(event)
+
+		if (!batch.length) break
+		attempted += batch.length
+
+		/** @type {string[]} */
+		const authorsThisRound = []
+		for (const event of batch) {
+			const author = authorFromNoteEvent(event)
+			if (!author) continue
+			if (event.groupId !== timelineGroupId(author)) continue
+			if (!await ingestRemoteTimelineEvent(username, author, event)) continue
+			imported++
+			authorsThisRound.push(author)
+		}
+		if (!authorsThisRound.length) break
+		authorsThisRound.sort()
+		const nextCursor = authorsThisRound[authorsThisRound.length - 1]
+		if (afterAuthor && nextCursor <= afterAuthor) break
+		afterAuthor = nextCursor
+		if (batch.length < NOTE_PULL_BATCH) break
+	}
+
+	return { attempted, imported }
+}

--- a/src/public/parts/shells/social/src/federation/partQuery.mjs
+++ b/src/public/parts/shells/social/src/federation/partQuery.mjs
@@ -1,0 +1,31 @@
+/**
+ * Social part_query 种类注册表：Load/Unload 各一次批量登记/清空。
+ */
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { registerQueryInboundHandler } from 'npm:@steve02081504/fount-p2p/wire/part_query'
+
+/** @type {Map<string, (inboundContext: object, query: unknown) => Promise<object[]> | object[]>} */
+let registeredKinds = new Map()
+
+/**
+ * 批量注册 Social part_query handlers。
+ * @param {Record<string, (inboundContext: object, query: unknown) => Promise<object[]> | object[]>} table kind → handler
+ * @returns {void}
+ */
+export function registerSocialQueryKinds(table) {
+	const partpath = getShellPartpath('social')
+	registeredKinds = new Map(Object.entries(table))
+	for (const [kind, handler] of registeredKinds)
+		registerQueryInboundHandler(partpath, kind, handler)
+}
+
+/**
+ * 清空已注册的 Social part_query handlers。
+ * @returns {void}
+ */
+export function unregisterSocialQueryKinds() {
+	const partpath = getShellPartpath('social')
+	for (const kind of registeredKinds.keys())
+		registerQueryInboundHandler(partpath, kind, () => [])
+	registeredKinds = new Map()
+}

--- a/src/public/parts/shells/social/src/federation/poll/index.mjs
+++ b/src/public/parts/shells/social/src/federation/poll/index.mjs
@@ -1,0 +1,112 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { createPostScopedJsonStore, normalizePostTarget } from '../postScopedJsonStore.mjs'
+
+const store = createPostScopedJsonStore({
+	dirName: 'poll_tally',
+	mutexPrefix: 'poll-tally',
+	/**
+	 * @returns {{ votes: Record<string, { choices: number[] }>, tally: Record<string, number> }} 空 tally
+	 */
+	empty: () => ({ votes: {}, tally: {} }),
+	/**
+	 * @param {object | null | undefined} raw 磁盘 tally
+	 * @returns {{ votes: Record<string, { choices: number[] }>, tally: Record<string, number> }} 规范化
+	 */
+	normalize: raw => ({ votes: raw?.votes || {}, tally: raw?.tally || {} }),
+})
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {string} tally 文件路径
+ */
+export function pollTallyPath(username, targetEntityHash, postId) {
+	return store.filePath(username, targetEntityHash, postId)
+}
+
+/**
+ * @param {Record<string, { choices: number[] }>} votes voter → choices
+ * @returns {Record<string, number>} 选项计数
+ */
+export function computePollTallyFromVotes(votes) {
+	/** @type {Record<string, number>} */
+	const tally = {}
+	for (const row of Object.values(votes))
+		for (const idx of row?.choices || [])
+			tally[String(idx)] = (tally[String(idx)] || 0) + 1
+	return tally
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ votes: Record<string, { choices: number[] }>, tally: Record<string, number> }>} tally 投影
+ */
+export async function readPollTally(username, targetEntityHash, postId) {
+	return store.read(username, targetEntityHash, postId)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {Record<string, { choices: number[] }>} votes voter → choices
+ * @returns {Promise<void>}
+ */
+async function writePollTally(username, targetEntityHash, postId, votes) {
+	await store.write(username, targetEntityHash, postId, {
+		votes,
+		tally: computePollTallyFromVotes(votes),
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string} voterEntityHash 投票者
+ * @param {number[]} choices 选项下标
+ * @returns {Promise<void>}
+ */
+export async function upsertPollVote(username, targetEntityHash, postId, voterEntityHash, choices) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	if (!ids) return
+	const voter = String(voterEntityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(voter)) return
+	await store.withMutex(ids.target, ids.postId, async () => {
+		const current = await store.read(username, ids.target, ids.postId)
+		await writePollTally(username, ids.target, ids.postId, {
+			...current.votes,
+			[voter]: { choices: [...choices] },
+		})
+	})
+}
+
+/**
+ * poll_vote 事件落盘后更新 tally 投影。
+ * @param {string} replicaUsername replica 登录名
+ * @param {string} timelineOwnerEntityHash 投票者时间线 owner
+ * @param {object} event 签名事件
+ * @returns {Promise<void>}
+ */
+export async function projectPollVoteFromTimelineEvent(replicaUsername, timelineOwnerEntityHash, event) {
+	if (event.type !== 'poll_vote') return
+	const ids = normalizePostTarget(event.content?.targetEntityHash, event.content?.targetPostId)
+	const choices = event.content?.choices
+	if (!ids || !Array.isArray(choices)) return
+	await upsertPollVote(replicaUsername, ids.target, ids.postId, timelineOwnerEntityHash, choices)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<Record<string, number>>} 选项计数
+ */
+export async function listPollTally(username, targetEntityHash, postId) {
+	const { tally } = await readPollTally(username, targetEntityHash, postId)
+	return tally
+}

--- a/src/public/parts/shells/social/src/federation/postQueryRow.mjs
+++ b/src/public/parts/shells/social/src/federation/postQueryRow.mjs
@@ -1,0 +1,89 @@
+/**
+ * 联邦帖文 part_query 出站行与入站清洗（discover / search 共用）。
+ */
+import { isPublicDiscoverable } from '../lib/visibilitySpec.mjs'
+
+/**
+ * 出站：把本机帖压成联邦查询行。
+ * @param {object} post 物化帖
+ * @param {string} entityHash 作者
+ * @param {string} nodeHash 本节点
+ * @param {{ visibilityMode?: 'public' | 'preserve' }} [options] visibility 策略
+ * @returns {object | null} 查询行；缺字段时 null
+ */
+export function federatedPostQueryRow(post, entityHash, nodeHash, options = {}) {
+	const postId = String(post?.id || '').trim()
+	const hash = String(entityHash || '').trim().toLowerCase()
+	if (!post || !postId || !hash) return null
+	const visibilityMode = options.visibilityMode === 'preserve' ? 'preserve' : 'public'
+	const visibility = visibilityMode === 'public' || isPublicDiscoverable(post.content)
+		? 'public'
+		: post.content?.visibility
+	return {
+		entityHash: hash,
+		postId,
+		text: String(post.content?.text || '').slice(0, 500),
+		hlc: post.hlc || null,
+		mediaRefs: (post.content?.mediaRefs || []).slice(0, 4),
+		nodeHash: String(nodeHash || '').toLowerCase(),
+		event: {
+			id: post.id,
+			type: 'post',
+			content: {
+				text: post.content?.text,
+				mediaRefs: post.content?.mediaRefs,
+				visibility,
+				tags: post.content?.tags,
+			},
+			hlc: post.hlc,
+			timestamp: post.timestamp,
+			signer: post.signer,
+			signature: post.signature,
+		},
+	}
+}
+
+/**
+ * 入站清洗：仅公开可见摘录，截断文本/媒体/标签。
+ * @param {unknown} raw 网络行
+ * @param {{ mediaOnly?: boolean }} [options] 过滤
+ * @returns {{ entityHash: string, postId: string, event: object, nodeHash: string, hlc: unknown } | null} 清洗行
+ */
+export function sanitizeFederatedPostQueryRow(raw, options = {}) {
+	if (!raw || typeof raw !== 'object') return null
+	const entityHash = String(/** @type {{ entityHash?: unknown }} */raw.entityHash || '').trim().toLowerCase()
+	const postId = String(/** @type {{ postId?: unknown }} */raw.postId || '').trim()
+	const event = /** @type {{ event?: object }} */raw.event
+	if (!entityHash || !postId || !event) return null
+	if (!isPublicDiscoverable(event.content)) return null
+	if (options.mediaOnly && !(Array.isArray(event.content?.mediaRefs) && event.content.mediaRefs.length))
+		return null
+	return {
+		entityHash,
+		postId,
+		hlc: event.hlc || /** @type {{ hlc?: unknown }} */raw.hlc || null,
+		nodeHash: String(/** @type {{ nodeHash?: unknown }} */raw.nodeHash || '').toLowerCase(),
+		event: {
+			...event,
+			id: postId,
+			type: 'post',
+			content: {
+				text: String(event.content?.text || '').slice(0, 2000),
+				mediaRefs: Array.isArray(event.content?.mediaRefs) ? event.content.mediaRefs.slice(0, 16) : [],
+				visibility: 'public',
+				tags: Array.isArray(event.content?.tags) ? event.content.tags.slice(0, 16) : undefined,
+			},
+		},
+	}
+}
+
+/**
+ * @param {unknown} row 查询行
+ * @returns {string} 去重键
+ */
+export function federatedPostRowKey(row) {
+	if (!row || typeof row !== 'object') return ''
+	const entityHash = String(/** @type {{ entityHash?: unknown }} */row.entityHash || '').toLowerCase()
+	const postId = String(/** @type {{ postId?: unknown }} */row.postId || '')
+	return entityHash && postId ? `${entityHash}:${postId}` : ''
+}

--- a/src/public/parts/shells/social/src/federation/postScopedJsonStore.mjs
+++ b/src/public/parts/shells/social/src/federation/postScopedJsonStore.mjs
@@ -1,0 +1,120 @@
+/**
+ * 逐帖 JSON 投影（note / poll / reaction）共用脚手架。
+ */
+import path from 'node:path'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import { writeJsonAtomic } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { withAsyncMutex } from 'npm:@steve02081504/fount-p2p/utils/async_mutex'
+import { createLruMap } from 'npm:@steve02081504/fount-p2p/utils/lru'
+
+import { getUserDictionary } from '../../../../../../server/auth/index.mjs'
+
+import { socialPostKey } from './post_key.mjs'
+
+/**
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {{ target: string, postId: string } | null} 规范化键
+ */
+export function normalizePostTarget(targetEntityHash, postId) {
+	const target = String(targetEntityHash || '').trim().toLowerCase()
+	const id = normalizeHex64(String(postId || '').trim())
+	if (!parseEntityHash(target) || !isHex64(id)) return null
+	return { target, postId: id }
+}
+
+/**
+ * @template T
+ * @param {object} options 配置
+ * @param {string} options.dirName shells/social 子目录
+ * @param {() => T} options.empty 空投影工厂
+ * @param {(raw: object | null | undefined) => T} options.normalize 读盘规范化
+ * @param {number} [options.cacheMax=512] LRU 容量
+ * @param {string} [options.mutexPrefix] mutex 前缀
+ * @returns {{ filePath: Function, read: Function, write: Function, withMutex: Function }} 存储
+ */
+export function createPostScopedJsonStore({
+	dirName,
+	empty,
+	normalize,
+	cacheMax = 512,
+	mutexPrefix = dirName,
+}) {
+	/** @type {ReturnType<typeof createLruMap<string, T>>} */
+	const cache = createLruMap(cacheMax)
+
+	/**
+	 * @param {string} username replica
+	 * @param {string} targetEntityHash 帖作者
+	 * @param {string} postId 帖 id
+	 * @returns {string} 路径
+	 */
+	function filePath(username, targetEntityHash, postId) {
+		const ids = normalizePostTarget(targetEntityHash, postId)
+		if (!ids) throw new Error(`invalid ${dirName} target`)
+		return path.join(getUserDictionary(username), 'shells/social', dirName, ids.target, `${ids.postId}.json`)
+	}
+
+	/**
+	 * @param {string} username replica
+	 * @param {string} targetEntityHash 帖作者
+	 * @param {string} postId 帖 id
+	 * @returns {Promise<T>} 投影
+	 */
+	async function read(username, targetEntityHash, postId) {
+		const ids = normalizePostTarget(targetEntityHash, postId)
+		if (!ids) return empty()
+		const key = socialPostKey(ids.target, ids.postId)
+		const cached = cache.get(key)
+		if (cached) {
+			cache.touch(key, cached)
+			return cached
+		}
+		const { readFile } = await import('node:fs/promises')
+		try {
+			const normalized = normalize(JSON.parse(await readFile(filePath(username, ids.target, ids.postId), 'utf8')))
+			cache.touch(key, normalized)
+			return normalized
+		}
+		catch (err) {
+			if (err?.code !== 'ENOENT') throw err
+			const blank = empty()
+			cache.touch(key, blank)
+			return blank
+		}
+	}
+
+	/**
+	 * @param {string} username replica
+	 * @param {string} targetEntityHash 帖作者
+	 * @param {string} postId 帖 id
+	 * @param {T} data 投影
+	 * @returns {Promise<void>}
+	 */
+	async function write(username, targetEntityHash, postId, data) {
+		const ids = normalizePostTarget(targetEntityHash, postId)
+		if (!ids) return
+		const key = socialPostKey(ids.target, ids.postId)
+		const { mkdir } = await import('node:fs/promises')
+		const file = filePath(username, ids.target, ids.postId)
+		await mkdir(path.dirname(file), { recursive: true })
+		await writeJsonAtomic(file, data)
+		cache.touch(key, data)
+	}
+
+	/**
+	 * @param {string} targetEntityHash 帖作者
+	 * @param {string} postId 帖 id
+	 * @param {() => Promise<void>} fn 临界区
+	 * @returns {Promise<void>}
+	 */
+	function withMutex(targetEntityHash, postId, fn) {
+		const ids = normalizePostTarget(targetEntityHash, postId)
+		if (!ids) return Promise.resolve()
+		return withAsyncMutex(`${mutexPrefix}:${socialPostKey(ids.target, ids.postId)}`, fn)
+	}
+
+	return { filePath, read, write, withMutex }
+}

--- a/src/public/parts/shells/social/src/federation/post_key.mjs
+++ b/src/public/parts/shells/social/src/federation/post_key.mjs
@@ -1,0 +1,11 @@
+import { compositeKey } from 'npm:@steve02081504/fount-p2p/core/composite_key'
+
+/**
+ * Social 帖子/互动 Map 键（entityHash + postId）。
+ * @param {string} entityHash 128 hex
+ * @param {string} postId 帖子 id
+ * @returns {string} 复合键
+ */
+export function socialPostKey(entityHash, postId) {
+	return compositeKey(String(entityHash).toLowerCase(), String(postId))
+}

--- a/src/public/parts/shells/social/src/federation/push_admission.mjs
+++ b/src/public/parts/shells/social/src/federation/push_admission.mjs
@@ -1,0 +1,69 @@
+/**
+ * 联邦 push（part_timeline_put）接纳：已关注或共同群成员。
+ * pull（syncFollowingTimelines）已按关注拉取，不经此门。
+ */
+import { join } from 'node:path'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { safeReadJson } from '../../../chat/src/chat/lib/fsSafe.mjs'
+import { shellChatRoot } from '../../../chat/src/chat/lib/paths.mjs'
+import { listUserGroups } from '../../../chat/src/chat/lib/userGroups.mjs'
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../../chat/src/entity/identity.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+
+import { listLocalAgentEntities } from './hosting.mjs'
+
+/**
+ * 本机 operator + agent 是否关注目标（含自关注）。
+ * @param {string} username replica
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<boolean>} 是否在关注并集中
+ */
+async function isFollowedByLocalEntities(username, entityHash) {
+	const target = entityHash.toLowerCase()
+	const actors = []
+	const operator = await resolveOperatorEntityHash(username)
+	if (operator) actors.push(operator.toLowerCase())
+	for (const { entityHash: agent } of listLocalAgentEntities(username))
+		actors.push(agent.toLowerCase())
+	for (const actor of actors) {
+		const { following } = await loadFollowingForActor(username, actor)
+		if (following.some(hash => hash === target)) return true
+	}
+	return false
+}
+
+/**
+ * 本机任一群快照中是否有该实体活跃成员（共同群）。
+ * @param {string} username replica
+ * @param {string} entityHash 远端实体
+ * @returns {Promise<boolean>} 是否共群
+ */
+async function isCoGroupMember(username, entityHash) {
+	const target = entityHash.toLowerCase()
+	const root = shellChatRoot(username)
+	for (const groupId of await listUserGroups(username)) {
+		const snapshot = await safeReadJson(join(root, 'groups', groupId, 'snapshot.json'))
+		const members = snapshot?.members_record?.members || {}
+		for (const row of Object.values(members)) {
+			if (String(row?.entityHash || '').toLowerCase() !== target) continue
+			if (row?.status === 'active') return true
+		}
+	}
+	return false
+}
+
+/**
+ * push 是否接纳该时间线 owner（关注 ∪ 共群；denylist/信誉仍由 ingest 链处理）。
+ * @param {string} username replica
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<boolean>} 是否接纳
+ */
+export async function isRemoteTimelinePushAdmitted(username, entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return false
+	if (await isFollowedByLocalEntities(username, parsed.entityHash)) return true
+	if (await isCoGroupMember(username, parsed.entityHash)) return true
+	return false
+}

--- a/src/public/parts/shells/social/src/federation/reaction/index.mjs
+++ b/src/public/parts/shells/social/src/federation/reaction/index.mjs
@@ -1,0 +1,150 @@
+/**
+ * 逐帖反应投影：like/dislike 签名事件按 (author, postId, reactor) 索引。
+ * 聚合物 = 签名事件集合，能隐瞒不能伪造。
+ */
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { createPostScopedJsonStore, normalizePostTarget } from '../postScopedJsonStore.mjs'
+
+/** 联邦 RPC 单批反应上限 */
+export const REACTION_PULL_BATCH = 200
+
+/** @typedef {{ kind: 'like' | 'dislike', event: object }} ReactionEntry */
+/** @typedef {{ reactors: Record<string, ReactionEntry> }} ReactionIndex */
+
+/**
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {{ target: string, postId: string } | null} 规范化键，非法则 null
+ */
+export const normalizeReactionTarget = normalizePostTarget
+
+const store = createPostScopedJsonStore({
+	dirName: 'reaction_index',
+	mutexPrefix: 'reaction-index',
+	/**
+	 * @returns {ReactionIndex} 空投影
+	 */
+	empty: () => ({ reactors: {} }),
+	/**
+	 * @param {object | null | undefined} raw 磁盘数据
+	 * @returns {ReactionIndex} 规范化投影
+	 */
+	normalize: raw => ({ reactors: raw?.reactors && typeof raw.reactors === 'object' ? raw.reactors : {} }),
+})
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {string} 投影文件路径
+ */
+export function reactionIndexPath(username, targetEntityHash, postId) {
+	return store.filePath(username, targetEntityHash, postId)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<ReactionIndex>} 反应投影
+ */
+export async function readReactionIndex(username, targetEntityHash, postId) {
+	return store.read(username, targetEntityHash, postId)
+}
+
+/**
+ * 写入或清除反应者条目。
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string} reactorEntityHash 反应者
+ * @param {ReactionEntry | null} entry null = 删除
+ * @returns {Promise<void>}
+ */
+export async function upsertReaction(username, targetEntityHash, postId, reactorEntityHash, entry) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	if (!ids) return
+	const reactor = String(reactorEntityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(reactor)) return
+	await store.withMutex(ids.target, ids.postId, async () => {
+		const current = await store.read(username, ids.target, ids.postId)
+		const reactors = { ...current.reactors }
+		if (entry) reactors[reactor] = entry
+		else delete reactors[reactor]
+		await store.write(username, ids.target, ids.postId, { reactors })
+	})
+}
+
+/**
+ * like/dislike/unlike/undislike 落盘后更新投影。
+ * @param {string} replicaUsername replica 登录名
+ * @param {string} timelineOwnerEntityHash 反应者时间线 owner
+ * @param {object} event 签名事件
+ * @returns {Promise<void>}
+ */
+export async function projectReactionFromTimelineEvent(replicaUsername, timelineOwnerEntityHash, event) {
+	const type = event?.type
+	if (!['like', 'unlike', 'dislike', 'undislike'].includes(type)) return
+	const ids = normalizePostTarget(event.content?.targetEntityHash, event.content?.targetPostId)
+	if (!ids) return
+	const reactor = String(timelineOwnerEntityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(reactor)) return
+	const { loadTaste } = await import('../../taste/store.mjs')
+	const taste = await loadTaste(replicaUsername, reactor)
+	if (taste.privacy.publishReactions === false) {
+		await upsertReaction(replicaUsername, ids.target, ids.postId, reactor, null)
+		return
+	}
+	if (type === 'like')
+		await upsertReaction(replicaUsername, ids.target, ids.postId, reactor, { kind: 'like', event })
+	else if (type === 'dislike')
+		await upsertReaction(replicaUsername, ids.target, ids.postId, reactor, { kind: 'dislike', event })
+	else
+		await upsertReaction(replicaUsername, ids.target, ids.postId, reactor, null)
+}
+
+/**
+ * 按 reactor 排序分页返回签名反应事件。
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {string | null | undefined} afterReactor 游标（上一批末 reactor）
+ * @param {number} [limit=REACTION_PULL_BATCH] 上限
+ * @returns {Promise<object[]>} 签名事件列表
+ */
+export async function listReactionEvents(username, targetEntityHash, postId, afterReactor, limit = REACTION_PULL_BATCH) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	if (!ids) return []
+	const { reactors } = await readReactionIndex(username, ids.target, ids.postId)
+	const keys = Object.keys(reactors).sort()
+	let start = 0
+	if (afterReactor) {
+		const cursor = String(afterReactor).trim().toLowerCase()
+		if (!parseEntityHash(cursor)) return []
+		const idx = keys.findIndex(key => key === cursor)
+		start = idx >= 0 ? idx + 1 : 0
+	}
+	const batch = Math.min(Math.max(Number(limit) || REACTION_PULL_BATCH, 1), REACTION_PULL_BATCH)
+	return keys.slice(start, start + batch).map(key => reactors[key].event)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ likes: string[], dislikes: string[] }>} 反应者 entityHash 列表
+ */
+export async function summarizeReactions(username, targetEntityHash, postId) {
+	const ids = normalizePostTarget(targetEntityHash, postId)
+	if (!ids) return { likes: [], dislikes: [] }
+	const { reactors } = await readReactionIndex(username, ids.target, ids.postId)
+	/** @type {string[]} */
+	const likes = []
+	/** @type {string[]} */
+	const dislikes = []
+	for (const [reactor, entry] of Object.entries(reactors))
+		if (entry.kind === 'like') likes.push(reactor)
+		else if (entry.kind === 'dislike') dislikes.push(reactor)
+	return { likes, dislikes }
+}

--- a/src/public/parts/shells/social/src/federation/reaction/pull.mjs
+++ b/src/public/parts/shells/social/src/federation/reaction/pull.mjs
@@ -1,0 +1,77 @@
+/**
+ * 经 TrustGraph 拉取某帖的签名反应事件，验签并入本地投影。
+ */
+import { ingestRemoteTimelineEvent } from '../../timeline/sync.mjs'
+import { timelineGroupId } from '../namespace.mjs'
+import { collectSocialRpcMerged } from '../rpc/wire.mjs'
+
+import { REACTION_PULL_BATCH } from './index.mjs'
+
+const REACTION_PULL_MAX_ROUNDS = 8
+
+/**
+ * @param {object} event 签名反应事件
+ * @returns {string | null} 反应者 entityHash（时间线 owner）
+ */
+function reactorFromReactionEvent(event) {
+	const expectedPrefix = 'social-timeline:'
+	const groupId = String(event?.groupId || '')
+	if (!groupId.startsWith(expectedPrefix)) return null
+	const hash = groupId.slice(expectedPrefix.length).toLowerCase()
+	return hash.length === 128 ? hash : null
+}
+
+/**
+ * 拉取并导入某帖的 like/dislike 签名事件。
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ attempted: number, imported: number }>} 同步统计
+ */
+export async function pullPostReactions(username, targetEntityHash, postId) {
+	const target = String(targetEntityHash).toLowerCase()
+	const id = String(postId).trim()
+	let afterReactor = null
+	let imported = 0
+	let attempted = 0
+
+	for (let round = 0; round < REACTION_PULL_MAX_ROUNDS; round++) {
+		const { data: responses, errors } = await collectSocialRpcMerged(username, {
+			type: 'social_reaction_pull_request',
+			targetEntityHash: target,
+			postId: id,
+			afterReactor,
+			limit: REACTION_PULL_BATCH,
+		}, 3000, 8)
+		if (errors.length)
+			console.warn('social: reaction pull neighbor errors', { targetEntityHash: target, postId: id, count: errors.length })
+
+		/** @type {object[]} */
+		const batch = []
+		for (const row of responses)
+			for (const event of row.events || [])
+				batch.push(event)
+
+		if (!batch.length) break
+		attempted += batch.length
+
+		/** @type {string[]} */
+		const reactorsThisRound = []
+		for (const event of batch) {
+			const reactor = reactorFromReactionEvent(event)
+			if (!reactor) continue
+			if (event.groupId !== timelineGroupId(reactor)) continue
+			if (!await ingestRemoteTimelineEvent(username, reactor, event)) continue
+			imported++
+			reactorsThisRound.push(reactor)
+		}
+		if (!reactorsThisRound.length) break
+		reactorsThisRound.sort()
+		const nextCursor = reactorsThisRound[reactorsThisRound.length - 1]
+		if (afterReactor && nextCursor <= afterReactor) break
+		afterReactor = nextCursor
+		if (batch.length < REACTION_PULL_BATCH) break
+	}
+
+	return { attempted, imported }
+}

--- a/src/public/parts/shells/social/src/federation/reputation/engine.mjs
+++ b/src/public/parts/shells/social/src/federation/reputation/engine.mjs
@@ -1,0 +1,82 @@
+/**
+ * Social 信誉传导纯算子（模拟器与 reputation/index.mjs 共用）。
+ */
+import {
+	clampReputationScore,
+	computeRepMaxEff,
+	REP_MAX,
+	subjectiveSlashPenalty,
+} from 'npm:@steve02081504/fount-p2p/reputation/math'
+
+import socialTunables from './tunables.json' with { type: 'json' }
+
+/** @typedef {import('npm:@steve02081504/fount-p2p/node/reputation_store').ReputationFile} ReputationFile */
+
+/**
+ * @returns {typeof socialTunables} 默认 tunables
+ */
+export function defaultSocialTunables() {
+	return socialTunables
+}
+
+/**
+ * @param {ReputationFile} data 信誉表
+ * @param {object} options 参数
+ * @param {string} options.followerNodeHash 关注者节点
+ * @param {string} options.targetNodeHash 被拉黑节点
+ * @param {string} options.voterKey 投票键（entityHash）
+ * @param {'block' | 'unblock'} options.action 动作
+ * @param {boolean} [options.selfTrust] 自己拉黑时满信任权重
+ * @param {number} [now] 当前时间
+ * @param {typeof socialTunables} [tunables] tunables
+ * @returns {boolean} 是否已应用
+ */
+export function applyFollowedBlockSignalPure(data, options, now = Date.now(), tunables = socialTunables) {
+	const { followerNodeHash, targetNodeHash, voterKey, action } = options
+	const isBlock = action === 'block'
+	const selfTrust = !!options.selfTrust
+
+	const row = data.byNodeHash[targetNodeHash] || { score: 0 }
+	row.blockPenalties ??= {}
+
+	if (isBlock) {
+		if (row.blockPenalties[voterKey]) return false
+		const repMaxEff = computeRepMaxEff(data)
+		const repSender = selfTrust
+			? REP_MAX
+			: Number(data.byNodeHash[followerNodeHash]?.score ?? 0)
+		const penalty = subjectiveSlashPenalty(tunables.socialBlockClaim, repSender, repMaxEff, selfTrust)
+		row.score = clampReputationScore(Number(row.score ?? 0) - penalty)
+		row.blockPenalties[voterKey] = { penalty, appliedAt: now, decayedRefund: 0 }
+		data.byNodeHash[targetNodeHash] = row
+		return true
+	}
+
+	const record = row.blockPenalties[voterKey]
+	if (!record) return false
+	const remaining = Number(record.penalty) - Number(record.decayedRefund || 0)
+	if (remaining > 0)
+		row.score = clampReputationScore(Number(row.score ?? 0) + remaining)
+	delete row.blockPenalties[voterKey]
+	data.byNodeHash[targetNodeHash] = row
+	return true
+}
+
+/**
+ * @param {number} score 节点分
+ * @param {typeof socialTunables} [tunables] tunables
+ * @returns {boolean} 是否应隐藏
+ */
+export function shouldHideByScore(score, tunables = socialTunables) {
+	return score < tunables.socialRepHideThreshold
+}
+
+/**
+ * @param {number} score 节点分
+ * @param {typeof socialTunables} [tunables] tunables
+ * @returns {number} 排序惩罚
+ */
+export function reputationSortPenaltyFromScore(score, tunables = socialTunables) {
+	if (score >= tunables.socialRepDemoteThreshold) return 0
+	return Math.round((tunables.socialRepDemoteThreshold - score) * 1_000_000)
+}

--- a/src/public/parts/shells/social/src/federation/reputation/index.mjs
+++ b/src/public/parts/shells/social/src/federation/reputation/index.mjs
@@ -1,0 +1,65 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import {
+	applyFollowedBlockSignalPure,
+	reputationSortPenaltyFromScore,
+	shouldHideByScore,
+} from './engine.mjs'
+import socialTunables from './tunables.json' with { type: 'json' }
+
+/** 公开拉黑主张强度 */
+export const SOCIAL_BLOCK_CLAIM = socialTunables.socialBlockClaim
+
+/** feed/搜索：低于此分直接隐藏作者 */
+export const SOCIAL_REP_HIDE_THRESHOLD = socialTunables.socialRepHideThreshold
+
+/** feed：低于此分降权排序 */
+export const SOCIAL_REP_DEMOTE_THRESHOLD = socialTunables.socialRepDemoteThreshold
+
+/**
+ * @param {object} options 参数
+ * @param {string} options.followerEntityHash 关注者（拉黑发起方）实体
+ * @param {string} options.targetEntityHash 被拉黑实体
+ * @param {'block' | 'unblock'} options.action 动作
+ * @param {boolean} [options.selfTrust] 自己拉黑时满信任权重
+ * @param {(mutator: (data: import('npm:@steve02081504/fount-p2p/node/reputation_store').ReputationFile) => void | Promise<void>) => Promise<void>} mutateReputation 突变器
+ * @returns {Promise<boolean>} 是否已应用
+ */
+export async function applyFollowedBlockSignal(options, mutateReputation) {
+	const follower = parseEntityHash(options.followerEntityHash)
+	const target = parseEntityHash(options.targetEntityHash)
+	if (!follower || !target) return false
+
+	await mutateReputation(data => {
+		applyFollowedBlockSignalPure(data, {
+			followerNodeHash: follower.nodeHash,
+			targetNodeHash: target.nodeHash,
+			voterKey: follower.entityHash,
+			action: options.action,
+			selfTrust: !!options.selfTrust,
+		})
+	})
+	return true
+}
+
+/**
+ * @param {string} entityHash 作者实体
+ * @param {(nodeId: string) => number} scoreOf 取分函数
+ * @returns {boolean} 是否应隐藏
+ */
+export function shouldHideAuthorByReputation(entityHash, scoreOf) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return false
+	return shouldHideByScore(scoreOf(parsed.nodeHash))
+}
+
+/**
+ * @param {string} entityHash 作者实体
+ * @param {(nodeId: string) => number} scoreOf 取分函数
+ * @returns {number} 排序惩罚（越大越靠后）
+ */
+export function reputationSortPenalty(entityHash, scoreOf) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return 0
+	return reputationSortPenaltyFromScore(scoreOf(parsed.nodeHash))
+}

--- a/src/public/parts/shells/social/src/federation/reputation/tunables.json
+++ b/src/public/parts/shells/social/src/federation/reputation/tunables.json
@@ -1,0 +1,5 @@
+{
+	"socialBlockClaim": 0.5,
+	"socialRepHideThreshold": -0.5,
+	"socialRepDemoteThreshold": 0
+}

--- a/src/public/parts/shells/social/src/federation/rpc/wire.mjs
+++ b/src/public/parts/shells/social/src/federation/rpc/wire.mjs
@@ -1,0 +1,38 @@
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import {
+	partInvokeDataRows,
+	partInvokeErrorMessages,
+	PART_INVOKE_FANOUT_DEFAULT,
+} from 'npm:@steve02081504/fount-p2p/wire/part_common'
+import { collectPartInvokeResponses } from 'npm:@steve02081504/fount-p2p/wire/part_fanout'
+
+/**
+ * @param {object} rpc social RPC 体（不含 kind）
+ * @returns {object} part_invoke 调用体
+ */
+export function wrapSocialRpc(rpc) {
+	return { kind: 'social_rpc', ...rpc }
+}
+
+/**
+ * @param {string} username 用户
+ * @param {object} rpc social RPC 体
+ * @param {number} [timeoutMs=2500] 超时
+ * @param {number} [maxResponses=6] 最多响应数
+ * @returns {Promise<import('npm:@steve02081504/fount-p2p/wire/part_invoke').PartInvokeResponse[]>} 邻居 PartInvokeResponse
+ */
+export function collectSocialRpcResponses(username, rpc, timeoutMs = 2500, maxResponses = PART_INVOKE_FANOUT_DEFAULT) {
+	return collectPartInvokeResponses(username, getShellPartpath('social'), wrapSocialRpc(rpc), timeoutMs, maxResponses)
+}
+
+/**
+ * @param {string} username 用户
+ * @param {object} rpc social RPC 体
+ * @param {number} [timeoutMs=2500] 超时
+ * @param {number} [maxResponses=6] 最多响应数
+ * @returns {Promise<{ data: object[], errors: string[] }>} 成功 data 与邻居 error
+ */
+export async function collectSocialRpcMerged(username, rpc, timeoutMs = 2500, maxResponses = PART_INVOKE_FANOUT_DEFAULT) {
+	const results = await collectSocialRpcResponses(username, rpc, timeoutMs, maxResponses)
+	return { data: partInvokeDataRows(results), errors: partInvokeErrorMessages(results) }
+}

--- a/src/public/parts/shells/social/src/federation/visibility.mjs
+++ b/src/public/parts/shells/social/src/federation/visibility.mjs
@@ -1,0 +1,101 @@
+/**
+ * Social 时间线联邦 pull 出站可见性纯逻辑。
+ */
+
+import { canViewByVisibility } from '../lib/visibilitySpec.mjs'
+
+/** 联邦 pull 永不外泄的类型（反应按 owner.publishReactions 另过滤） */
+export const FEDERATION_PRIVATE_EVENT_TYPES = new Set([
+	'follow',
+	'unfollow',
+	'follow_approve',
+	'file_share',
+])
+
+/** 受 publishReactions 控制的反应事件 */
+export const FEDERATION_REACTION_EVENT_TYPES = new Set([
+	'like',
+	'unlike',
+	'dislike',
+	'undislike',
+])
+
+/** 相册相关事件 */
+export const FEDERATION_ALBUM_EVENT_TYPES = new Set([
+	'album_create',
+	'album_update',
+	'album_delete',
+	'album_post_add',
+	'album_post_remove',
+])
+
+/**
+ * @param {object} event 时间线事件
+ * @param {string} ownerEntityHash owner
+ * @param {object} requesterContext 请求者上下文
+ * @param {(post: object, requesterEntityHash: string | null, blocked: Set<string>, following: Set<string>, followSince?: Map<string, number>) => boolean} canViewPost 帖子可见性
+ * @returns {boolean} 是否可联邦导出
+ */
+export function isTimelineEventVisibleForFederation(event, ownerEntityHash, requesterContext, canViewPost) {
+	const type = event.type
+	if (FEDERATION_PRIVATE_EVENT_TYPES.has(type)) return false
+	if (FEDERATION_REACTION_EVENT_TYPES.has(type))
+		return requesterContext.publishReactions !== false
+	if (requesterContext.isOwner) return true
+
+	if (type === 'social_meta') return !requesterContext.hideFromDiscovery
+
+	if (type === 'post' || type === 'repost')
+		return canViewPost(
+			{ entityHash: ownerEntityHash, content: event.content },
+			requesterContext.requesterEntityHash,
+			new Set(),
+			new Set(requesterContext.followsOwner ? [ownerEntityHash] : []),
+			requesterContext.followSince || new Map(),
+		)
+
+	if (type === 'post_edit' || type === 'post_delete' || type === 'post_visibility_set') return true
+
+	if (FEDERATION_ALBUM_EVENT_TYPES.has(type)) {
+		const albumId = String(event.content?.albumId || '').trim()
+		const album = requesterContext.albums?.[albumId]
+		if (type === 'album_delete') return true
+		if (!album && (type === 'album_create' || type === 'album_update'))
+			return canViewByVisibility(event.content, {
+				viewerEntityHash: requesterContext.requesterEntityHash,
+				following: new Set(requesterContext.followsOwner ? [ownerEntityHash] : []),
+				followSince: requesterContext.followSince || new Map(),
+				at: Date.now(),
+			}, ownerEntityHash)
+		if (!album) return false
+		return canViewByVisibility(album, {
+			viewerEntityHash: requesterContext.requesterEntityHash,
+			following: new Set(requesterContext.followsOwner ? [ownerEntityHash] : []),
+			followSince: requesterContext.followSince || new Map(),
+			at: Date.now(),
+		}, ownerEntityHash)
+	}
+
+	if (type === 'poll_vote') {
+		if (requesterContext.isOwner) return true
+		const target = String(event.content?.targetEntityHash || '').toLowerCase()
+		return target === String(requesterContext.requesterEntityHash || '').toLowerCase()
+	}
+
+	if (type === 'tag_name')
+		return requesterContext.publishPreferences !== false
+
+	return false
+}
+
+/**
+ * @param {object[]} events 原始事件
+ * @param {string} ownerEntityHash owner
+ * @param {object} requesterContext 请求者上下文
+ * @param {(post: object, requesterEntityHash: string | null, blocked: Set<string>, following: Set<string>, followSince?: Map<string, number>) => boolean} canViewPost 帖子可见性
+ * @returns {object[]} 过滤后的事件
+ */
+export function filterTimelineEventsForFederation(events, ownerEntityHash, requesterContext, canViewPost) {
+	const owner = String(ownerEntityHash).toLowerCase()
+	return events.filter(event => isTimelineEventVisibleForFederation(event, owner, requesterContext, canViewPost))
+}

--- a/src/public/parts/shells/social/src/federation/write_auth.mjs
+++ b/src/public/parts/shells/social/src/federation/write_auth.mjs
@@ -1,0 +1,162 @@
+/**
+ * Social 时间线写入授权（联邦入站 untrusted 边界）。
+ */
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import { readJsonl } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import {
+	activeSenderHashFromPubKeyHex,
+	createGenesisKeyHistory,
+	recoverySubjectHashFromPubKeyHex,
+} from 'npm:@steve02081504/fount-p2p/federation/entity_key_chain'
+
+import { getEntityProfile } from '../lib/entityProfile.mjs'
+import { timelineEventsPath } from '../paths.mjs'
+
+import {
+	foldEntityKeyHistoryFromEvents,
+	isEntityTimelineWriteAuthorized,
+} from './entity_key_auth.mjs'
+
+/**
+ * 从当前入站事件引导密钥链（无本地先验时）。
+ * @param {{ entityHash: string, subjectHash: string }} parsed 已解析 entityHash
+ * @param {string} sender 已规范化 sender
+ * @param {{ eventType?: string, eventContent?: object, senderPubKeyHex?: string }} options 事件上下文
+ * @returns {{ recoveryPubKeyHex: string | null, entityKeyHistory: object[] } | null} 引导结果
+ */
+function bootstrapKeyChainFromEvent(parsed, sender, options) {
+	const type = options.eventType || ''
+	const content = options.eventContent || {}
+
+	if (type === 'social_meta') {
+		const recovery = normalizeHex64(content.recoveryPubKeyHex || '')
+		if (!isHex64(recovery)) return null
+		if (recoverySubjectHashFromPubKeyHex(recovery) !== parsed.subjectHash) return null
+		return { recoveryPubKeyHex: recovery, entityKeyHistory: [] }
+	}
+
+	if (type === 'entity_key_rotate' && Number(content.generation) === 0) {
+		const recovery = normalizeHex64(options.senderPubKeyHex || '')
+		if (!isHex64(recovery)) return null
+		if (recoverySubjectHashFromPubKeyHex(recovery) !== parsed.subjectHash) return null
+		if (normalizeHex64(sender) !== parsed.subjectHash) return null
+		const active = normalizeHex64(content.activePubKeyHex || '')
+		return {
+			recoveryPubKeyHex: recovery,
+			entityKeyHistory: isHex64(active) ? createGenesisKeyHistory(recovery, active) : [],
+		}
+	}
+
+	return null
+}
+
+/**
+ * EVFS 验签 profile 作跨节点活跃钥 attestation（readPublicFile 已锚定 recovery）。
+ * @param {string} username replica
+ * @param {string} entityHash 时间线 owner
+ * @param {string} sender 事件 sender
+ * @returns {Promise<boolean>} 是否与 profile.activePubKeyHex 匹配
+ */
+async function isAuthorizedByEvfsProfile(username, entityHash, sender) {
+	const { readPublicFile } = await import('npm:@steve02081504/fount-p2p/files/evfs')
+	const plain = await readPublicFile(username, entityHash, 'profile.json')
+	if (!plain) return false
+	let payload
+	try {
+		payload = JSON.parse(plain.toString('utf8'))
+	}
+	catch {
+		return false
+	}
+	if (String(payload?.entityHash || '').toLowerCase() !== entityHash) return false
+	const active = normalizeHex64(payload.activePubKeyHex || '')
+	if (!isHex64(active)) return false
+	return activeSenderHashFromPubKeyHex(active) === sender
+}
+
+/**
+ * owner 以自身活跃钥改/删所属实体帖：凭 profile.ownerEntityHash 与 owner 时间线密钥链复核。
+ * @param {string} entityHash 时间线 owner
+ * @param {string} sender 事件 sender pubKeyHash
+ * @param {{ username?: string, eventType?: string, eventContent?: object }} options 需 username 以读 owner 时间线
+ * @returns {Promise<boolean>} 是否授权
+ */
+async function isOwnerContentEventAuthorized(entityHash, sender, options) {
+	const username = String(options.username || '').trim()
+	if (!username) return false
+	const profile = await getEntityProfile(username, entityHash)
+	const ownerEntityHash = String(profile?.ownerEntityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(ownerEntityHash)) return false
+	let ownerEvents
+	try {
+		ownerEvents = await readJsonl(timelineEventsPath(username, ownerEntityHash))
+	}
+	catch {
+		return false
+	}
+	if (!ownerEvents?.length) return false
+	const folded = foldEntityKeyHistoryFromEvents(ownerEvents)
+	if (!folded.recoveryPubKeyHex || !folded.entityKeyHistory?.length) return false
+	return isEntityTimelineWriteAuthorized({
+		entityHash: ownerEntityHash,
+		sender,
+		eventType: options.eventType || 'post_delete',
+		eventContent: options.eventContent || {},
+		recoveryPubKeyHex: folded.recoveryPubKeyHex,
+		entityKeyHistory: folded.entityKeyHistory,
+	})
+}
+
+/**
+ * 判定已验签的 sender 是否有权写入目标时间线。
+ * @param {string} entityHash 时间线 owner（128 hex）
+ * @param {string} sender 事件 sender（已验签的 pubKeyHash，64 hex）
+ * @param {object} [options] 可选上下文
+ * @param {string} [options.eventType] 事件 type
+ * @param {object} [options.eventContent] 事件 content
+ * @param {object[]} [options.priorEvents] 已有事件（折叠密钥链）
+ * @param {string} [options.username] 本机 replica（owner 删帖 / EVFS 兜底）
+ * @param {string} [options.senderPubKeyHex] 事件 senderPubKey（gen0 引导用）
+ * @returns {Promise<boolean>} 是否授权写入
+ */
+export async function isTimelineWriteAuthorized(entityHash, sender, options = {}) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return false
+	const normalizedSender = normalizeHex64(sender)
+	if (!isHex64(normalizedSender)) return false
+
+	let { recoveryPubKeyHex, entityKeyHistory } = foldEntityKeyHistoryFromEvents(options.priorEvents || [])
+
+	if (!recoveryPubKeyHex || !entityKeyHistory.length) {
+		const boot = bootstrapKeyChainFromEvent(parsed, normalizedSender, options)
+		if (boot) {
+			recoveryPubKeyHex = recoveryPubKeyHex || boot.recoveryPubKeyHex
+			if (!entityKeyHistory.length && boot.entityKeyHistory.length)
+				entityKeyHistory = boot.entityKeyHistory
+		}
+	}
+
+	if (recoveryPubKeyHex && isEntityTimelineWriteAuthorized({
+		entityHash: parsed.entityHash,
+		sender: normalizedSender,
+		eventType: options.eventType || '',
+		eventContent: options.eventContent || {},
+		recoveryPubKeyHex,
+		entityKeyHistory,
+	}))
+		return true
+
+	if (normalizedSender === parsed.subjectHash)
+		return true
+
+	if ((options.eventType === 'post_delete' || options.eventType === 'post_edit')
+		&& await isOwnerContentEventAuthorized(parsed.entityHash, normalizedSender, options))
+		return true
+
+	// 无先验链时：EVFS 验签 profile 的 activePubKeyHex 作 attestation 兜底
+	if (options.username && await isAuthorizedByEvfsProfile(options.username, parsed.entityHash, normalizedSender))
+		return true
+
+	return false
+}

--- a/src/public/parts/shells/social/src/feed/buildItem.mjs
+++ b/src/public/parts/shells/social/src/feed/buildItem.mjs
@@ -1,0 +1,149 @@
+import { summarizeNotes } from '../federation/note/index.mjs'
+import { listPollTally } from '../federation/poll/index.mjs'
+import { socialPostKey } from '../federation/post_key.mjs'
+import { isPollClosed, viewerPollChoicesFromView } from '../lib/poll.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { maybeDecryptPostContent } from '../vault_crypto/vault.mjs'
+
+/**
+ * @param {{ likes: Map<string, number>, dislikes?: Map<string, number>, reposts: Map<string, number>, replies: Map<string, number> }} engagement 互动计数索引
+ * @param {Set<string>} viewerLiked 观看者已赞键集合
+ * @param {Set<string>} [viewerDisliked] 观看者已踩键集合
+ * @returns {(targetEntityHash: string, targetPostId: string) => object} 互动计数查询
+ */
+export function createEngagementForPost(engagement, viewerLiked, viewerDisliked = new Set()) {
+	return function engagementForPost(targetEntityHash, targetPostId) {
+		const key = socialPostKey(targetEntityHash, targetPostId)
+		return {
+			likeCount: engagement.likes.get(key) || 0,
+			dislikeCount: engagement.dislikes?.get(key) || 0,
+			repostCount: engagement.reposts.get(key) || 0,
+			replyCount: engagement.replies.get(key) || 0,
+			viewerLiked: viewerLiked.has(key),
+			viewerDisliked: viewerDisliked.has(key),
+		}
+	}
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 作者
+ * @param {object} post 物化帖子
+ * @param {string | null} [viewerEntityHash] 读者实体哈希，定向帖解密用
+ * @returns {Promise<object>} 解密后的帖子副本
+ */
+export async function withDecryptedPostContent(username, entityHash, post, viewerEntityHash = null) {
+	const decrypted = await maybeDecryptPostContent(username, entityHash, post.content, viewerEntityHash)
+	if (decrypted)
+		return { ...post, content: decrypted }
+	return { ...post, content: null, decryptView: { failed: true } }
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 作者
+ * @param {object} post 物化帖子
+ * @param {object} feedContext 构建上下文
+ * @param {(entityHash: string) => Promise<object | null>} feedContext.authorProfile 作者资料加载器
+ * @param {(targetEntityHash: string, targetPostId: string) => object} feedContext.engagementForPost 互动查询
+ * @param {boolean} [feedContext.decrypt=true] 是否解密 content
+ * @returns {Promise<object>} feed 条目
+ */
+export async function buildPostFeedItem(username, entityHash, post, feedContext) {
+	const decrypt = feedContext.decrypt !== false
+	const viewerEntityHash = feedContext.viewerEntityHash || null
+	const postOut = decrypt
+		? await withDecryptedPostContent(username, entityHash, post, viewerEntityHash)
+		: post
+	const authorProfile = await feedContext.authorProfile(entityHash)
+	const item = {
+		kind: 'post',
+		entityHash,
+		postId: post.id,
+		post: postOut,
+		hlc: post.hlc,
+		authorProfile,
+		ownerEntityHash: authorProfile?.ownerEntityHash || null,
+		...feedContext.engagementForPost(entityHash, post.id),
+	}
+	const replyTo = postOut?.content?.replyTo || post.content?.replyTo
+	if (replyTo?.entityHash && replyTo?.postId)
+		item.replyContext = await buildReplyContext(username, replyTo, feedContext)
+	if (feedContext.warmAlbumView)
+		await feedContext.warmAlbumView(entityHash)
+	if (feedContext.albumsForPost)
+		item.albums = feedContext.albumsForPost(entityHash, post.id) || []
+	const poll = postOut.content?.poll
+	if (poll?.options?.length) {
+		const tally = await listPollTally(username, entityHash, post.id)
+		item.poll = {
+			options: poll.options,
+			multi: poll.multi === true,
+			deadline: poll.deadline || null,
+			tally,
+			closed: isPollClosed(poll),
+			viewerChoices: feedContext.viewerPollChoices
+				? viewerPollChoicesFromView(feedContext.viewerPollChoices, entityHash, post.id)
+				: null,
+		}
+	}
+	const { topNote, notes } = await summarizeNotes(username, entityHash, post.id)
+	if (topNote || notes.length)
+		item.communityNote = { topNote, noteCount: notes.length }
+	return item
+}
+
+/**
+ * @param {string} username 用户
+ * @param {{ entityHash: string, postId: string }} replyTo 被回复引用
+ * @param {object} feedContext feed 构建上下文
+ * @returns {Promise<object>} replyContext
+ */
+async function buildReplyContext(username, replyTo, feedContext) {
+	const targetEntityHash = String(replyTo.entityHash).toLowerCase()
+	const targetPostId = String(replyTo.postId)
+	const authorProfile = await feedContext.authorProfile(targetEntityHash)
+	let text = ''
+	try {
+		const view = await getTimelineMaterialized(username, targetEntityHash)
+		const parent = view.postById?.[targetPostId] || view.posts?.find(row => row.id === targetPostId)
+		if (parent?.content) {
+			const decrypted = await maybeDecryptPostContent(
+				username,
+				targetEntityHash,
+				parent.content,
+				feedContext.viewerEntityHash || null,
+			)
+			text = String((decrypted || parent.content)?.text || '').slice(0, 200)
+		}
+	}
+	catch { /* 父帖不可见时仅返回引用 */ }
+	return {
+		entityHash: targetEntityHash,
+		postId: targetPostId,
+		authorProfile,
+		text,
+	}
+}
+
+/**
+ * @param {object} head repost 候选头
+ * @param {object} originalPost 原帖
+ * @param {object} feedContext 构建上下文
+ * @returns {Promise<object>} feed 条目
+ */
+export async function buildRepostFeedItem(head, originalPost, feedContext) {
+	return {
+		kind: 'repost',
+		entityHash: head.entityHash,
+		postId: head.postId,
+		post: originalPost,
+		targetEntityHash: head.originalEntityHash,
+		targetPostId: head.originalPostId,
+		repostComment: String(head.repost.content?.comment || ''),
+		hlc: head.hlc,
+		authorProfile: await feedContext.authorProfile(head.entityHash),
+		targetAuthorProfile: await feedContext.authorProfile(head.originalEntityHash),
+		...feedContext.engagementForPost(head.originalEntityHash, head.originalPostId),
+	}
+}

--- a/src/public/parts/shells/social/src/feed/home.mjs
+++ b/src/public/parts/shells/social/src/feed/home.mjs
@@ -1,0 +1,508 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isEntityHashBlocked } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import {
+	isAuthorFilteredByPersonalSets,
+	loadPersonalFilterSets,
+} from 'npm:@steve02081504/fount-p2p/node/personal_block'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../../chat/src/entity/identity.mjs'
+import { socialPostKey } from '../federation/post_key.mjs'
+import { reputationSortPenalty, shouldHideAuthorByReputation } from '../federation/reputation/index.mjs'
+import { compareFeedItems, kWayMergeFeedStreams, pickNextFeedStreamIndex } from '../feedMerge.mjs'
+import { canViewPost } from '../feedVisibility.mjs'
+import { loadFollowing, loadFollowingForActor, listFollowedTimelineOwners } from '../following.mjs'
+import { isPublicDiscoverable } from '../lib/visibilitySpec.mjs'
+import { loadMutedKeywords } from '../mutedKeywords.mjs'
+import { queryReplyIndex } from '../searchIndex.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import {
+	buildPostFeedItem,
+	buildRepostFeedItem,
+	withDecryptedPostContent,
+} from './buildItem.mjs'
+import { createFeedItemBuildContext } from './iterate.mjs'
+
+/**
+ * @param {Map<string, number>} counts 计数表
+ * @param {string} entityHash 目标实体
+ * @param {string | number} postId 帖子 id
+ */
+function bumpEngagementCount(counts, entityHash, postId) {
+	if (!entityHash || postId == null) return
+	const key = socialPostKey(entityHash.toLowerCase(), postId)
+	counts.set(key, (counts.get(key) || 0) + 1)
+}
+
+/**
+ * 扫描时间线构建点赞/点踩/转发/回复计数索引。
+ * @param {string} username 用户
+ * @param {Iterable<string>} [owners] 仅扫描这些时间线 owner；缺省为全部已知 owner
+ * @returns {Promise<{ likes: Map<string, number>, dislikes: Map<string, number>, reposts: Map<string, number>, replies: Map<string, number> }>} 互动计数索引
+ */
+export async function buildEngagementIndex(username, owners = null) {
+	/** @type {Map<string, number>} */
+	const likes = new Map()
+	/** @type {Map<string, number>} */
+	const dislikes = new Map()
+	/** @type {Map<string, number>} */
+	const reposts = new Map()
+	/** @type {Map<string, number>} */
+	const replies = new Map()
+
+	const ownerList = owners ? [...owners] : await listFollowedTimelineOwners(username)
+	for (const owner of ownerList) {
+		const view = await getTimelineMaterialized(username, owner)
+		for (const like of view.likes || [])
+			bumpEngagementCount(likes, like.content?.targetEntityHash, like.content?.targetPostId)
+		for (const dislike of view.dislikes || [])
+			bumpEngagementCount(dislikes, dislike.content?.targetEntityHash, dislike.content?.targetPostId)
+		for (const repost of view.reposts || [])
+			bumpEngagementCount(reposts, repost.content?.targetEntityHash, repost.content?.targetPostId)
+		for (const post of view.posts || []) {
+			const replyTo = post.content?.replyTo
+			bumpEngagementCount(replies, replyTo?.entityHash, replyTo?.postId)
+		}
+	}
+	return { likes, dislikes, reposts, replies }
+}
+
+/**
+ * 收集观看者已点赞的帖子键集合。
+ * @param {string} username 用户
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<Set<string>>} 已点赞帖子键集合
+ */
+export async function buildViewerLikedSet(username, viewerEntityHash) {
+	const self = viewerEntityHash
+		? String(viewerEntityHash).trim().toLowerCase()
+		: await resolveOperatorEntityHash(username)
+	if (!self) return new Set()
+	const view = await getTimelineMaterialized(username, self)
+	return new Set((view.likes || []).map(like =>
+		socialPostKey(like.content.targetEntityHash, like.content.targetPostId),
+	))
+}
+
+/**
+ * 收集观看者已点踩的帖子键集合。
+ * @param {string} username 用户
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<Set<string>>} 已点踩帖子键集合
+ */
+export async function buildViewerDislikedSet(username, viewerEntityHash) {
+	const self = viewerEntityHash
+		? String(viewerEntityHash).trim().toLowerCase()
+		: await resolveOperatorEntityHash(username)
+	if (!self) return new Set()
+	const view = await getTimelineMaterialized(username, self)
+	return new Set((view.dislikes || []).map(dislike =>
+		socialPostKey(dislike.content.targetEntityHash, dislike.content.targetPostId),
+	))
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} [viewerEntityHash] 可选指定观看实体，默认 operator
+ * @returns {Promise<{ viewerEntityHash: string | null, following: Set<string>, followSince: Map<string, number>, personalFilter: Awaited<ReturnType<typeof loadPersonalFilterSets>>, mutedKeywords: Awaited<ReturnType<typeof loadMutedKeywords>>, at: number }>} 观看者上下文
+ */
+export async function loadViewerContext(username, viewerEntityHash = null) {
+	const viewer = viewerEntityHash || await resolveOperatorEntityHash(username)
+	const following = new Set(
+		viewer
+			? (await loadFollowingForActor(username, viewer)).following.map(id => id.toLowerCase())
+			: [],
+	)
+	/** @type {Map<string, number>} */
+	const followSince = new Map()
+	if (viewer) {
+		const { latestFollowWallForAuthor } = await import('../lib/replyPolicy.mjs')
+		const viewerView = await getTimelineMaterialized(username, viewer)
+		for (const author of following) {
+			const wall = latestFollowWallForAuthor(viewerView, author)
+			if (wall != null) followSince.set(author, wall)
+			else if (author === viewer.toLowerCase()) followSince.set(author, 0)
+		}
+	}
+	const personalFilter = viewer
+		? await loadPersonalFilterSets(viewer)
+		: {
+			blockedEntityHashes: new Set(),
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		}
+	const mutedKeywords = viewer
+		? await loadMutedKeywords(username, viewer)
+		: { entries: [] }
+	return { viewerEntityHash: viewer, following, followSince, personalFilter, mutedKeywords, at: Date.now() }
+}
+
+/**
+ * @param {object} item feed 条目
+ * @returns {string} 分页游标（始终指向原帖 entityHash:postId）
+ */
+export function feedItemCursorKey(item) {
+	if (item.kind === 'repost') {
+		const originalEntity = item.targetEntityHash || item.post?.entityHash
+		const originalPostId = item.targetPostId || item.post?.id
+		if (originalEntity && originalPostId)
+			return `${originalEntity}:${originalPostId}`
+	}
+	return `${item.entityHash}:${item.postId}`
+}
+
+/**
+ * @param {string} entityHash 作者实体
+ * @returns {boolean} 是否因信誉隐藏
+ */
+function isHiddenByAuthorReputation(entityHash) {
+	return shouldHideAuthorByReputation(entityHash, pickNodeScore)
+}
+
+/**
+ * 解析并校验对观看者可见的帖子（含解密）。
+ * @param {string} username 用户
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖子 id
+ * @param {object} viewerContext 观看者上下文
+ * @returns {Promise<object | null>} 可见帖子或 null
+ */
+async function resolveVisiblePost(username, entityHash, postId, viewerContext) {
+	const post = (await getTimelineMaterialized(username, entityHash)).postById?.[postId]
+	if (!post) return null
+	const enriched = { ...post, entityHash }
+	if (!canViewPost(enriched, viewerContext))
+		return null
+	return withDecryptedPostContent(username, entityHash, post)
+}
+
+/**
+ * 构建关注流首页 feed（含原帖与转发，多路归并排序）。
+ * @param {string} username 用户
+ * @param {object} [options] 分页选项
+ * @param {string} [options.viewerEntityHash] 观看实体；缺省 = operator
+ * @param {number} [options.limit=50] 条数上限
+ * @param {string} [options.cursor] 分页游标
+ * @returns {Promise<{ items: object[], nextCursor: string | null }>} 首页 feed
+ */
+export async function buildHomeFeed(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 50, 1), 200)
+	const viewer = options.viewerEntityHash || null
+	const { following } = viewer
+		? await loadFollowingForActor(username, viewer)
+		: await loadFollowing(username)
+	const viewerContext = await loadViewerContext(username, viewer)
+	const feedSources = new Set(following)
+	const itemContext = await createFeedItemBuildContext(username, feedSources, viewer)
+
+	/** @type {{ candidates: object[], index: number }[]} */
+	const streams = []
+	for (const entityHash of feedSources) {
+		if (!isEntityHash128(entityHash)) continue
+		if (isEntityHashBlocked(entityHash)) continue
+		if (isHiddenByAuthorReputation(entityHash)) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		if (!view.posts?.length && !view.reposts?.length) continue
+		/** @type {object[]} */
+		const candidates = []
+		for (const post of view.posts) {
+			const enriched = { ...post, entityHash }
+			if (!canViewPost(enriched, viewerContext))
+				continue
+			candidates.push({
+				kind: 'post',
+				entityHash,
+				postId: post.id,
+				post,
+				hlc: post.hlc,
+				repPenalty: reputationSortPenalty(entityHash, pickNodeScore),
+			})
+		}
+		for (const repost of view.reposts) {
+			const originalEntityHash = (repost.content?.targetEntityHash || '').toLowerCase()
+			const originalPostId = repost.content?.targetPostId || ''
+			if (!isEntityHash128(originalEntityHash) || !originalPostId) continue
+			candidates.push({
+				kind: 'repost',
+				entityHash,
+				postId: repost.id,
+				hlc: repost.hlc,
+				repost,
+				originalEntityHash,
+				originalPostId,
+				repPenalty: reputationSortPenalty(entityHash, pickNodeScore),
+			})
+		}
+		candidates.sort((a, b) => -compareFeedItems(a, b))
+		streams.push({ candidates, index: 0 })
+	}
+
+	// 订阅话题源：从已知时间线注入含标签的公开帖
+	if (viewer) {
+		const viewerView = await getTimelineMaterialized(username, viewer)
+		const followedTags = new Set((viewerView.followedTags || []).map(t => String(t).toLowerCase()))
+		if (followedTags.size) {
+			const { extractHashtagsFromText } = await import('../lib/hashtags.mjs')
+			/** @type {object[]} */
+			const topicCandidates = []
+			const seenKeys = new Set()
+			for (const entityHash of feedSources) {
+				if (!isEntityHash128(entityHash)) continue
+				const view = await getTimelineMaterialized(username, entityHash)
+				for (const post of view.posts || []) {
+					if (!isPublicDiscoverable(post.content)) continue
+					const tags = [
+						...extractHashtagsFromText(post.content?.text || ''),
+						...Array.isArray(post.content?.tags) ? post.content.tags.map(t => String(t).toLowerCase()) : [],
+					]
+					if (!tags.some(tag => followedTags.has(tag))) continue
+					const key = `${entityHash}:${post.id}`
+					if (seenKeys.has(key)) continue
+					seenKeys.add(key)
+					topicCandidates.push({
+						kind: 'post',
+						entityHash,
+						postId: post.id,
+						post,
+						hlc: post.hlc,
+						via: 'topic',
+						repPenalty: reputationSortPenalty(entityHash, pickNodeScore),
+					})
+				}
+			}
+			if (topicCandidates.length) {
+				topicCandidates.sort((a, b) => -compareFeedItems(a, b))
+				streams.push({ candidates: topicCandidates, index: 0 })
+			}
+		}
+	}
+
+	let collecting = !options.cursor
+	/** @type {object[]} */
+	const items = []
+	let hasMore = false
+
+	while (collecting ? items.length < limit : true) {
+		const best = pickNextFeedStreamIndex(streams)
+		if (best < 0) break
+
+		const stream = streams[best]
+		const candidate = stream.candidates[stream.index]
+		stream.index++
+
+		/** @type {object | null} */
+		let item = null
+		if (candidate.kind === 'repost') {
+			const originalPost = await resolveVisiblePost(username, candidate.originalEntityHash, candidate.originalPostId, viewerContext)
+			if (originalPost)
+				item = await buildRepostFeedItem(candidate, originalPost, itemContext)
+		}
+		else
+			item = await buildPostFeedItem(username, candidate.entityHash, candidate.post, itemContext)
+
+		if (!item) continue
+		if (candidate.via) item.via = candidate.via
+		const key = feedItemCursorKey(item)
+		if (!collecting) {
+			if (key === options.cursor) collecting = true
+			continue
+		}
+		items.push(item)
+	}
+
+	if (items.length === limit) {
+		const peek = kWayMergeFeedStreams(streams.map(s => ({ ...s })), 1)
+		hasMore = peek.length > 0
+	}
+
+	const next = hasMore && items.length
+		? feedItemCursorKey(items[items.length - 1])
+		: null
+	return { items, nextCursor: next }
+}
+
+/**
+ * 构建资料页帖子列表（与首页 feed 同构，支持 cursor 分页）。
+ * @param {string} username 用户
+ * @param {string} entityHash 资料页 owner
+ * @param {{ limit?: number, cursor?: string, viewerEntityHash?: string }} [options] 分页与观看者
+ * @returns {Promise<{ entityHash: string, items: object[], nextCursor: string | null }>} 与首页 feed 同构的帖子列表
+ */
+export async function buildProfileFeedItems(username, entityHash, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 30, 1), 100)
+	entityHash = entityHash.trim().toLowerCase()
+	if (!isEntityHash128(entityHash))
+		return { entityHash, items: [], nextCursor: null }
+
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	const itemContext = await createFeedItemBuildContext(username, null, options.viewerEntityHash || null)
+	const view = await getTimelineMaterialized(username, entityHash)
+
+	/** @type {object[]} */
+	const items = []
+
+	for (const post of view.posts) {
+		const enriched = { ...post, entityHash }
+		if (!canViewPost(enriched, viewerContext))
+			continue
+		items.push(await buildPostFeedItem(username, entityHash, post, itemContext))
+	}
+
+	items.sort((left, right) => compareFeedItems(left, right) * -1)
+
+	let start = 0
+	if (options.cursor) {
+		const cursor = String(options.cursor).trim().toLowerCase()
+		const index = items.findIndex(item => String(item.postId || '').toLowerCase() === cursor)
+		start = index >= 0 ? index + 1 : 0
+	}
+	const page = items.slice(start, start + limit)
+	const nextCursor = page.length === limit && start + limit < items.length
+		? String(page[page.length - 1].postId)
+		: null
+	return { entityHash, items: page, nextCursor }
+}
+
+/**
+ * 构建资料页点赞列表（与首页 feed 同构）。
+ * @param {string} username 用户
+ * @param {string} entityHash 资料页 owner
+ * @param {{ viewerEntityHash?: string }} [options] 观看者
+ * @returns {Promise<{ entityHash: string, items: object[] }>} 点赞过的帖子列表
+ */
+export async function buildLikedFeedItems(username, entityHash, options = {}) {
+	entityHash = entityHash.trim().toLowerCase()
+	if (!isEntityHash128(entityHash))
+		return { entityHash, items: [] }
+
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	const itemContext = await createFeedItemBuildContext(username, null, options.viewerEntityHash || null)
+	const view = await getTimelineMaterialized(username, entityHash)
+	if (!view.likes?.length)
+		return { entityHash, items: [] }
+
+	/** @type {object[]} */
+	const items = []
+
+	for (const like of view.likes) {
+		const targetEntityHash = (like.content?.targetEntityHash || '').toLowerCase()
+		const targetPostId = like.content?.targetPostId
+		if (!isEntityHash128(targetEntityHash) || targetPostId == null) continue
+		const post = await resolveVisiblePost(username, targetEntityHash, String(targetPostId), viewerContext)
+		if (!post) continue
+		items.push(await buildPostFeedItem(username, targetEntityHash, post, itemContext))
+	}
+
+	items.sort((left, right) => compareFeedItems(left, right) * -1)
+	return { entityHash, items }
+}
+
+/**
+ * 列出指定帖子的可见回复。
+ * @param {string} username 用户
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖子
+ * @param {{ viewerEntityHash?: string }} [options] 观看者
+ * @returns {Promise<object[]>} 可见回复（完整 feed item + featured）
+ */
+export async function listReplies(username, entityHash, postId, options = {}) {
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	const { canReplyUnderPolicy, featuredReplyKey, loadPostReplyGate, normalizeReplyDisplay } = await import('../lib/replyPolicy.mjs')
+	const gate = await loadPostReplyGate(username, entityHash, postId)
+	const replyPolicy = gate?.replyPolicy || 'everyone'
+	const replyDisplay = gate?.replyDisplay || 'all'
+	const authorView = await getTimelineMaterialized(username, entityHash)
+	const featuredSet = new Set(authorView.featuredReplies?.[postId] || [])
+	/** @type {{ entityHash: string, post: object, featured: boolean }[]} */
+	const rawReplies = []
+	const refs = await queryReplyIndex(username, entityHash, postId)
+
+	for (const ref of refs) {
+		const author = ref.entityHash
+		if (isAuthorFilteredByPersonalSets(viewerContext.personalFilter, author)) continue
+		if (isHiddenByAuthorReputation(author)) continue
+		const view = await getTimelineMaterialized(username, author)
+		const post = view.postById?.[ref.postId] || view.posts?.find(row => row.id === ref.postId)
+		if (!post) continue
+		if (!canViewPost({ ...post, entityHash: author }, viewerContext)) continue
+		const allowed = await canReplyUnderPolicy({
+			username,
+			authorEntityHash: entityHash,
+			replierEntityHash: author,
+			replyPolicy,
+			at: Number(post.hlc?.wall) || Number(post.timestamp) || Date.now(),
+		})
+		if (!allowed) continue
+		const featured = featuredSet.has(featuredReplyKey(author, ref.postId))
+		rawReplies.push({ entityHash: author, post, featured })
+	}
+
+	if (!rawReplies.length)
+		for (const author of await listFollowedTimelineOwners(username, options.viewerEntityHash || null)) {
+			if (isAuthorFilteredByPersonalSets(viewerContext.personalFilter, author)) continue
+			if (isHiddenByAuthorReputation(author)) continue
+			const view = await getTimelineMaterialized(username, author)
+			if (!view.posts?.length) continue
+			for (const post of view.posts) {
+				const replyTo = post.content?.replyTo
+				if (!replyTo) continue
+				if (replyTo.entityHash?.toLowerCase() !== entityHash.toLowerCase()) continue
+				if (replyTo.postId !== postId) continue
+				if (!canViewPost({ ...post, entityHash: author }, viewerContext))
+					continue
+				const allowed = await canReplyUnderPolicy({
+					username,
+					authorEntityHash: entityHash,
+					replierEntityHash: author,
+					replyPolicy,
+					at: Number(post.hlc?.wall) || Number(post.timestamp) || Date.now(),
+				})
+				if (!allowed) continue
+				const featured = featuredSet.has(featuredReplyKey(author, post.id))
+				rawReplies.push({ entityHash: author, post, featured })
+			}
+		}
+
+	rawReplies.sort((left, right) => {
+		if (left.featured !== right.featured) return left.featured ? -1 : 1
+		const lw = Number(left.post.hlc.wall)
+		const rw = Number(right.post.hlc.wall)
+		return rw - lw
+	})
+	const filtered = normalizeReplyDisplay(replyDisplay) === 'featured_only'
+		? rawReplies.filter(row => row.featured)
+		: rawReplies
+	const owners = new Set(filtered.map(row => row.entityHash))
+	owners.add(entityHash)
+	const itemContext = await createFeedItemBuildContext(username, owners, options.viewerEntityHash || null)
+	/** @type {object[]} */
+	const replies = []
+	for (const row of filtered) {
+		const item = await buildPostFeedItem(username, row.entityHash, row.post, itemContext)
+		item.featured = row.featured
+		replies.push(item)
+	}
+	return replies
+}
+
+/**
+ * 构建单帖 feed item（详情页 / HTTP GET）。
+ * @param {string} username 用户
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @param {{ viewerEntityHash?: string }} [options] 观看者
+ * @returns {Promise<object | null>} feed item；不可见或不存在时 null
+ */
+export async function buildSinglePostFeedItem(username, entityHash, postId, options = {}) {
+	const owner = String(entityHash).toLowerCase()
+	const id = String(postId)
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	const view = await getTimelineMaterialized(username, owner)
+	const post = view.postById?.[id] || view.posts?.find(row => row.id === id)
+	if (!post) return null
+	if (!canViewPost({ ...post, entityHash: owner }, viewerContext)) return null
+	const itemContext = await createFeedItemBuildContext(username, new Set([owner]), options.viewerEntityHash || null)
+	return buildPostFeedItem(username, owner, post, itemContext)
+}

--- a/src/public/parts/shells/social/src/feed/iterate.mjs
+++ b/src/public/parts/shells/social/src/feed/iterate.mjs
@@ -1,0 +1,106 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isEntityHashBlocked } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { shouldHideAuthorByReputation } from '../federation/reputation/index.mjs'
+import { canViewPost } from '../feedVisibility.mjs'
+import { listFollowedTimelineOwners } from '../following.mjs'
+import { albumsForPostFromView } from '../lib/albumRefs.mjs'
+import { createAuthorProfileLoader } from '../lib/authorProfileSummary.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { createEngagementForPost } from './buildItem.mjs'
+import {
+	buildEngagementIndex,
+	buildViewerDislikedSet,
+	buildViewerLikedSet,
+	loadViewerContext,
+} from './home.mjs'
+
+/**
+ * @param {string} username 用户
+ * @param {Iterable<string>} [owners] engagement 扫描范围
+ * @param {string | null} [viewerEntityHash] 观看者实体（用于 poll 自选投影）
+ * @returns {Promise<object>} feed 条目构建上下文
+ */
+export async function createFeedItemBuildContext(username, owners, viewerEntityHash = null) {
+	const engagement = await buildEngagementIndex(username, owners)
+	const viewerLiked = await buildViewerLikedSet(username, viewerEntityHash)
+	const viewerDisliked = await buildViewerDislikedSet(username, viewerEntityHash)
+	const authorProfile = createAuthorProfileLoader(username)
+	const engagementForPost = createEngagementForPost(engagement, viewerLiked, viewerDisliked)
+	let viewerPollChoices = null
+	if (viewerEntityHash) {
+		const view = await getTimelineMaterialized(username, viewerEntityHash)
+		viewerPollChoices = view
+	}
+	const viewerContext = await loadViewerContext(username, viewerEntityHash)
+	/** @type {Map<string, object>} */
+	const albumViewCache = new Map()
+	/**
+	 * @param {string} authorEntityHash 作者
+	 * @param {string} postId 帖
+	 * @returns {{ albumId: string, name: string }[]} 可见相册
+	 */
+	function albumsForPost(authorEntityHash, postId) {
+		const owner = String(authorEntityHash).toLowerCase()
+		const view = albumViewCache.get(owner)
+		if (!view) 
+			// 同步缓存：物化视图通常已在内存；首次 miss 时用空（异步预热由调用方保证）
+			return []
+		
+		return albumsForPostFromView(view, owner, postId, viewerContext)
+	}
+	/**
+	 * @param {string} authorEntityHash 作者
+	 * @returns {Promise<void>}
+	 */
+	async function warmAlbumView(authorEntityHash) {
+		const owner = String(authorEntityHash).toLowerCase()
+		if (albumViewCache.has(owner)) return
+		albumViewCache.set(owner, await getTimelineMaterialized(username, owner))
+	}
+	return {
+		authorProfile,
+		engagementForPost,
+		engagement,
+		viewerLiked,
+		viewerDisliked,
+		viewerPollChoices,
+		viewerEntityHash,
+		albumsForPost,
+		warmAlbumView,
+		albumViewCache,
+	}
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {AsyncGenerator<string>} 可见时间线 owner
+ */
+export async function* iterateVisibleTimelineOwners(username, viewerEntityHash) {
+	for (const entityHash of await listFollowedTimelineOwners(username, viewerEntityHash)) {
+		if (!isEntityHash128(entityHash)) continue
+		if (isEntityHashBlocked(entityHash)) continue
+		if (shouldHideAuthorByReputation(entityHash, pickNodeScore)) continue
+		yield entityHash
+	}
+}
+
+/**
+ * @param {string} username 用户
+ * @param {Awaited<ReturnType<import('./home.mjs').loadViewerContext>>} viewerContext 观看者上下文
+ * @returns {AsyncGenerator<{ entityHash: string, post: object, enriched: object }>} 可见帖子
+ */
+export async function* iterateVisiblePosts(username, viewerContext) {
+	for await (const entityHash of iterateVisibleTimelineOwners(username, viewerContext?.viewerEntityHash)) {
+		const view = await getTimelineMaterialized(username, entityHash)
+		if (!view.posts?.length) continue
+		for (const post of view.posts) {
+			const enriched = { ...post, entityHash }
+			if (!canViewPost(enriched, viewerContext)) continue
+			yield { entityHash, post, enriched }
+		}
+	}
+}

--- a/src/public/parts/shells/social/src/feed/ranking.mjs
+++ b/src/public/parts/shells/social/src/feed/ranking.mjs
@@ -1,0 +1,200 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isEntityHashBlocked } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { loadDwellAuthorBoosts } from '../engagement/dwell.mjs'
+import { socialPostKey } from '../federation/post_key.mjs'
+import { reputationSortPenalty, shouldHideAuthorByReputation } from '../federation/reputation/index.mjs'
+import { canViewPost } from '../feedVisibility.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+import { computeTasteMatch, ensureTasteFresh } from '../taste/cluster.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { buildPostFeedItem } from './buildItem.mjs'
+import { buildEngagementIndex, loadViewerContext } from './home.mjs'
+import { createFeedItemBuildContext } from './iterate.mjs'
+
+const SCORE_HALF_LIFE_MS = 86_400_000
+
+/**
+ * @param {object} post 物化帖
+ * @param {object} engagement 互动索引
+ * @param {number} affinity 与作者互动次数
+ * @param {number} [tasteMatch=0] 口味匹配分
+ * @param {number} [now=Date.now()] 当前时刻
+ * @returns {number} 推荐分
+ */
+export function scorePostForYou(post, engagement, affinity, tasteMatch = 0, now = Date.now()) {
+	const ageMs = Math.max(0, now - Number(post.hlc?.wall || post.timestamp || now))
+	const freshness = Math.exp(-ageMs / SCORE_HALF_LIFE_MS)
+	const key = socialPostKey(post.entityHash || '', post.id)
+	const likes = engagement.likes.get(key) || 0
+	const dislikes = engagement.dislikes?.get(key) || 0
+	const reposts = engagement.reposts.get(key) || 0
+	const replies = engagement.replies.get(key) || 0
+	const engagementBoost = 1 + Math.log1p(Math.max(0, likes + 2 * reposts + replies - dislikes))
+	const affinityBoost = 1 + Math.log1p(affinity)
+	const interestBoost = tasteMatch >= 0
+		? 1 + Math.log1p(tasteMatch)
+		: 1 / (1 + Math.log1p(-tasteMatch))
+	return freshness * engagementBoost * affinityBoost * interestBoost
+}
+
+/**
+ * @param {string} username replica
+ * @param {Set<string>} following 关注列表
+ * @param {string | null} [viewerEntityHash] 观看者（用于 dwell 亲和）
+ * @returns {Promise<Map<string, number>>} 作者 → 双向互动次数
+ */
+async function buildAffinityIndex(username, following, viewerEntityHash = null) {
+	/** @type {Map<string, number>} */
+	const affinity = new Map()
+	for (const entityHash of following) {
+		if (!isEntityHash128(entityHash)) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		for (const like of view.likes || [])
+			if (like.content?.targetEntityHash)
+				affinity.set(String(like.content.targetEntityHash).toLowerCase(), (affinity.get(String(like.content.targetEntityHash).toLowerCase()) || 0) + 1)
+		for (const repost of view.reposts || [])
+			if (repost.content?.targetEntityHash)
+				affinity.set(String(repost.content.targetEntityHash).toLowerCase(), (affinity.get(String(repost.content.targetEntityHash).toLowerCase()) || 0) + 2)
+		for (const post of view.posts || []) {
+			const replyTo = post.content?.replyTo
+			if (replyTo?.entityHash)
+				affinity.set(String(replyTo.entityHash).toLowerCase(), (affinity.get(String(replyTo.entityHash).toLowerCase()) || 0) + 1)
+		}
+	}
+	if (viewerEntityHash) {
+		const dwellBoosts = await loadDwellAuthorBoosts(username, viewerEntityHash)
+		for (const [author, boost] of dwellBoosts)
+			affinity.set(author, (affinity.get(author) || 0) + boost)
+	}
+	return affinity
+}
+
+/**
+ * @param {string} username replica
+ * @param {Set<string>} following 关注列表
+ * @param {object} viewerContext 观看者上下文
+ * @param {import('../taste/store.mjs').TasteStore | null} taste 观看者偏好
+ * @returns {AsyncGenerator<{ entityHash: string, post: object, score: number }>} 候选帖
+ */
+async function* iterateForYouCandidates(username, following, viewerContext, taste) {
+	const engagement = await buildEngagementIndex(username, following)
+	const affinity = await buildAffinityIndex(username, following, viewerContext.viewerEntityHash || null)
+	const seen = new Set()
+
+	/**
+	 * @param {string} entityHash 作者
+	 * @param {object} post 帖
+	 * @param {number} [discount=1] 二度折扣
+	 * @returns {number} 分
+	 */
+	function scoreOf(entityHash, post, discount = 1) {
+		const enriched = { ...post, entityHash }
+		const match = taste ? computeTasteMatch(enriched, entityHash, taste) : 0
+		const base = scorePostForYou(enriched, engagement, affinity.get(entityHash.toLowerCase()) || 0, match)
+		const repPenalty = reputationSortPenalty(entityHash, pickNodeScore)
+		const demoted = base / (1 + repPenalty)
+		return demoted * discount
+	}
+
+	for (const entityHash of following) {
+		if (!isEntityHash128(entityHash) || isEntityHashBlocked(entityHash)) continue
+		if (shouldHideAuthorByReputation(entityHash, pickNodeScore)) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		for (const post of view.posts || []) {
+			const enriched = { ...post, entityHash }
+			if (!canViewPost(enriched, viewerContext)) continue
+			const key = `${entityHash}:${post.id}`
+			if (seen.has(key)) continue
+			seen.add(key)
+			yield { entityHash, post, score: scoreOf(entityHash, post) }
+		}
+	}
+
+	for (const entityHash of following) {
+		if (!isEntityHash128(entityHash)) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		for (const like of view.likes || []) {
+			const targetEntity = String(like.content?.targetEntityHash || '').toLowerCase()
+			const targetPostId = String(like.content?.targetPostId || '')
+			if (!isEntityHash128(targetEntity) || !targetPostId) continue
+			const key = `${targetEntity}:${targetPostId}`
+			if (seen.has(key)) continue
+			const targetView = await getTimelineMaterialized(username, targetEntity)
+			const post = targetView.postById?.[targetPostId]
+			if (!post) continue
+			const enriched = { ...post, entityHash: targetEntity }
+			if (!canViewPost(enriched, viewerContext)) continue
+			if ((post.content?.visibility || 'public') !== 'public') continue
+			seen.add(key)
+			yield { entityHash: targetEntity, post, score: scoreOf(targetEntity, post, 0.85) }
+		}
+		for (const repost of view.reposts || []) {
+			const targetEntity = String(repost.content?.targetEntityHash || '').toLowerCase()
+			const targetPostId = String(repost.content?.targetPostId || '')
+			if (!isEntityHash128(targetEntity) || !targetPostId) continue
+			const key = `${targetEntity}:${targetPostId}`
+			if (seen.has(key)) continue
+			const targetView = await getTimelineMaterialized(username, targetEntity)
+			const post = targetView.postById?.[targetPostId]
+			if (!post) continue
+			const enriched = { ...post, entityHash: targetEntity }
+			if (!canViewPost(enriched, viewerContext)) continue
+			if ((post.content?.visibility || 'public') !== 'public') continue
+			seen.add(key)
+			yield { entityHash: targetEntity, post, score: scoreOf(targetEntity, post, 0.9) }
+		}
+	}
+}
+
+/**
+ * @param {object} item feed 条目
+ * @returns {string} for_you 游标
+ */
+export function forYouCursorKey(item) {
+	return `${Number(item.score || 0).toFixed(12)}:${item.postId}`
+}
+
+/**
+ * @param {string} username 用户
+ * @param {object} [options] 分页选项
+ * @returns {Promise<{ items: object[], nextCursor: string | null }>} For You feed 分页
+ */
+export async function buildForYouFeed(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 50, 1), 200)
+	const viewer = options.viewerEntityHash || null
+	const { following } = await loadFollowingForActor(username, viewer)
+	const viewerContext = await loadViewerContext(username, viewer)
+	const itemContext = await createFeedItemBuildContext(username, following, viewer)
+	const taste = viewer ? await ensureTasteFresh(username, viewer) : null
+
+	/** @type {{ entityHash: string, post: object, score: number }[]} */
+	const candidates = []
+	for await (const row of iterateForYouCandidates(username, following, viewerContext, taste))
+		candidates.push(row)
+
+	candidates.sort((left, right) => right.score - left.score || right.post.id.localeCompare(left.post.id))
+
+	let start = 0
+	if (options.cursor) {
+		const cursor = String(options.cursor)
+		const index = candidates.findIndex(row => forYouCursorKey({ score: row.score, postId: row.post.id }) === cursor)
+		start = index >= 0 ? index + 1 : 0
+	}
+
+	const slice = candidates.slice(start, start + limit + 1)
+	const hasMore = slice.length > limit
+	const page = hasMore ? slice.slice(0, limit) : slice
+	const items = []
+	for (const row of page) {
+		const item = await buildPostFeedItem(username, row.entityHash, row.post, itemContext)
+		item.score = row.score
+		items.push(item)
+	}
+	const nextCursor = hasMore && items.length
+		? forYouCursorKey(items[items.length - 1])
+		: null
+	return { items, nextCursor }
+}

--- a/src/public/parts/shells/social/src/feedMerge.mjs
+++ b/src/public/parts/shells/social/src/feedMerge.mjs
@@ -1,0 +1,140 @@
+/**
+ * Feed 条目按 HLC 降序比较（与 buildHomeFeed 历史排序一致）。
+ * @param {object} left 左侧 feed 条目
+ * @param {object} right 右侧 feed 条目
+ * @returns {number} 正数表示 left 更新
+ */
+export function compareFeedItems(left, right) {
+	const leftWall = Number(left.hlc?.wall || 0) - Number(left.repPenalty || 0)
+	const rightWall = Number(right.hlc?.wall || 0) - Number(right.repPenalty || 0)
+	if (leftWall !== rightWall) return leftWall - rightWall
+	return String(left.postId).localeCompare(String(right.postId))
+}
+
+/**
+ * @param {{ candidates: object[], index: number }} stream 单源流
+ * @returns {object | null} 当前队首
+ */
+function streamHead(stream) {
+	if (stream.index >= stream.candidates.length) return null
+	return stream.candidates[stream.index]
+}
+
+/**
+ * @param {{ candidates: object[], index: number }[]} streams 每源已按 compareFeedItems 降序
+ * @param {number} streamIndex 流下标
+ * @returns {boolean} 该流是否仍有队首
+ */
+function streamHasHead(streams, streamIndex) {
+	return streamIndex >= 0 && streamHead(streams[streamIndex]) != null
+}
+
+/**
+ * @param {{ candidates: object[], index: number }[]} streams 源流
+ * @param {number} leftIndex 左流下标
+ * @param {number} rightIndex 右流下标
+ * @returns {boolean} left 队首是否新于 right
+ */
+function streamHeadBeats(streams, leftIndex, rightIndex) {
+	return compareFeedItems(streamHead(streams[leftIndex]), streamHead(streams[rightIndex])) > 0
+}
+
+/**
+ * 多路归并已排序 feed 流用的最大堆（存流下标，按队首 compareFeedItems 降序）。
+ */
+class FeedStreamMaxHeap {
+	/**
+	 * @param {{ candidates: object[], index: number }[]} streams 每源已按 compareFeedItems 降序
+	 */
+	constructor(streams) {
+		this.streams = streams
+		/** @type {number[]} */
+		this.heap = []
+		for (let index = 0; index < streams.length; index++)
+			if (streamHasHead(streams, index)) this.heap.push(index)
+		for (let index = (this.heap.length >> 1) - 1; index >= 0; index--) this.#siftDown(index)
+	}
+
+	/**
+	 * @returns {number} 当前最优流索引，无则 -1
+	 */
+	popMax() {
+		if (!this.heap.length) return -1
+		const best = this.heap[0]
+		const last = this.heap.pop()
+		if (this.heap.length) {
+			this.heap[0] = last
+			this.#siftDown(0)
+		}
+		return best
+	}
+
+	/**
+	 * 某流前进一位后若仍有队首则重新入堆。
+	 * @param {number} streamIndex 流索引
+	 * @returns {void}
+	 */
+	offerStream(streamIndex) {
+		if (!streamHasHead(this.streams, streamIndex)) return
+		this.heap.push(streamIndex)
+		this.#siftUp(this.heap.length - 1)
+	}
+
+	/** @param {number} heapIndex 堆下标 */
+	#siftUp(heapIndex) {
+		const streams = this.streams
+		let index = heapIndex
+		while (index > 0) {
+			const parent = (index - 1) >> 1
+			if (!streamHeadBeats(streams, this.heap[index], this.heap[parent])) break
+			;[this.heap[index], this.heap[parent]] = [this.heap[parent], this.heap[index]]
+			index = parent
+		}
+	}
+
+	/** @param {number} heapIndex 堆下标 */
+	#siftDown(heapIndex) {
+		const streams = this.streams
+		const heapLength = this.heap.length
+		let index = heapIndex
+		while (true) {
+			const left = index * 2 + 1
+			const right = left + 1
+			let largest = index
+			if (left < heapLength && streamHeadBeats(streams, this.heap[left], this.heap[largest])) largest = left
+			if (right < heapLength && streamHeadBeats(streams, this.heap[right], this.heap[largest])) largest = right
+			if (largest === index) break
+			;[this.heap[index], this.heap[largest]] = [this.heap[largest], this.heap[index]]
+			index = largest
+		}
+	}
+}
+
+/**
+ * @param {{ candidates: object[], index: number }[]} streams 每源已按 compareFeedItems 降序
+ * @returns {number} 下一候选所在流索引，无则 -1
+ */
+export function pickNextFeedStreamIndex(streams) {
+	const heap = new FeedStreamMaxHeap(streams)
+	return heap.popMax()
+}
+
+/**
+ * 多路归并已排序的 feed 候选流，取前 maxCount 条（不含游标偏移）。
+ * @param {{ candidates: object[], index: number }[]} streams 每源已按 compareFeedItems 降序
+ * @param {number} maxCount 最多条数
+ * @returns {object[]} 合并后最多 maxCount 条 feed 条目
+ */
+export function kWayMergeFeedStreams(streams, maxCount) {
+	const heap = new FeedStreamMaxHeap(streams)
+	/** @type {object[]} */
+	const merged = []
+	while (merged.length < maxCount) {
+		const best = heap.popMax()
+		if (best < 0) break
+		merged.push(streams[best].candidates[streams[best].index])
+		streams[best].index++
+		heap.offerStream(best)
+	}
+	return merged
+}

--- a/src/public/parts/shells/social/src/feedVisibility.mjs
+++ b/src/public/parts/shells/social/src/feedVisibility.mjs
@@ -1,0 +1,30 @@
+import { isAuthorFilteredByPersonalSets } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { postMatchesMutedKeywords } from './lib/contentFilter.mjs'
+import { canViewByVisibility } from './lib/visibilitySpec.mjs'
+
+/**
+ * 根据可见性与个人拉黑/隐藏/关注关系判断帖子是否对观看者可见。
+ * @param {object} post 帖子
+ * @param {object} viewerContext loadViewerContext 结果
+ * @returns {boolean} 是否可见
+ */
+export function canViewPost(post, viewerContext) {
+	const authorEntity = String(post.entityHash || '').toLowerCase()
+	if (isAuthorFilteredByPersonalSets(viewerContext.personalFilter, authorEntity))
+		return false
+	if (postMatchesMutedKeywords(post, viewerContext.mutedKeywords))
+		return false
+	return canViewByVisibility(post.content, viewerContext, authorEntity)
+}
+
+/**
+ * 相册可见性（与帖同核心，无关键词过滤）。
+ * @param {object} album 相册物化行（含 visibility 字段）
+ * @param {string} ownerEntityHash owner
+ * @param {object} viewerContext 观看者上下文
+ * @returns {boolean} 是否可见
+ */
+export function canViewAlbum(album, ownerEntityHash, viewerContext) {
+	return canViewByVisibility(album, viewerContext, ownerEntityHash)
+}

--- a/src/public/parts/shells/social/src/following.mjs
+++ b/src/public/parts/shells/social/src/following.mjs
@@ -1,0 +1,73 @@
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../chat/src/entity/identity.mjs'
+
+import { applyFollowNetworkHints } from './federation/network_hints.mjs'
+import { commitTimelineEvent } from './timeline/append.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * 从实体时间线物化视图读取关注列表。
+ * @param {string} username 用户
+ * @param {string} entityHash 观看/写操作实体
+ * @returns {Promise<{ following: string[] }>} 关注列表
+ */
+export async function loadFollowingForActor(username, entityHash) {
+	const actor = String(entityHash || '').trim().toLowerCase()
+	if (!actor) return { following: [] }
+	const view = await getTimelineMaterialized(username, actor)
+	const following = new Set(view.following.map(id => id.toLowerCase()))
+	following.add(actor)
+	return { following: [...following] }
+}
+
+/**
+ * 从操作者时间线物化视图读取关注列表（默认 operator）。
+ * @param {string} username 用户
+ * @returns {Promise<{ following: string[] }>} 关注列表
+ */
+export async function loadFollowing(username) {
+	const operator = await resolveOperatorEntityHash(username)
+	if (!operator) return { following: [] }
+	return loadFollowingForActor(username, operator)
+}
+
+/**
+ * 关注或取关：追加 follow/unfollow 事件、联邦 fanout、网络 hint。
+ * @param {string} username 用户
+ * @param {string} entityHash 发起方实体（operator 或本地 agent）
+ * @param {string} targetEntityHash 目标
+ * @param {boolean} follow true=关注 false=取关
+ * @returns {Promise<string[]>} 规范化后的关注列表
+ */
+export async function setFollow(username, entityHash, targetEntityHash, follow) {
+	const self = String(entityHash || '').trim().toLowerCase()
+	if (!self) throw new Error('configure federation identity before following')
+	const id = String(targetEntityHash).toLowerCase()
+	const { following } = await loadFollowingForActor(username, self)
+	const already = following.includes(id)
+	if (follow === already) return following
+
+	await commitTimelineEvent(username, self, {
+		type: follow ? 'follow' : 'unfollow',
+		content: {
+			targetEntityHash: id,
+		},
+	})
+	applyFollowNetworkHints(username, id, follow)
+	if (follow) return [...following, id]
+	return following.filter(hash => hash !== id)
+}
+
+/**
+ * 列出观看者已知的时间线 owner（关注 + 自身；自身由隐式自关注保证）。
+ * @param {string} username 用户
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<string[]>} 已知时间线 owner
+ */
+export async function listFollowedTimelineOwners(username, viewerEntityHash) {
+	const viewer = viewerEntityHash
+		? String(viewerEntityHash).trim().toLowerCase()
+		: await resolveOperatorEntityHash(username)
+	if (!viewer) return []
+	const { following } = await loadFollowingForActor(username, viewer)
+	return following
+}

--- a/src/public/parts/shells/social/src/inbox.mjs
+++ b/src/public/parts/shells/social/src/inbox.mjs
@@ -1,0 +1,468 @@
+/**
+ * 【文件】inbox.mjs — 通知持久 inbox（append-only JSONL + 服务端已读水位 + 读取层聚合）。
+ */
+import { extractMentionEntityHashes } from 'fount/public/parts/shells/chat/public/shared/mentions.mjs'
+import { createJsonlInboxStore } from 'fount/public/parts/shells/chat/src/chat/lib/jsonlInboxStore.mjs'
+import { isMutedBy } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { getUserDictionary } from '../../../../../server/auth/index.mjs'
+
+import { postMatchesMutedKeywords } from './lib/contentFilter.mjs'
+import { loadMutedKeywords } from './mutedKeywords.mjs'
+import { canWriteTimeline } from './timeline/append.mjs'
+import { pushFeedUpdate } from './ws/feedHub.mjs'
+
+/** @type {Set<string>} */
+export const VALID_NOTIFICATION_TYPES = new Set(['reply', 'mention', 'like', 'repost', 'follow', 'care_post', 'poll_closed', 'post_note', 'live_started'])
+
+/**
+ *
+ */
+export const FOLLOW_AGGREGATE_WINDOW_MS = 86_400_000
+/**
+ *
+ */
+export const SNIPPET_MAX_LEN = 120
+/**
+ *
+ */
+export const MAX_DISPLAY_ACTORS = 3
+
+/**
+ * @param {string | undefined | null} typesParam 逗号分隔类型
+ * @returns {string[] | null} 合法类型列表；无参数时为 null（不过滤）
+ */
+export function parseNotificationTypesFilter(typesParam) {
+	if (!typesParam) return null
+	const types = String(typesParam).split(',')
+		.map(type => type.trim().toLowerCase())
+		.filter(type => VALID_NOTIFICATION_TYPES.has(type))
+	return types.length ? types : null
+}
+
+/**
+ * @param {string | null | undefined} text 原文
+ * @param {number} [maxLen=120] 最大长度
+ * @returns {string | null} 摘要
+ */
+export function notificationSnippet(text, maxLen = SNIPPET_MAX_LEN) {
+	if (!text) return null
+	const plain = String(text)
+		.replace(/```[\s\S]*?```/g, ' ')
+		.replace(/`[^`]*`/g, ' ')
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+		.replace(/[#>*_\-\n\r]+/g, ' ')
+		.replace(/\s+/g, ' ')
+		.trim()
+	if (!plain) return null
+	return plain.length <= maxLen ? plain : `${plain.slice(0, maxLen - 1)}…`
+}
+
+/**
+ * @param {object} row 原始通知行
+ * @returns {string} 原始去重键
+ */
+export function rawNotificationCursor(row) {
+	return `${row.at}:${row.actorEntityHash}:${row.type}:${row.postId ?? ''}:${row.targetPostId ?? ''}`
+}
+
+/**
+ * @param {object} row 通知条目（原始或聚合）
+ * @returns {string} 分页游标
+ */
+export function notificationCursor(row) {
+	if (row.aggregateKey)
+		return `${row.at}:${row.aggregateKey}`
+	return rawNotificationCursor(row)
+}
+
+/**
+ * @param {object} row 通知行
+ * @param {string} viewerEntityHash 收件人
+ * @returns {string} 聚合键
+ */
+export function computeAggregateKey(row, viewerEntityHash) {
+	const type = row.type
+	if (type === 'like' || type === 'repost') {
+		const target = (row.targetEntityHash || viewerEntityHash || '').toLowerCase()
+		return `${type}:${target}:${row.targetPostId ?? ''}`
+	}
+	if (type === 'follow') {
+		const bucket = Math.floor(Number(row.at) / FOLLOW_AGGREGATE_WINDOW_MS)
+		return `follow:${bucket}`
+	}
+	return `${type}:${row.actorEntityHash}:${row.postId ?? ''}:${row.targetPostId ?? ''}`
+}
+
+/**
+ * @param {object[]} rows 原始通知行（已去重）
+ * @param {string} viewerEntityHash 收件人
+ * @returns {object[]} 聚合后的展示通知
+ */
+export function aggregateNotificationRows(rows, viewerEntityHash) {
+	/** @type {Map<string, object>} */
+	const groups = new Map()
+	for (const row of rows) {
+		const key = row.aggregateKey || computeAggregateKey(row, viewerEntityHash)
+		const at = Number(row.at) || 0
+		let group = groups.get(key)
+		if (!group) {
+			/** @type {Map<string, { entityHash: string, at: number }>} */
+			const actorMap = new Map([[row.actorEntityHash, { entityHash: row.actorEntityHash, at }]])
+			group = {
+				type: row.type,
+				actorEntityHash: row.actorEntityHash,
+				latestActorEntityHash: row.actorEntityHash,
+				postId: row.postId ?? null,
+				targetPostId: row.targetPostId ?? null,
+				targetEntityHash: row.targetEntityHash ?? null,
+				snippet: row.snippet ?? null,
+				at,
+				actorMap,
+				actorCount: 1,
+				aggregateKey: key,
+			}
+			groups.set(key, group)
+			continue
+		}
+		group.at = Math.max(group.at, at)
+		if (!group.snippet && row.snippet) group.snippet = row.snippet
+		if (!group.targetEntityHash && row.targetEntityHash) group.targetEntityHash = row.targetEntityHash
+		const prev = group.actorMap.get(row.actorEntityHash)
+		if (!prev || at > prev.at) group.actorMap.set(row.actorEntityHash, { entityHash: row.actorEntityHash, at })
+		group.actorCount = group.actorMap.size
+		const sortedActors = [...group.actorMap.values()].sort((left, right) => right.at - left.at)
+		const latest = sortedActors[0]
+		if (latest) {
+			group.actorEntityHash = latest.entityHash
+			group.latestActorEntityHash = latest.entityHash
+		}
+	}
+	return [...groups.values()]
+		.map(group => {
+			const sortedActors = [...group.actorMap.values()].sort((left, right) => right.at - left.at)
+			const { actorMap, ...rest } = group
+			return {
+				...rest,
+				actors: sortedActors.slice(0, MAX_DISPLAY_ACTORS),
+			}
+		})
+		.sort((left, right) => right.at - left.at)
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人 entityHash
+ * @returns {string} inbox 目录
+ */
+export function inboxDir(username, entityHash) {
+	return `${getUserDictionary(username)}/shells/social/inbox/${entityHash.toLowerCase()}`
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人 entityHash
+ * @returns {string} inbox events.jsonl
+ */
+export function inboxEventsPath(username, entityHash) {
+	return `${inboxDir(username, entityHash)}/events.jsonl`
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人 entityHash
+ * @returns {string} read.json
+ */
+export function inboxReadPath(username, entityHash) {
+	return `${inboxDir(username, entityHash)}/read.json`
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人
+ * @returns {ReturnType<typeof createJsonlInboxStore>} store
+ */
+function socialInboxStore(username, entityHash) {
+	return createJsonlInboxStore(inboxDir(username, entityHash))
+}
+
+/**
+ * @param {string} type 通知类型
+ * @param {string} actorEntityHash 动作来源 timeline owner
+ * @param {number} at 时间戳
+ * @param {string | null | undefined} postId 相关帖 id
+ * @param {string | null | undefined} targetPostId 目标帖 id
+ * @param {string | null | undefined} [targetEntityHash] 目标帖 owner
+ * @param {string | null | undefined} [snippet] 摘要
+ * @returns {object} 规范化通知条目
+ */
+export function normalizeNotificationRow(type, actorEntityHash, at, postId, targetPostId, targetEntityHash = null, snippet = null) {
+	return {
+		type,
+		actorEntityHash: actorEntityHash.toLowerCase(),
+		postId: postId ?? null,
+		targetPostId: targetPostId ?? null,
+		targetEntityHash: targetEntityHash?.toLowerCase() ?? null,
+		snippet: snippet ?? null,
+		at,
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} timelineOwner 事件 timeline owner
+ * @param {object} event 签名事件
+ * @param {object} row 推导出的通知行
+ * @returns {Promise<string | null>} 摘要
+ */
+async function resolveNotificationSnippet(username, timelineOwner, event, row) {
+	if (event.type === 'post')
+		return notificationSnippet(event.content?.text || '')
+	if (event.type === 'like' || event.type === 'repost') {
+		const targetOwner = (event.content?.targetEntityHash || '').toLowerCase()
+		const targetPostId = event.content?.targetPostId
+		if (!targetOwner || !targetPostId) return null
+		const { getTimelineMaterialized } = await import('./timeline/materialize.mjs')
+		const view = await getTimelineMaterialized(username, targetOwner)
+		const post = view.posts.find(entry => entry.id === targetPostId)
+		return notificationSnippet(post?.content?.text || '')
+	}
+	if (row.type === 'reply' && row.targetPostId && row.targetEntityHash) {
+		const { getTimelineMaterialized } = await import('./timeline/materialize.mjs')
+		const view = await getTimelineMaterialized(username, row.targetEntityHash)
+		const post = view.posts.find(entry => entry.id === row.targetPostId)
+		return notificationSnippet(post?.content?.text || '')
+	}
+	return null
+}
+
+/**
+ * 从 timeline 事件推导应写入 inbox 的收件人通知。
+ * @param {string} timelineOwner 事件所在 timeline owner
+ * @param {object} event 签名 timeline 事件
+ * @returns {Array<{ recipient: string } & object>} 收件人 + 通知体
+ */
+export function deriveInboxNotifications(timelineOwner, event) {
+	const owner = timelineOwner.toLowerCase()
+	const at = Number(event.hlc?.wall) || Number(event.timestamp) || Date.now()
+	/** @type {Array<{ recipient: string, type: string, actorEntityHash: string, postId: string | null, targetPostId: string | null, targetEntityHash: string | null, snippet: string | null, at: number }>} */
+	const rows = []
+
+	if (event.type === 'post') {
+		const replyTo = event.content?.replyTo
+		if (replyTo?.entityHash?.toLowerCase()) {
+			const recipient = replyTo.entityHash.toLowerCase()
+			rows.push({
+				recipient,
+				...normalizeNotificationRow('reply', owner, at, event.id, replyTo.postId, recipient),
+			})
+		}
+		for (const mention of extractMentionEntityHashes(event.content?.text || '')) {
+			if (mention === owner) continue
+			rows.push({ recipient: mention, ...normalizeNotificationRow('mention', owner, at, event.id, null) })
+		}
+	}
+	if (event.type === 'like') {
+		const target = (event.content?.targetEntityHash || '').toLowerCase()
+		if (target)
+			rows.push({
+				recipient: target,
+				...normalizeNotificationRow('like', owner, at, null, event.content?.targetPostId ?? null, target),
+			})
+	}
+	if (event.type === 'repost') {
+		const target = (event.content?.targetEntityHash || '').toLowerCase()
+		if (target)
+			rows.push({
+				recipient: target,
+				...normalizeNotificationRow('repost', owner, at, null, event.content?.targetPostId ?? null, target),
+			})
+	}
+	if (event.type === 'follow') {
+		const target = (event.content?.targetEntityHash || '').toLowerCase()
+		if (target && target !== owner)
+			rows.push({ recipient: target, ...normalizeNotificationRow('follow', owner, at, null, null) })
+	}
+	if (event.type === 'post_note') {
+		const target = (event.content?.targetEntityHash || '').toLowerCase()
+		if (target && target !== owner)
+			rows.push({
+				recipient: target,
+				...normalizeNotificationRow('post_note', owner, at, null, event.content?.targetPostId ?? null, target),
+				snippet: notificationSnippet(event.content?.text || ''),
+			})
+	}
+	return rows
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人
+ * @returns {number} 已读水位毫秒
+ */
+export function getNotificationsSeenAt(username, entityHash) {
+	return socialInboxStore(username, entityHash).getSeenAt()
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 收件人
+ * @param {number} at 已读水位
+ * @returns {void}
+ */
+export function setNotificationsSeenAt(username, entityHash, at) {
+	socialInboxStore(username, entityHash).setSeenAt(at)
+}
+
+/**
+ * operator 特别关心作者的新帖：写 care_post inbox 行并触达。
+ * @param {string} username replica
+ * @param {string} recipientEntityHash 收件人（operator）
+ * @param {string} authorEntityHash 发帖作者
+ * @param {object} post 签名 post
+ * @param {string | null} [snippet] 摘要
+ * @returns {Promise<void>}
+ */
+export async function appendCarePostInboxRow(username, recipientEntityHash, authorEntityHash, post, snippet = null) {
+	const recipient = String(recipientEntityHash || '').trim().toLowerCase()
+	const author = String(authorEntityHash || '').trim().toLowerCase()
+	if (!recipient || !author || recipient === author) return
+	if (!await canWriteTimeline(username, recipient)) return
+	const at = Number(post.hlc?.wall) || Number(post.timestamp) || Date.now()
+	const textSnippet = snippet ?? notificationSnippet(post.content?.text || '')
+	const notification = {
+		...normalizeNotificationRow('care_post', author, at, post.id, null),
+		snippet: textSnippet,
+		aggregateKey: computeAggregateKey({
+			type: 'care_post',
+			actorEntityHash: author,
+			postId: post.id,
+			targetPostId: null,
+			at,
+		}, recipient),
+	}
+	await socialInboxStore(username, recipient).append(notification)
+	pushFeedUpdate(username, { type: 'notification', notification })
+	const { notifyUser } = await import('fount/server/web_server/notify/notify.mjs')
+	void notifyUser(username, {
+		title: 'care_post',
+		body: String(textSnippet || 'care_post'),
+		url: '/parts/shells:social/',
+		tag: `social:care_post:${recipient}`,
+	})
+}
+
+/**
+ * poll 截止后写 poll_closed inbox 行。
+ * @param {string} username replica
+ * @param {string} recipientEntityHash 收件人
+ * @param {string} authorEntityHash 帖作者
+ * @param {string} postId 帖 id
+ * @param {object} poll poll 配置
+ * @param {Record<string, number>} tally 选项计数
+ * @returns {Promise<void>}
+ */
+export async function appendPollClosedInboxRow(username, recipientEntityHash, authorEntityHash, postId, poll, tally) {
+	const recipient = String(recipientEntityHash || '').trim().toLowerCase()
+	const author = String(authorEntityHash || '').trim().toLowerCase()
+	if (!recipient || !author || !postId) return
+	if (!await canWriteTimeline(username, recipient)) return
+	const at = Date.now()
+	const preview = String(poll?.options?.[0] || 'poll closed').slice(0, SNIPPET_MAX_LEN)
+	const notification = {
+		...normalizeNotificationRow('poll_closed', author, at, postId, null),
+		snippet: preview,
+		tally,
+		aggregateKey: computeAggregateKey({
+			type: 'poll_closed',
+			actorEntityHash: author,
+			postId,
+			targetPostId: null,
+			at,
+		}, recipient),
+	}
+	await socialInboxStore(username, recipient).append(notification)
+	pushFeedUpdate(username, { type: 'notification', notification })
+}
+
+/**
+ * timeline 事件落盘后增量写 inbox（仅本机可写 entity）。
+ * @param {string} username replica
+ * @param {string} timelineOwner 事件 timeline owner
+ * @param {object} event 签名事件
+ * @returns {Promise<void>}
+ */
+export async function appendInboxFromTimelineEvent(username, timelineOwner, event) {
+	for (const row of deriveInboxNotifications(timelineOwner, event)) {
+		if (row.actorEntityHash === row.recipient) continue
+		if (!await canWriteTimeline(username, row.recipient)) continue
+		if (await isMutedBy(row.recipient, { entityHash: row.actorEntityHash })) continue
+		if (row.type === 'reply' && event.content?.replyTo?.entityHash) {
+			const { canReplyUnderPolicy, loadPostReplyGate } = await import('./lib/replyPolicy.mjs')
+			const gate = await loadPostReplyGate(
+				username,
+				String(event.content.replyTo.entityHash),
+				String(event.content.replyTo.postId || ''),
+			)
+			const allowed = await canReplyUnderPolicy({
+				username,
+				authorEntityHash: String(event.content.replyTo.entityHash),
+				replierEntityHash: timelineOwner,
+				replyPolicy: gate?.replyPolicy || 'everyone',
+				at: Number(event.hlc?.wall) || Number(event.timestamp) || Date.now(),
+			})
+			if (!allowed) continue
+		}
+		const snippet = await resolveNotificationSnippet(username, timelineOwner, event, row)
+		const mutedKeywords = await loadMutedKeywords(username, row.recipient)
+		const filterPost = {
+			content: {
+				text: `${event?.content?.text || ''}\n${snippet || ''}`,
+				contentWarning: event?.content?.contentWarning,
+				tags: event?.content?.tags,
+			},
+		}
+		if (postMatchesMutedKeywords(filterPost, mutedKeywords)) continue
+		const { recipient, ...baseRow } = row
+		const notification = {
+			...baseRow,
+			snippet,
+			aggregateKey: computeAggregateKey({ ...row, snippet }, recipient),
+		}
+		await socialInboxStore(username, recipient).append(notification)
+		pushFeedUpdate(username, { type: 'notification', notification })
+		const { notifyUser } = await import('fount/server/web_server/notify/notify.mjs')
+		void notifyUser(username, {
+			title: row.type,
+			body: String(snippet || row.type || ''),
+			url: '/parts/shells:social/',
+			tag: `social:${row.type}:${recipient}`,
+		})
+	}
+}
+
+/**
+ * 从 inbox JSONL 读通知页（聚合后分页）。
+ * @param {string} username 用户
+ * @param {string} viewerEntityHash 观看者 entityHash
+ * @param {{ limit?: number, cursor?: string | null, types?: string[] | null }} [options] 分页与过滤
+ * @returns {Promise<{ notifications: object[], nextCursor: string | null, unreadCount: number }>} 通知页与未读数
+ */
+export async function readInboxNotifications(username, viewerEntityHash, options = {}) {
+	const types = options.types ?? null
+	const page = await socialInboxStore(username, viewerEntityHash).listPage({
+		limit: options.limit,
+		cursor: options.cursor,
+		rowCursor: rawNotificationCursor,
+		pageCursor: notificationCursor,
+		sortByAtDesc: false,
+		filter: types?.length ? row => types.includes(row.type) : undefined,
+		/**
+		 * @param {object[]} rows 去重后的原始行
+		 * @returns {object[]} 聚合后的通知
+		 */
+		transform: rows => aggregateNotificationRows(rows, viewerEntityHash),
+	})
+	return { notifications: page.items, nextCursor: page.nextCursor, unreadCount: page.unreadCount }
+}

--- a/src/public/parts/shells/social/src/lib/albumRefs.mjs
+++ b/src/public/parts/shells/social/src/lib/albumRefs.mjs
@@ -1,0 +1,22 @@
+import { canViewAlbum } from '../feedVisibility.mjs'
+
+/**
+ * 从物化视图提取观看者可见的所属相册摘要。
+ * @param {object} view 物化视图
+ * @param {string} owner owner
+ * @param {string} postId 帖
+ * @param {object} viewerContext 观看者
+ * @returns {{ albumId: string, name: string }[]} 可见相册
+ */
+export function albumsForPostFromView(view, owner, postId, viewerContext) {
+	const ids = view.albumsByPost?.[postId] || []
+	/** @type {{ albumId: string, name: string }[]} */
+	const out = []
+	for (const albumId of ids) {
+		const album = view.albums?.[albumId]
+		if (!album || album.virtual) continue
+		if (!canViewAlbum(album, owner, viewerContext)) continue
+		out.push({ albumId: album.albumId, name: album.name })
+	}
+	return out
+}

--- a/src/public/parts/shells/social/src/lib/authorProfileSummary.mjs
+++ b/src/public/parts/shells/social/src/lib/authorProfileSummary.mjs
@@ -1,0 +1,33 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { memoizePromise } from '../../../../../../scripts/memo.mjs'
+import { customProfileAvatar } from '../../../chat/public/shared/hashAvatar.mjs'
+import { getProfile } from '../../../chat/src/entity/profile.mjs'
+
+
+/**
+ * 单次 feed/search 构建内的作者资料摘要加载（请求级 memo，不跨请求共享）。
+ * @param {string} username 查看者
+ * @returns {(entityHash: string) => Promise<object | null>} 按 entityHash 去重加载的资料摘要
+ */
+export function createAuthorProfileLoader(username) {
+	return memoizePromise(
+		entityHash => entityHash,
+		async entityHash => {
+			if (!isEntityHash128(entityHash)) return null
+			// getProfile 对远端作者返回派生默认资料；不可用 ensureLocalEntityProfile（远端会抛错使整个 feed 失败）。
+			const profile = await getProfile(entityHash, username)
+			if (!profile) return null
+			return {
+				name: profile.name,
+				handle: profile.handle || '',
+				avatar: customProfileAvatar(profile) || null,
+				infoDefaults: profile.infoDefaults
+					? { avatar: profile.infoDefaults.avatar || '' }
+					: null,
+				ownerEntityHash: profile.ownerEntityHash || null,
+			}
+		},
+		{ max: 256 },
+	)
+}

--- a/src/public/parts/shells/social/src/lib/bootstrap.mjs
+++ b/src/public/parts/shells/social/src/lib/bootstrap.mjs
@@ -1,0 +1,31 @@
+/**
+ * Social 引导：账号即 Chat 联邦 P2P 实体，首次访问时自动准备 timeline。
+ */
+import { isWritableLocalEntity } from 'npm:@steve02081504/fount-p2p/node/identity'
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../../chat/src/entity/identity.mjs'
+import { ensureSocialMeta } from '../timeline/append.mjs'
+
+
+/**
+ * 确保 entity 的 social_meta 创世事件就绪。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 128 hex
+ * @returns {Promise<void>}
+ */
+export async function ensureEntitySocialReady(username, entityHash) {
+	if (!isWritableLocalEntity(entityHash)) return
+	await ensureSocialMeta(username, entityHash)
+}
+
+/**
+ * 确保当前操作者（Chat 联邦 identity）的 social 时间线可用。
+ * @param {string} username replica 登录名
+ * @returns {Promise<string | null>} operator entityHash
+ */
+export async function ensureOperatorSocialReady(username) {
+	const entityHash = await resolveOperatorEntityHash(username)
+	if (!entityHash) return null
+	await ensureEntitySocialReady(username, entityHash)
+	return entityHash
+}

--- a/src/public/parts/shells/social/src/lib/charSocial.mjs
+++ b/src/public/parts/shells/social/src/lib/charSocial.mjs
@@ -1,0 +1,16 @@
+/**
+ * 加载具备 interfaces.social 的角色 part（OnFollow 等须显式 social 接口）。
+ */
+import { loadPart } from '../../../../../../server/parts_loader.mjs'
+
+/**
+ * @param {string} username replica 登录名
+ * @param {string} charPartName chars/ 目录名
+ * @returns {Promise<object>} 已定义 social 接口的 char part
+ */
+export async function ensureCharSocialInterface(username, charPartName) {
+	const char = await loadPart(username, `chars/${charPartName}`)
+	if (!char?.interfaces?.social)
+		throw new Error(`char ${charPartName} missing interfaces.social`)
+	return char
+}

--- a/src/public/parts/shells/social/src/lib/contentFilter.mjs
+++ b/src/public/parts/shells/social/src/lib/contentFilter.mjs
@@ -1,0 +1,76 @@
+import { extractHashtagsFromText } from './hashtags.mjs'
+
+const MAX_ENTRIES = 200
+const MAX_PATTERN_LEN = 64
+
+/**
+ * @param {unknown} raw 原始条目
+ * @returns {object | null} 规范化条目
+ */
+export function normalizeMutedKeywordEntry(raw) {
+	if (!raw || typeof raw !== 'object') return null
+	const pattern = String(/** @type {{ pattern?: unknown }} */raw.pattern || '').trim().toLowerCase()
+	if (!pattern || pattern.length > MAX_PATTERN_LEN) return null
+	const matchTags = /** @type {{ matchTags?: unknown }} */raw.matchTags !== false
+	const expiresRaw = /** @type {{ expiresAt?: unknown }} */raw.expiresAt
+	const expiresAt = expiresRaw == null || expiresRaw === ''
+		? undefined
+		: Number(expiresRaw)
+	if (expiresAt != null && (!Number.isFinite(expiresAt) || expiresAt <= 0)) return null
+	return {
+		pattern,
+		matchTags,
+		...expiresAt != null ? { expiresAt } : {},
+	}
+}
+
+/**
+ * @param {object[]} entries 条目列表
+ * @returns {object[]} 去重且惰性清理过期后的列表
+ */
+export function pruneMutedKeywordEntries(entries) {
+	const now = Date.now()
+	const seen = new Set()
+	const out = []
+	for (const raw of entries || []) {
+		const entry = normalizeMutedKeywordEntry(raw)
+		if (!entry) continue
+		if (entry.expiresAt != null && entry.expiresAt <= now) continue
+		if (seen.has(entry.pattern)) continue
+		seen.add(entry.pattern)
+		out.push(entry)
+		if (out.length >= MAX_ENTRIES) break
+	}
+	return out
+}
+
+/**
+ * 帖子是否命中观看者的关键词/标签屏蔽表。
+ * @param {object} post 帖子（含 content.text / tags / contentWarning）
+ * @param {{ entries?: object[] } | null | undefined} mutedKeywords loadMutedKeywords 结果
+ * @returns {boolean} 命中则应隐藏
+ */
+export function postMatchesMutedKeywords(post, mutedKeywords) {
+	const entries = mutedKeywords?.entries
+	if (!entries?.length) return false
+	const text = String(post?.content?.text || '').toLowerCase()
+	const warning = String(post?.content?.contentWarning || '').toLowerCase()
+	const haystack = `${text}\n${warning}`
+	const tagSet = new Set([
+		...extractHashtagsFromText(post?.content?.text || ''),
+		...(Array.isArray(post?.content?.tags) ? post.content.tags : []).map(tag => String(tag).trim().toLowerCase()).filter(Boolean),
+	])
+	const now = Date.now()
+	for (const entry of entries) {
+		const expiresAt = entry.expiresAt
+		if (expiresAt != null && Number(expiresAt) > 0 && Number(expiresAt) <= now) continue
+		const pattern = String(entry.pattern || '').trim().toLowerCase()
+		if (!pattern) continue
+		if (haystack.includes(pattern)) return true
+		if (entry.matchTags !== false) {
+			const bare = pattern.startsWith('#') ? pattern.slice(1) : pattern
+			if (bare && tagSet.has(bare)) return true
+		}
+	}
+	return false
+}

--- a/src/public/parts/shells/social/src/lib/dwellSignal.mjs
+++ b/src/public/parts/shells/social/src/lib/dwellSignal.mjs
@@ -1,0 +1,46 @@
+/**
+ *
+ */
+export const DWELL_MIN_MS = 3000
+/**
+ *
+ */
+export const DWELL_MAX_MS = 120_000
+/**
+ *
+ */
+export const AUTHOR_BOOST_PER_DWELL = 0.25
+/**
+ *
+ */
+export const TAG_WEIGHT_PER_DWELL = 0.15
+
+/**
+ * @param {unknown} raw 原始条目
+ * @returns {{ author: string, postId: string, tags: string[], dwellMs: number, at: number } | null} 规范化
+ */
+export function normalizeDwellEntry(raw) {
+	if (!raw || typeof raw !== 'object') return null
+	const author = String(/** @type {{ author?: unknown }} */raw.author || '').trim().toLowerCase()
+	const postId = String(/** @type {{ postId?: unknown }} */raw.postId || '').trim().toLowerCase()
+	if (!author || !postId) return null
+	const dwellMsRaw = Number(/** @type {{ dwellMs?: unknown }} */raw.dwellMs) || 0
+	const watchMs = Number(/** @type {{ watchMs?: unknown }} */raw.watchMs) || 0
+	const dwellMs = Math.min(DWELL_MAX_MS, Math.max(0, Math.max(dwellMsRaw, watchMs)))
+	if (dwellMs < DWELL_MIN_MS) return null
+	const tags = Array.isArray(/** @type {{ tags?: unknown }} */raw.tags)
+		? [...new Set(/** @type {unknown[]} *//** @type {{ tags?: unknown }} */raw.tags
+			.map(tag => String(tag).trim().toLowerCase())
+			.filter(Boolean))].slice(0, 16)
+		: []
+	const watchRatio = Math.min(1, Math.max(0, Number(/** @type {{ watchRatio?: unknown }} */raw.watchRatio) || 0))
+	return {
+		author,
+		postId,
+		tags,
+		dwellMs,
+		...watchMs ? { watchMs } : {},
+		...watchRatio ? { watchRatio } : {},
+		at: Number(/** @type {{ at?: unknown }} */raw.at) || Date.now(),
+	}
+}

--- a/src/public/parts/shells/social/src/lib/entityJson.mjs
+++ b/src/public/parts/shells/social/src/lib/entityJson.mjs
@@ -1,0 +1,34 @@
+/**
+ * 实体私有 JSON（drafts / savedPosts）：缺文件 → empty 工厂新对象。
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+/**
+ * @template T
+ * @param {string} filePath 绝对路径
+ * @param {() => T} empty 空结构工厂
+ * @param {(raw: unknown) => T} [normalize] 读盘规范化
+ * @returns {Promise<T>} 数据
+ */
+export async function loadEntityJson(filePath, empty, normalize) {
+	try {
+		const raw = JSON.parse(await readFile(filePath, 'utf8'))
+		return normalize ? normalize(raw) : /** @type {T} */ raw
+	}
+	catch {
+		return empty()
+	}
+}
+
+/**
+ * @template T
+ * @param {string} filePath 绝对路径
+ * @param {T} data 写入数据
+ * @returns {Promise<T>} 原样返回 data
+ */
+export async function saveEntityJson(filePath, data) {
+	await mkdir(path.dirname(filePath), { recursive: true })
+	await writeFile(filePath, JSON.stringify(data, null, '\t'), 'utf8')
+	return data
+}

--- a/src/public/parts/shells/social/src/lib/entityProfile.mjs
+++ b/src/public/parts/shells/social/src/lib/entityProfile.mjs
@@ -1,0 +1,13 @@
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { getProfile } from '../../../chat/src/entity/profile.mjs'
+
+/**
+ * @param {string} username replica 用户名
+ * @param {string} entityHash 128 位实体 hash
+ * @returns {Promise<object | null>} 实体 profile
+ */
+export async function getEntityProfile(username, entityHash) {
+	if (!isEntityHash128(entityHash)) return null
+	return getProfile(entityHash, username)
+}

--- a/src/public/parts/shells/social/src/lib/entityTarget.mjs
+++ b/src/public/parts/shells/social/src/lib/entityTarget.mjs
@@ -1,0 +1,46 @@
+import { isEntityHash128, parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getEntityStore, isNodeInitialized } from 'npm:@steve02081504/fount-p2p/node/instance'
+import { loadNetwork } from 'npm:@steve02081504/fount-p2p/node/network'
+
+import { findHostingReplicaUsername, resolveSocialEntity } from '../federation/hosting.mjs'
+
+
+/**
+ * @param {string} nodeHash 64 hex
+ * @returns {boolean} 是否在 P2P 网络表中已知
+ */
+function isKnownNetworkNode(nodeHash) {
+	const net = loadNetwork()
+	const id = normalizeHex64(nodeHash)
+	if (!isHex64(id)) return false
+	if (id === getNodeHash()) return true
+	if (net.trustedPeers.some(peer => normalizeHex64(peer) === id)) return true
+	if (net.explorePeers.some(peer => normalizeHex64(peer) === id)) return true
+	return net.hints.some(hint => normalizeHex64(hint.nodeHash) === id)
+}
+
+/**
+ * 目标 entity 是否可解析/可发现（本地 replica、已知托管节点、network hint 或已缓存 profile）。
+ * @param {string} username 调用方 replica
+ * @param {string} entityHash 128 hex
+ * @returns {Promise<boolean>} 是否可解析/可发现
+ */
+export async function isKnownSocialTarget(username, entityHash) {
+	const target = String(entityHash || '').trim().toLowerCase()
+	if (!isEntityHash128(target)) return false
+
+	const resolved = await resolveSocialEntity(target, username)
+	if (resolved?.local && resolved.kind !== 'unknown') return true
+	if (await findHostingReplicaUsername(target)) return true
+
+	if (!isNodeInitialized()) return false
+
+	const store = getEntityStore()
+	if (await store.readEntityJson(target, 'profile.json')) return true
+
+	const parsed = parseEntityHash(target)
+	if (!parsed) return false
+	return isKnownNetworkNode(parsed.nodeHash)
+}

--- a/src/public/parts/shells/social/src/lib/hashtags.mjs
+++ b/src/public/parts/shells/social/src/lib/hashtags.mjs
@@ -1,0 +1,19 @@
+/** 话题标签（不含 Chat `#[channel:…]` 等 typed hash token）。 */
+export const HASHTAG_TOKEN_RE = /#([\p{L}\p{N}_-]{2,32})/gu
+
+/**
+ * 从正文提取话题标签（不含 Chat 群链标记）。
+ * @param {string} text 正文
+ * @returns {string[]} 小写话题列表（去重）
+ */
+export function extractHashtagsFromText(text) {
+	const source = text || ''
+	/** @type {Set<string>} */
+	const tags = new Set()
+	for (const match of source.matchAll(HASHTAG_TOKEN_RE)) {
+		const index = match.index ?? 0
+		if (index > 0 && source[index - 1] === '[') continue
+		tags.add(match[1].toLowerCase())
+	}
+	return [...tags]
+}

--- a/src/public/parts/shells/social/src/lib/mediaRefs.mjs
+++ b/src/public/parts/shells/social/src/lib/mediaRefs.mjs
@@ -1,0 +1,52 @@
+import { isSafeHtmlUrl } from 'fount/public/pages/scripts/lib/sanitizeHtml.mjs'
+import { resolveSensitiveMedia as resolveSensitiveMediaShared } from 'fount/public/parts/shells/chat/public/shared/messageFields.mjs'
+
+const ALT_MAX = 1500
+const MEDIA_MAX = 16
+
+/**
+ * 与 chat `messageFields.resolveSensitiveMedia` 同实现；Social 入口再导出以免调用方改路径。
+ */
+export const resolveSensitiveMedia = resolveSensitiveMediaShared
+
+/**
+ * 去掉本地 File / objectUrl / pending（草稿持久化用；不校验 url）。
+ * @param {unknown} refs 原始 mediaRefs
+ * @returns {object[]} 可序列化 refs
+ */
+export function stripTransientMediaFields(refs) {
+	if (!Array.isArray(refs)) return []
+	return refs.map(ref => {
+		if (!ref || typeof ref !== 'object') return null
+		const { file: _f, objectUrl: _o, pending: _p, ...rest } = /** @type {object} */ ref
+		return rest
+	}).filter(Boolean)
+}
+
+/**
+ * 清理入站 / 本机写入的 mediaRefs（截断 alt、限制数量、剥危险 url scheme）。
+ * @param {unknown} raw 原始 refs
+ * @returns {object[]} 清洗后的 refs
+ */
+export function sanitizeMediaRefs(raw) {
+	if (!Array.isArray(raw)) return []
+	const out = []
+	for (const ref of stripTransientMediaFields(raw).slice(0, MEDIA_MAX)) {
+		if (!ref || typeof ref !== 'object') continue
+		const cleaned = { ...ref }
+		if (cleaned.alt != null) {
+			const alt = String(cleaned.alt).trim().slice(0, ALT_MAX)
+			if (alt) cleaned.alt = alt
+			else delete cleaned.alt
+		}
+		if (cleaned.url != null)
+			if (isSafeHtmlUrl(cleaned.url)) cleaned.url = String(cleaned.url).trim()
+			else delete cleaned.url
+
+		const isGroupEmoji = cleaned.kind === 'groupEmoji'
+			&& cleaned.groupId && cleaned.emojiId && cleaned.contentHash
+		if (!cleaned.url && !(cleaned.entityHash && cleaned.path) && !isGroupEmoji) continue
+		out.push(cleaned)
+	}
+	return out
+}

--- a/src/public/parts/shells/social/src/lib/mentionSuggest.mjs
+++ b/src/public/parts/shells/social/src/lib/mentionSuggest.mjs
@@ -1,0 +1,75 @@
+import { formatHashShort } from 'fount/public/parts/shells/chat/public/shared/entityHash.mjs'
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../../chat/src/entity/identity.mjs'
+import { listLocalAgentEntities } from '../federation/hosting.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+
+import { getEntityProfile } from './entityProfile.mjs'
+
+
+/**
+ * 返回发帖 @ 提及 autocomplete 候选列表。
+ * @param {string} username 用户
+ * @param {string} [query] 过滤关键词
+ * @param {number} [limit=20] 条数上限
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<{ suggestions: object[] }>} @ 提及候选
+ */
+export async function suggestMentions(username, query = '', limit = 20, viewerEntityHash) {
+	const normalizedQuery = query.trim().toLowerCase()
+	/** @type {object[]} */
+	const suggestions = []
+	const seen = new Set()
+
+	/**
+	 * 将 @ 提及候选加入结果集（去重与关键词过滤）。
+	 * @param {{ entityHash?: string, displayName?: string, charPartName?: string }} suggestion 候选条目
+	 * @returns {void}
+	 */
+	function pushSuggestion(suggestion) {
+		const entityHash = suggestion.entityHash.toLowerCase()
+		if (!entityHash || seen.has(entityHash)) return
+		if (normalizedQuery && !entityHash.includes(normalizedQuery)
+			&& !String(suggestion.displayName || '').toLowerCase().includes(normalizedQuery)
+			&& !String(suggestion.charPartName || '').toLowerCase().includes(normalizedQuery))
+			return
+		seen.add(entityHash)
+		suggestions.push(suggestion)
+	}
+
+	const selfEntityHash = viewerEntityHash
+		? String(viewerEntityHash).trim().toLowerCase()
+		: await resolveOperatorEntityHash(username)
+	if (selfEntityHash) {
+		const profile = await getEntityProfile(username, selfEntityHash)
+		pushSuggestion({
+			entityHash: selfEntityHash,
+			displayName: profile?.name || formatHashShort(selfEntityHash, { headLen: 8, tailLen: 0, ellipsis: false }),
+			kind: 'self',
+		})
+	}
+
+	const { following } = selfEntityHash
+		? await loadFollowingForActor(username, selfEntityHash)
+		: { following: [] }
+	for (const entityHash of following) {
+		const profile = await getEntityProfile(username, entityHash)
+		pushSuggestion({
+			entityHash,
+			displayName: profile?.name || formatHashShort(entityHash, { headLen: 8, tailLen: 0 }),
+			kind: 'following',
+		})
+	}
+
+	for (const { entityHash, charPartName } of listLocalAgentEntities(username)) {
+		const profile = await getEntityProfile(username, entityHash)
+		pushSuggestion({
+			entityHash,
+			displayName: profile?.name || charPartName,
+			charPartName,
+			kind: 'agent',
+		})
+	}
+
+	return { suggestions: suggestions.slice(0, Math.min(50, Math.max(1, limit))) }
+}

--- a/src/public/parts/shells/social/src/lib/noteScore.mjs
+++ b/src/public/parts/shells/social/src/lib/noteScore.mjs
@@ -1,0 +1,11 @@
+/**
+ * @param {object} _note note 条目
+ * @param {Record<string, boolean>} votes voter → helpful
+ * @returns {number} 净分
+ */
+export function noteHelpfulScore(_note, votes = {}) {
+	let score = 0
+	for (const helpful of Object.values(votes))
+		score += helpful ? 1 : -1
+	return score
+}

--- a/src/public/parts/shells/social/src/lib/poll.mjs
+++ b/src/public/parts/shells/social/src/lib/poll.mjs
@@ -1,0 +1,93 @@
+import { socialPostKey } from '../federation/post_key.mjs'
+import { maybeDecryptPostContent } from '../vault_crypto/vault.mjs'
+
+/**
+ * @param {object | null | undefined} poll poll 配置
+ * @param {number} [wallTime=Date.now()] 判定时刻
+ * @returns {boolean} 是否已截止
+ */
+export function isPollClosed(poll, wallTime = Date.now()) {
+	if (!poll?.deadline) return false
+	const parsed = Date.parse(String(poll.deadline))
+	if (!Number.isFinite(parsed)) return false
+	return parsed <= wallTime
+}
+
+/**
+ * @param {object} poll poll 配置
+ * @returns {object} 规范化 poll 草稿
+ */
+export function normalizePollDraft(poll) {
+	const options = (poll?.options || []).map(opt => String(opt).trim()).filter(Boolean)
+	if (options.length < 2) throw new Error('poll requires at least 2 options')
+	if (options.length > 10) throw new Error('poll allows at most 10 options')
+	const multi = poll?.multi === true
+	let deadline = poll?.deadline ? String(poll.deadline).trim() : null
+	if (deadline) {
+		const parsed = Date.parse(deadline)
+		if (!Number.isFinite(parsed)) throw new Error('invalid poll deadline')
+		if (parsed <= Date.now()) throw new Error('poll deadline must be in the future')
+	}
+	else deadline = null
+	return { options, multi, deadline }
+}
+
+/**
+ * @param {object} poll poll 配置
+ * @param {number[]} choices 选项下标
+ * @returns {number[]} 合法 choices
+ */
+export function normalizePollChoices(poll, choices) {
+	const indices = [...new Set((choices || []).map(n => Number(n)).filter(n => Number.isInteger(n) && n >= 0))]
+	if (!indices.length) throw new Error('choices required')
+	const max = poll.options.length - 1
+	for (const idx of indices)
+		if (idx > max) throw new Error('invalid poll choice')
+	if (!poll.multi && indices.length > 1) throw new Error('poll does not allow multiple choices')
+	return indices
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} targetPostId 帖 id
+ * @returns {Promise<{ post: object, poll: object, content: object }>} 目标帖与 poll
+ */
+export async function loadPollTargetPost(username, targetEntityHash, targetPostId) {
+	const { getTimelineMaterialized } = await import('../timeline/materialize.mjs')
+	const owner = targetEntityHash.toLowerCase()
+	const view = await getTimelineMaterialized(username, owner)
+	const post = view.postById[targetPostId]
+	if (!post) throw new Error('post not found')
+	const content = await maybeDecryptPostContent(username, owner, post.content)
+	const poll = content?.poll
+	if (!poll?.options?.length) throw new Error('post has no poll')
+	return { post, poll, content }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} targetPostId 帖 id
+ * @param {number[]} choices 选项下标
+ * @param {number} [wallTime=Date.now()] 判定时刻
+ * @returns {Promise<number[]>} 合法 choices
+ */
+export async function assertPollVoteAllowed(username, targetEntityHash, targetPostId, choices, wallTime = Date.now()) {
+	const { poll } = await loadPollTargetPost(username, targetEntityHash, targetPostId)
+	if (isPollClosed(poll, wallTime)) throw new Error('poll closed')
+	return normalizePollChoices(poll, choices)
+}
+
+/**
+ * @param {object} view 物化视图
+ * @param {string} targetEntityHash 帖作者
+ * @param {string} targetPostId 帖 id
+ * @returns {number[] | null} viewer 已选
+ */
+export function viewerPollChoicesFromView(view, targetEntityHash, targetPostId) {
+	const key = socialPostKey(targetEntityHash, targetPostId)
+	const row = view.pollVotes?.get?.(key) || view.pollVotes?.[key]
+	if (!row?.choices?.length) return null
+	return row.choices
+}

--- a/src/public/parts/shells/social/src/lib/pollDeadlineWatcher.mjs
+++ b/src/public/parts/shells/social/src/lib/pollDeadlineWatcher.mjs
@@ -1,0 +1,105 @@
+/**
+ * Social poll 截止 watcher。
+ */
+import { notifyUser } from '../../../../../../server/web_server/notify/notify.mjs'
+import { createDeadlineScheduler } from '../../../chat/src/chat/lib/deadlineScheduler.mjs'
+import { getReplicaUsernamesProvider } from '../federation/follower/registry.mjs'
+import { resolveSocialEntity } from '../federation/hosting.mjs'
+import { listPollTally, readPollTally } from '../federation/poll/index.mjs'
+import { appendPollClosedInboxRow } from '../inbox.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { maybeDecryptPostContent } from '../vault_crypto/vault.mjs'
+import { pushFeedUpdate } from '../ws/feedHub.mjs'
+
+import { isPollClosed } from './poll.mjs'
+
+const deadlines = createDeadlineScheduler()
+
+/**
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {string} 调度键
+ */
+function scheduleKey(entityHash, postId) {
+	return `${entityHash.toLowerCase()}:${postId}`
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<void>}
+ */
+export async function firePollClosed(username, entityHash, postId) {
+	const owner = entityHash.toLowerCase()
+	const view = await getTimelineMaterialized(username, owner)
+	const post = view.postById[postId]
+	if (!post) return
+	const content = await maybeDecryptPostContent(username, owner, post.content)
+	const poll = content?.poll
+	if (!poll?.options?.length) return
+	if (!isPollClosed(poll)) return
+	const resolved = await resolveSocialEntity(owner, username)
+	if (!resolved?.local || resolved.replicaUsername !== username) return
+	const { votes } = await readPollTally(username, owner, postId)
+	const tally = await listPollTally(username, owner, postId)
+	const recipients = new Set([owner, ...Object.keys(votes)])
+	for (const recipient of recipients)
+		await appendPollClosedInboxRow(username, recipient, owner, postId, poll, tally)
+	const preview = String(content?.text || poll.options[0] || 'poll closed').slice(0, 120)
+	void notifyUser(username, {
+		title: '投票已结束',
+		body: preview,
+		url: `/parts/shells:social/#post:${encodeURIComponent(owner)}:${encodeURIComponent(postId)}`,
+		tag: `poll-closed:${postId}`,
+	})
+	pushFeedUpdate(username, { type: 'poll_closed', entityHash: owner, postId, tally })
+}
+
+/**
+ * 为单帖注册 poll deadline（热路径：commit 后只扫本帖）。
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {object} post 已落盘 post
+ * @returns {Promise<void>}
+ */
+export async function schedulePollDeadlineForPost(username, entityHash, post) {
+	const owner = entityHash.toLowerCase()
+	const content = await maybeDecryptPostContent(username, owner, post.content)
+	const poll = content?.poll
+	if (!poll?.deadline) return
+	const parsed = Date.parse(String(poll.deadline))
+	if (!Number.isFinite(parsed)) return
+	await deadlines.schedule(scheduleKey(owner, post.id), parsed, () =>
+		firePollClosed(username, owner, post.id))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @returns {Promise<void>}
+ */
+export async function schedulePollDeadlines(username, entityHash) {
+	const owner = entityHash.toLowerCase()
+	const view = await getTimelineMaterialized(username, owner)
+	for (const post of view.posts || [])
+		await schedulePollDeadlineForPost(username, owner, post)
+}
+
+/**
+ * 启动时为本实例全部 replica 的本地 entity 时间线注册 poll deadline。
+ * @returns {Promise<void>}
+ */
+export async function bootstrapPollDeadlineWatchers() {
+	const listUsers = getReplicaUsernamesProvider()
+	if (!listUsers) return
+	const { getTimelineOwnerIndex } = await import('../timeline/ownerIndex.mjs')
+	for (const username of listUsers()) {
+		const owners = (await getTimelineOwnerIndex(username)).all
+		for (const entityHash of owners) {
+			const resolved = await resolveSocialEntity(entityHash, username)
+			if (!resolved?.local || resolved.replicaUsername !== username) continue
+			await schedulePollDeadlines(username, entityHash)
+		}
+	}
+}

--- a/src/public/parts/shells/social/src/lib/postMentionText.mjs
+++ b/src/public/parts/shells/social/src/lib/postMentionText.mjs
@@ -1,0 +1,23 @@
+/**
+ * 帖子正文：@ 扫描与通知/RPC 可见文本分离（受保护帖不向外泄露正文）。
+ */
+
+/**
+ * 返回用于 @ 提及扫描的帖子正文（含受保护帖，仅服务端）。
+ * @param {object} post 签名 post 事件
+ * @returns {string} 用于 @ 提及扫描的正文（含受保护帖，仅服务端）
+ */
+export function mentionSourceText(post) {
+	return String(post?.content?.text || '')
+}
+
+/**
+ * 返回通知/RPC 可见正文；受保护帖不泄露。
+ * @param {object} post 签名 post 事件
+ * @returns {string | null} 通知/RPC 可见正文；受保护帖不泄露
+ */
+export function postTextForNotification(post) {
+	const content = post?.content
+	if (content?.scheme === 'gsh' && !content?.text) return null
+	return String(content?.text || '')
+}

--- a/src/public/parts/shells/social/src/lib/postQuery.mjs
+++ b/src/public/parts/shells/social/src/lib/postQuery.mjs
@@ -1,0 +1,41 @@
+/**
+ * 帖子正文匹配（搜索 / 过滤用纯函数）。
+ */
+import { extractHashtagsFromText } from './hashtags.mjs'
+
+/**
+ * 规范化用户搜索查询（文本或 #话题）。
+ * @param {string} query 原始查询
+ * @returns {{ kind: 'none' | 'text' | 'hashtag', value: string, display: string }} 规范化查询
+ */
+export function normalizeSearchQuery(query) {
+	const raw = (query || '').trim()
+	if (!raw) return { kind: 'none', value: '', display: '' }
+	if (raw.startsWith('#')) {
+		const tag = raw.slice(1).trim().toLowerCase()
+		if (tag.length >= 2)
+			return { kind: 'hashtag', value: tag, display: `#${tag}` }
+		return { kind: 'none', value: '', display: raw }
+	}
+	return { kind: 'text', value: raw.toLowerCase(), display: raw }
+}
+
+
+/**
+ * 判断物化帖子是否匹配搜索查询。
+ * @param {object} post 物化帖子
+ * @param {string} query 用户查询
+ * @returns {boolean} 是否匹配
+ */
+export function postMatchesQuery(post, query) {
+	const norm = normalizeSearchQuery(query)
+	if (norm.kind === 'none' || norm.value.length < 2) return false
+	if (!post?.content?.text) return false
+	const text = (post.content?.text || '').toLowerCase()
+	if (norm.kind === 'hashtag')
+		return extractHashtagsFromText(text).includes(norm.value)
+	if (text.includes(norm.value)) return true
+	const author = (post.entityHash || '').toLowerCase()
+	if (norm.value.length >= 8 && author.includes(norm.value)) return true
+	return false
+}

--- a/src/public/parts/shells/social/src/lib/postVisibility.mjs
+++ b/src/public/parts/shells/social/src/lib/postVisibility.mjs
@@ -1,0 +1,58 @@
+/**
+ * 帖子可见性变更：解密 → 改 spec → 重加密 → commit post_visibility_set。
+ */
+import { randomUUID } from 'node:crypto'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { commitTimelineEvent } from '../timeline/append.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { maybeDecryptPostContent, maybeEncryptPostContent } from '../vault_crypto/vault.mjs'
+
+import {
+	normalizeVisibilitySpec,
+	visibilitySpecFromContent,
+	visibilitySpecsEqual,
+	visibilitySpecToContentFields,
+} from './visibilitySpec.mjs'
+
+/**
+ * 将帖子可见性改为 targetSpec（若已相同则跳过）。
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} postId 帖 id
+ * @param {object | string} targetSpec 目标可见性
+ * @returns {Promise<object | null>} 签名事件；跳过则为 null
+ */
+export async function setPostVisibility(username, entityHash, postId, targetSpec) {
+	const owner = String(entityHash).toLowerCase()
+	const id = String(postId)
+	const view = await getTimelineMaterialized(username, owner)
+	const row = view.postById?.[id]
+	if (!row) throw httpError(404, 'post not found')
+
+	const plain = await maybeDecryptPostContent(username, owner, row.content, owner)
+	if (!plain) throw httpError(500, 'cannot decrypt post for visibility change')
+
+	const nextSpec = normalizeVisibilitySpec(targetSpec)
+	const currentSpec = visibilitySpecFromContent(plain)
+	if (visibilitySpecsEqual(currentSpec, nextSpec)) return null
+
+	const nextPlain = {
+		...plain,
+		...visibilitySpecToContentFields(nextSpec),
+	}
+	// 清掉旧档位字段
+	if (nextSpec.visibility !== 'followers_since') delete nextPlain.minFollowMs
+	if (nextSpec.visibility !== 'selected') delete nextPlain.allow
+	if (!nextSpec.except?.length) delete nextPlain.except
+
+	const encrypted = await maybeEncryptPostContent(username, owner, randomUUID(), nextPlain, nextSpec)
+	return commitTimelineEvent(username, owner, {
+		type: 'post_visibility_set',
+		content: {
+			targetPostId: id,
+			...visibilitySpecToContentFields(nextSpec),
+			content: encrypted,
+		},
+	})
+}

--- a/src/public/parts/shells/social/src/lib/replyPolicy.mjs
+++ b/src/public/parts/shells/social/src/lib/replyPolicy.mjs
@@ -1,0 +1,112 @@
+/**
+ * 作者评论门控：replyPolicy + 精选评论资格判断。
+ */
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { maybeDecryptPostContent } from '../vault_crypto/vault.mjs'
+
+/**
+ *
+ */
+export const REPLY_POLICIES = new Set(['everyone', 'followers_7d', 'author_follows'])
+/**
+ *
+ */
+export const FOLLOWERS_7D_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * @param {unknown} raw 原始值
+ * @returns {'everyone' | 'followers_7d' | 'author_follows'} 规范化
+ */
+export function normalizeReplyPolicy(raw) {
+	const value = String(raw || '').trim()
+	return REPLY_POLICIES.has(value) ? /** @type {'everyone' | 'followers_7d' | 'author_follows'} */ value : 'everyone'
+}
+
+/**
+ * @param {unknown} raw 原始值
+ * @returns {'all' | 'featured_only'} 规范化
+ */
+export function normalizeReplyDisplay(raw) {
+	return String(raw || '').trim() === 'featured_only' ? 'featured_only' : 'all'
+}
+
+/**
+ * 从 replier 时间线取对作者最近一次仍有效的 follow 时刻。
+ * @param {object} replierView 物化视图
+ * @param {string} authorEntityHash 作者
+ * @returns {number | null} follow 时刻 wall ms
+ */
+export function latestFollowWallForAuthor(replierView, authorEntityHash) {
+	const target = authorEntityHash.toLowerCase()
+	if (!(replierView.following || []).map(id => id.toLowerCase()).includes(target))
+		return null
+	let latest = null
+	for (const event of replierView.followEvents || []) {
+		if (String(event.content?.targetEntityHash || '').toLowerCase() !== target) continue
+		const wall = Number(event.hlc?.wall) || Number(event.timestamp) || 0
+		if (!latest || wall > latest) latest = wall
+	}
+	return latest
+}
+
+/**
+ * @param {object} options 参数
+ * @param {string} options.username replica
+ * @param {string} options.authorEntityHash 帖作者
+ * @param {string} options.replierEntityHash 回复者
+ * @param {string} options.replyPolicy 门控
+ * @param {number} [options.at] 回复时刻
+ * @returns {Promise<boolean>} 是否允许
+ */
+export async function canReplyUnderPolicy({ username, authorEntityHash, replierEntityHash, replyPolicy, at = Date.now() }) {
+	const author = authorEntityHash.toLowerCase()
+	const replier = replierEntityHash.toLowerCase()
+	const policy = normalizeReplyPolicy(replyPolicy)
+	if (replier === author) return true
+	if (policy === 'everyone') return true
+
+	if (policy === 'author_follows') {
+		const authorView = await getTimelineMaterialized(username, author)
+		return (authorView.following || []).map(id => id.toLowerCase()).includes(replier)
+	}
+
+	if (policy === 'followers_7d') {
+		const replierView = await getTimelineMaterialized(username, replier)
+		const followWall = latestFollowWallForAuthor(replierView, author)
+		if (followWall == null) return false
+		return Number(at) - followWall >= FOLLOWERS_7D_MS
+	}
+
+	return true
+}
+
+/**
+ * 读取目标帖的 replyPolicy（含解密）。
+ * @param {string} username replica
+ * @param {string} authorEntityHash 作者
+ * @param {string} postId 帖 id
+ * @returns {Promise<{ post: object, content: object, replyPolicy: string, replyDisplay: string } | null>} 门控信息；帖不存在则为 null
+ */
+export async function loadPostReplyGate(username, authorEntityHash, postId) {
+	const author = authorEntityHash.toLowerCase()
+	const view = await getTimelineMaterialized(username, author)
+	const post = view.postById?.[postId] || view.posts?.find(row => row.id === postId)
+	if (!post) return null
+	const content = await maybeDecryptPostContent(username, author, post.content) || post.content || {}
+	return {
+		post,
+		content,
+		replyPolicy: normalizeReplyPolicy(content.replyPolicy),
+		replyDisplay: normalizeReplyDisplay(content.replyDisplay),
+	}
+}
+
+/**
+ * 精选回复键。
+ * @param {string} replierEntityHash 回复作者
+ * @param {string} replyPostId 回复帖 id
+ * @returns {string} 键
+ */
+export function featuredReplyKey(replierEntityHash, replyPostId) {
+	return `${String(replierEntityHash).toLowerCase()}:${String(replyPostId)}`
+}

--- a/src/public/parts/shells/social/src/lib/replyViaChat.mjs
+++ b/src/public/parts/shells/social/src/lib/replyViaChat.mjs
@@ -1,0 +1,111 @@
+/**
+ * social OnMessage 意愿 true 或无 OnMessage 且被 @ 时，经 chat.GetReply 生成公开回复正文。
+ *
+ * Uid 语义与 chat 一致：
+ * - User* = 本机 operator（主人）
+ * - Char* = 正在回复的 local agent
+ * - ReplyTo* = 帖作者（回复对象）
+ * - chat_log 行 uid = 帖作者
+ */
+import { formatHashShort } from 'fount/public/parts/shells/chat/public/shared/entityHash.mjs'
+
+import { getLocalizedInfo, localesForUser } from '../../../../../../scripts/locale.mjs'
+import { BUILTIN_PERSONA, BUILTIN_WORLD } from '../../../chat/src/chat/session/builtinParts.mjs'
+import { resolveOperatorEntityHashForUser } from '../../../chat/src/entity/identity.mjs'
+
+import { getEntityProfile } from './entityProfile.mjs'
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash entityHash
+ * @returns {Promise<string>} 展示名
+ */
+async function displayNameForEntity(username, entityHash) {
+	const profile = entityHash ? await getEntityProfile(username, entityHash) : null
+	return profile?.name || formatHashShort(entityHash, { headLen: 8, tailLen: 4 }) || 'user'
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} charPartName chars 目录名
+ * @param {object} char char part
+ * @param {object} messageEvent SocialMessageEvent 载荷
+ * @returns {Promise<string | null>} 回复正文；char 无 GetReply 或回复为空时 null
+ */
+export async function replyViaChat(username, charPartName, char, messageEvent) {
+	const getReply = char.interfaces?.chat?.GetReply
+	if (!getReply) return null
+
+	const now = new Date()
+	const authorUid = String(messageEvent.authorEntityHash || '').trim().toLowerCase() || 'user'
+	const authorName = messageEvent.authorDisplayName || await displayNameForEntity(username, authorUid)
+	const charUid = String(messageEvent.viewerEntityHash || '').trim().toLowerCase() || 'char'
+	const operatorUid = await resolveOperatorEntityHashForUser(username) || 'user'
+	const operatorName = await displayNameForEntity(username, operatorUid)
+
+	const entry = {
+		name: authorName,
+		uid: authorUid,
+		time_stamp: now,
+		role: 'user',
+		content: messageEvent.postText || '',
+		files: [],
+		extension: {
+			platform: 'social',
+			postId: messageEvent.post?.id,
+			authorEntityHash: authorUid,
+		},
+	}
+	const locales = [...new Set([
+		messageEvent.locale,
+		...localesForUser(username),
+	].filter(Boolean))]
+	const charInfo = getLocalizedInfo(char.info, locales) || {}
+	const request = {
+		supported_functions: {
+			markdown: true,
+			mathjax: false,
+			html: false,
+			unsafe_html: false,
+			files: false,
+			add_message: false,
+			fount_i18nkeys: false,
+			fount_assets: false,
+			fount_themes: false,
+		},
+		chat_name: 'social:post',
+		char_id: charPartName,
+		username,
+		Charname: charInfo.name || charPartName,
+		CharUid: charUid,
+		UserCharname: operatorName,
+		UserUid: operatorUid,
+		ReplyToCharname: authorName,
+		ReplyToUid: authorUid,
+		locales,
+		time: now,
+		world: BUILTIN_WORLD,
+		user: BUILTIN_PERSONA,
+		char,
+		other_chars: {},
+		plugins: {},
+		chat_log: [entry],
+		timelines: [entry],
+		chat_summary: '',
+		chat_scoped_char_memory: {},
+		extension: {
+			platform: 'social',
+			post: {
+				id: messageEvent.post?.id,
+				authorEntityHash: authorUid,
+			},
+		},
+		/** @returns {Promise<null>} social 请求不支持追加消息 */
+		AddChatLogEntry: async () => null,
+		/** @returns {Promise<object>} 原样返回请求自身（无会话可刷新） */
+		Update: async function update() { return this },
+	}
+
+	const reply = await getReply(request)
+	return String(reply?.content ?? '').trim() || null
+}

--- a/src/public/parts/shells/social/src/lib/scheduledPostWatcher.mjs
+++ b/src/public/parts/shells/social/src/lib/scheduledPostWatcher.mjs
@@ -1,0 +1,91 @@
+/**
+ * 定时发帖 watcher。
+ */
+import { createDeadlineScheduler } from '../../../chat/src/chat/lib/deadlineScheduler.mjs'
+import { getReplicaUsernamesProvider } from '../federation/follower/registry.mjs'
+import { resolveSocialEntity } from '../federation/hosting.mjs'
+
+import { listScheduledPosts, takeScheduledPost } from './scheduledPosts.mjs'
+
+const deadlines = createDeadlineScheduler()
+
+/**
+ * @param {string} entityHash 作者
+ * @param {string} scheduledId id
+ * @returns {string} 调度键
+ */
+function scheduleKey(entityHash, scheduledId) {
+	return `${entityHash.toLowerCase()}:${scheduledId}`
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} scheduledId id
+ * @returns {Promise<void>}
+ */
+export async function fireScheduledPost(username, entityHash, scheduledId) {
+	const owner = entityHash.toLowerCase()
+	const row = takeScheduledPost(username, owner, scheduledId)
+	if (!row) return
+	const resolved = await resolveSocialEntity(owner, username)
+	if (!resolved?.local || resolved.replicaUsername !== username) return
+	const { getSocialClient } = await import('../api/client/index.mjs')
+	const client = await getSocialClient(username, owner)
+	const draft = { ...row.draft }
+	delete draft.publishAt
+	await client.post(draft)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {object} row 定时项
+ * @returns {void}
+ */
+export function scheduleOneScheduledPost(username, entityHash, row) {
+	const owner = entityHash.toLowerCase()
+	const publishAt = Number(row.publishAt)
+	if (!Number.isFinite(publishAt)) return
+	void deadlines.schedule(scheduleKey(owner, row.scheduledId), publishAt, () =>
+		fireScheduledPost(username, owner, row.scheduledId))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} scheduledId id
+ * @returns {void}
+ */
+export function cancelScheduledPostTimer(username, entityHash, scheduledId) {
+	deadlines.clear(scheduleKey(entityHash, scheduledId))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @returns {void}
+ */
+export function scheduleEntityScheduledPosts(username, entityHash) {
+	const owner = entityHash.toLowerCase()
+	for (const row of listScheduledPosts(username, owner))
+		scheduleOneScheduledPost(username, owner, row)
+}
+
+/**
+ * 启动时为本实例全部 replica 的本地 entity 注册定时发帖。
+ * @returns {Promise<void>}
+ */
+export async function bootstrapScheduledPostWatchers() {
+	const listUsers = getReplicaUsernamesProvider()
+	if (!listUsers) return
+	const { getTimelineOwnerIndex } = await import('../timeline/ownerIndex.mjs')
+	for (const username of listUsers()) {
+		const owners = (await getTimelineOwnerIndex(username)).all
+		for (const entityHash of owners) {
+			const resolved = await resolveSocialEntity(entityHash, username)
+			if (!resolved?.local || resolved.replicaUsername !== username) continue
+			scheduleEntityScheduledPosts(username, entityHash)
+		}
+	}
+}

--- a/src/public/parts/shells/social/src/lib/scheduledPosts.mjs
+++ b/src/public/parts/shells/social/src/lib/scheduledPosts.mjs
@@ -1,0 +1,83 @@
+/**
+ * 定时发帖草稿队列（本地 JSONL，到点由 scheduledPostWatcher 正式 commit）。
+ */
+import { randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+
+import { loadJsonFileIfExists, saveJsonFile } from '../../../../../../scripts/json_loader.mjs'
+import { scheduledPostsPath } from '../paths.mjs'
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @returns {object[]} 待发布列表
+ */
+export function listScheduledPosts(username, entityHash) {
+	const path = scheduledPostsPath(username, entityHash)
+	const data = loadJsonFileIfExists(path)
+	const rows = Array.isArray(data?.rows) ? data.rows : []
+	return rows
+		.filter(row => row && typeof row === 'object' && row.scheduledId && row.publishAt)
+		.sort((a, b) => Number(a.publishAt) - Number(b.publishAt))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {object[]} rows 全量覆盖
+ * @returns {void}
+ */
+function saveScheduledPosts(username, entityHash, rows) {
+	const path = scheduledPostsPath(username, entityHash)
+	fs.mkdirSync(path.replace(/[/\\][^/\\]+$/u, ''), { recursive: true })
+	saveJsonFile(path, { rows })
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {object} draft 发帖草稿
+ * @param {number} publishAt 未来毫秒时间戳
+ * @returns {object} 定时项
+ */
+export function enqueueScheduledPost(username, entityHash, draft, publishAt) {
+	const at = Number(publishAt)
+	if (!Number.isFinite(at) || at <= Date.now())
+		throw new Error('publishAt must be a future timestamp')
+	const rows = listScheduledPosts(username, entityHash)
+	const row = {
+		scheduledId: randomUUID(),
+		publishAt: at,
+		createdAt: Date.now(),
+		draft: structuredClone(draft),
+	}
+	rows.push(row)
+	saveScheduledPosts(username, entityHash, rows)
+	return row
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} scheduledId id
+ * @returns {object | null} 被移除项
+ */
+export function cancelScheduledPost(username, entityHash, scheduledId) {
+	const id = String(scheduledId || '').trim()
+	const rows = listScheduledPosts(username, entityHash)
+	const idx = rows.findIndex(row => row.scheduledId === id)
+	if (idx < 0) return null
+	const [removed] = rows.splice(idx, 1)
+	saveScheduledPosts(username, entityHash, rows)
+	return removed
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {string} scheduledId id
+ * @returns {object | null} 取出项（并从队列删除）
+ */
+export function takeScheduledPost(username, entityHash, scheduledId) {
+	return cancelScheduledPost(username, entityHash, scheduledId)
+}

--- a/src/public/parts/shells/social/src/lib/searchFilters.mjs
+++ b/src/public/parts/shells/social/src/lib/searchFilters.mjs
@@ -1,0 +1,95 @@
+/**
+ * 帖文搜索结构化过滤解析。
+ */
+import { extractHashtagsFromText } from './hashtags.mjs'
+import { normalizeSearchQuery, postMatchesQuery } from './postQuery.mjs'
+
+/**
+ * @param {object} options 原始选项
+ * @returns {{ q: string, author: string | null, media: 'image' | 'video' | null, tag: string | null, before: number | null, after: number | null, sort: 'latest' | 'top', scope: 'local' | 'nearby' }} 规范化
+ */
+export function parseSearchFilters(options = {}) {
+	let q = String(options.q || '').trim()
+	let author = options.author ? String(options.author).trim().toLowerCase() : null
+	let media = null
+	const mediaRaw = String(options.media || '').trim().toLowerCase()
+	if (mediaRaw === 'image' || mediaRaw === 'video') media = mediaRaw
+	let tag = options.tag ? String(options.tag).trim().replace(/^#/u, '').toLowerCase() : null
+	const before = options.before != null && Number.isFinite(Number(options.before)) ? Number(options.before) : null
+	const after = options.after != null && Number.isFinite(Number(options.after)) ? Number(options.after) : null
+	const sort = String(options.sort || 'latest').trim() === 'top' ? 'top' : 'latest'
+	const scope = String(options.scope || 'local').trim() === 'nearby' ? 'nearby' : 'local'
+
+	const tokens = q.split(/\s+/u).filter(Boolean)
+	const leftover = []
+	for (const token of tokens) {
+		const lower = token.toLowerCase()
+		if (lower.startsWith('author:') && !author) {
+			author = token.slice(7).trim().toLowerCase() || null
+			continue
+		}
+		if (lower.startsWith('media:') && !media) {
+			const value = token.slice(6).trim().toLowerCase()
+			if (value === 'image' || value === 'video') media = value
+			continue
+		}
+		if (lower.startsWith('tag:') && !tag) {
+			tag = token.slice(4).trim().replace(/^#/u, '').toLowerCase() || null
+			continue
+		}
+		leftover.push(token)
+	}
+	q = leftover.join(' ').trim()
+	if (!tag && q.startsWith('#')) {
+		const norm = normalizeSearchQuery(q)
+		if (norm.kind === 'hashtag') {
+			tag = norm.value
+			q = ''
+		}
+	}
+	return { q, author, media, tag, before, after, sort, scope }
+}
+
+/**
+ * @param {object} post 帖
+ * @param {ReturnType<typeof parseSearchFilters>} filters 过滤
+ * @returns {boolean} 是否命中
+ */
+export function postMatchesFilters(post, filters) {
+	if (filters.author) {
+		const author = String(post.entityHash || '').toLowerCase()
+		if (!author.includes(filters.author)) return false
+	}
+	if (filters.tag) {
+		const text = String(post.content?.text || '')
+		const tags = [
+			...extractHashtagsFromText(text),
+			...Array.isArray(post.content?.tags) ? post.content.tags.map(t => String(t).toLowerCase()) : [],
+		]
+		if (!tags.includes(filters.tag)) return false
+	}
+	if (filters.media) {
+		const refs = Array.isArray(post.content?.mediaRefs) ? post.content.mediaRefs : []
+		if (!refs.some(ref => String(ref?.kind || '').toLowerCase() === filters.media)) return false
+	}
+	const wall = Number(post.hlc?.wall) || Number(post.timestamp) || 0
+	if (filters.before != null && wall >= filters.before) return false
+	if (filters.after != null && wall <= filters.after) return false
+	if (filters.q && filters.q.length >= 2 && !postMatchesQuery(post, filters.q)) return false
+	if (!filters.q && !filters.tag && !filters.author && !filters.media && filters.before == null && filters.after == null)
+		return false
+	return true
+}
+
+/**
+ * 是否有足够搜索条件。
+ * @param {ReturnType<typeof parseSearchFilters>} filters 过滤
+ * @returns {boolean} 可否搜索
+ */
+export function hasSearchCriteria(filters) {
+	if (filters.q && filters.q.length >= 2) return true
+	if (filters.tag && filters.tag.length >= 2) return true
+	if (filters.author && filters.author.length >= 2) return true
+	if (filters.media) return true
+	return false
+}

--- a/src/public/parts/shells/social/src/lib/visibilitySpec.mjs
+++ b/src/public/parts/shells/social/src/lib/visibilitySpec.mjs
@@ -1,0 +1,221 @@
+/**
+ * Social 可见性档位规范化、偏序与读侧判定核心。
+ */
+
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+/** @typedef {'public' | 'unlisted' | 'followers' | 'followers_since' | 'selected' | 'private'} SocialVisibility */
+
+/** 合法可见性档位 */
+export const SOCIAL_VISIBILITIES = new Set([
+	'public',
+	'unlisted',
+	'followers',
+	'followers_since',
+	'selected',
+	'private',
+])
+
+/** UI 预设 → 规范档位 */
+export const VISIBILITY_UI_PRESETS = {
+	followers_7d: { visibility: 'followers_since', minFollowMs: 7 * 24 * 60 * 60 * 1000 },
+	followers_30d: { visibility: 'followers_since', minFollowMs: 30 * 24 * 60 * 60 * 1000 },
+}
+
+/** 偏序基数：越大越严 */
+const STRICTNESS_BASE = {
+	public: 0,
+	unlisted: 1,
+	followers: 2,
+	followers_since: 3,
+	selected: 4,
+	private: 5,
+}
+
+/**
+ * @param {unknown} raw 原始哈希列表
+ * @returns {string[]} 清洗后的 entityHash 列表
+ */
+function normalizeEntityHashList(raw) {
+	if (!Array.isArray(raw)) return []
+	const out = []
+	const seen = new Set()
+	for (const item of raw) {
+		const hash = String(item || '').trim().toLowerCase()
+		if (!isEntityHash128(hash) || seen.has(hash)) continue
+		seen.add(hash)
+		out.push(hash)
+	}
+	return out
+}
+
+/**
+ * 规范化可见性草稿（含 UI 预设展开）。
+ * @param {object | string} [draft] 草稿或档位字符串
+ * @returns {{ visibility: SocialVisibility, minFollowMs?: number, allow?: string[], except?: string[] }} 规范 spec
+ */
+export function normalizeVisibilitySpec(draft = {}) {
+	const raw = typeof draft === 'string' ? { visibility: draft } : draft || {}
+	const presetKey = String(raw.visibility || raw.preset || '').trim()
+	const preset = VISIBILITY_UI_PRESETS[presetKey]
+	let visibility = /** @type {SocialVisibility} */ 
+		preset ? preset.visibility : String(raw.visibility || 'public').trim()
+	
+	if (!SOCIAL_VISIBILITIES.has(visibility)) visibility = 'public'
+
+	/** @type {{ visibility: SocialVisibility, minFollowMs?: number, allow?: string[], except?: string[] }} */
+	const spec = { visibility }
+
+	if (visibility === 'followers_since') {
+		const ms = Number(raw.minFollowMs ?? preset?.minFollowMs)
+		spec.minFollowMs = Number.isFinite(ms) && ms > 0
+			? Math.floor(ms)
+			: VISIBILITY_UI_PRESETS.followers_7d.minFollowMs
+	}
+
+	if (visibility === 'selected') 
+		spec.allow = normalizeEntityHashList(raw.allow)
+	
+
+	if (visibility === 'private') 
+		spec.allow = []
+	
+
+	if (visibility === 'public' || visibility === 'unlisted' || visibility === 'followers' || visibility === 'followers_since') {
+		const except = normalizeEntityHashList(raw.except)
+		if (except.length) spec.except = except
+	}
+
+	return spec
+}
+
+/**
+ * 从帖/相册 content 抽取可见性 spec（信封外层或明文）。
+ * @param {object | null | undefined} content content
+ * @returns {{ visibility: SocialVisibility, minFollowMs?: number, allow?: string[], except?: string[] }} spec
+ */
+export function visibilitySpecFromContent(content) {
+	return normalizeVisibilitySpec({
+		visibility: content?.visibility,
+		minFollowMs: content?.minFollowMs,
+		allow: content?.allow,
+		except: content?.except,
+	})
+}
+
+/**
+ * 比较两个可见性档位的严格程度。
+ * @param {object | string} a 档位或 spec
+ * @param {object | string} b 档位或 spec
+ * @returns {number} <0 a 更公开；0 同级；>0 a 更严
+ */
+export function compareVisibilityStrictness(a, b) {
+	const left = normalizeVisibilitySpec(a)
+	const right = normalizeVisibilitySpec(b)
+	const leftBase = STRICTNESS_BASE[left.visibility] ?? 0
+	const rightBase = STRICTNESS_BASE[right.visibility] ?? 0
+	if (leftBase !== rightBase) return leftBase - rightBase
+	if (left.visibility === 'followers_since')
+		return (left.minFollowMs || 0) - (right.minFollowMs || 0)
+	return 0
+}
+
+/**
+ * 取多个 spec 中最公开的一个。
+ * @param {Array<object | string>} specs specs
+ * @returns {ReturnType<typeof normalizeVisibilitySpec> | null} 最公开；空列表为 null
+ */
+export function minVisibilitySpec(specs) {
+	let best = null
+	for (const item of specs) {
+		const spec = normalizeVisibilitySpec(item)
+		if (!best || compareVisibilityStrictness(spec, best) < 0) best = spec
+	}
+	return best
+}
+
+/**
+ * 是否仅应进入公开发现面（探索/热搜/搜索联邦/短视频发现）。
+ * @param {object | string | null | undefined} contentOrSpec content 或 spec
+ * @returns {boolean} 是否 public
+ */
+export function isPublicDiscoverable(contentOrSpec) {
+	const visibility = typeof contentOrSpec === 'string'
+		? contentOrSpec
+		: contentOrSpec?.visibility || 'public'
+	return visibility === 'public' || !visibility
+}
+
+/**
+ * 可见性读侧判定（不含个人拉黑/关键词；那些由 canViewPost 叠）。
+ * @param {object} content 帖/相册 content（含 visibility 字段）
+ * @param {object} viewerContext 观看者上下文
+ * @param {string} ownerEntityHash 作者/相册 owner
+ * @returns {boolean} 是否可见
+ */
+export function canViewByVisibility(content, viewerContext, ownerEntityHash) {
+	const owner = String(ownerEntityHash || '').toLowerCase()
+	const viewer = String(viewerContext?.viewerEntityHash || '').toLowerCase() || null
+	if (viewer && viewer === owner) return true
+
+	const spec = visibilitySpecFromContent(content)
+	if (viewer && spec.except?.includes(viewer)) return false
+
+	switch (spec.visibility) {
+		case 'public':
+		case 'unlisted':
+			return true
+		case 'followers':
+			return Boolean(viewer && viewerContext.following?.has(owner))
+		case 'followers_since': {
+			if (!viewer || !viewerContext.following?.has(owner)) return false
+			const followWall = viewerContext.followSince?.get(owner)
+			if (followWall == null) return false
+			const at = Number(viewerContext.at) || Date.now()
+			return at - followWall >= (spec.minFollowMs || 0)
+		}
+		case 'selected':
+			return Boolean(viewer && spec.allow?.includes(viewer))
+		case 'private':
+			return false
+		default:
+			return true
+	}
+}
+
+/**
+ * 两个可见性 spec 是否语义相等（用于 reconcile 跳过）。
+ * @param {object | string} a a
+ * @param {object | string} b b
+ * @returns {boolean} 相等
+ */
+export function visibilitySpecsEqual(a, b) {
+	const left = normalizeVisibilitySpec(a)
+	const right = normalizeVisibilitySpec(b)
+	if (left.visibility !== right.visibility) return false
+	if ((left.minFollowMs || 0) !== (right.minFollowMs || 0)) return false
+	const leftAllow = [...left.allow || []].sort().join(',')
+	const rightAllow = [...right.allow || []].sort().join(',')
+	if (leftAllow !== rightAllow) return false
+	const leftExcept = [...left.except || []].sort().join(',')
+	const rightExcept = [...right.except || []].sort().join(',')
+	return leftExcept === rightExcept
+}
+
+/**
+ * 将规范 spec 展开到 content 字段（剔除缺省）。
+ * @param {ReturnType<typeof normalizeVisibilitySpec>} spec spec
+ * @returns {object} content 片段
+ */
+export function visibilitySpecToContentFields(spec) {
+	const normalized = normalizeVisibilitySpec(spec)
+	/** @type {object} */
+	const fields = { visibility: normalized.visibility }
+	if (normalized.visibility === 'followers_since')
+		fields.minFollowMs = normalized.minFollowMs
+	if (normalized.visibility === 'selected')
+		fields.allow = [...normalized.allow || []]
+	if (normalized.except?.length)
+		fields.except = [...normalized.except]
+	return fields
+}

--- a/src/public/parts/shells/social/src/live/bridge.mjs
+++ b/src/public/parts/shells/social/src/live/bridge.mjs
@@ -1,0 +1,97 @@
+/**
+ * 跨节点直播 bridge：出站连对端 live-bridge WS；帧订阅 → 远端，入站注入本地房间。
+ */
+import WebSocket from 'npm:ws'
+
+import {
+	injectAvRelayFrame,
+	injectAvRelayControl,
+	subscribeAvRelayFrames,
+	subscribeAvRelayControls,
+} from '../../../chat/src/chat/ws/avRelay.mjs'
+
+import { ingestBridgedLiveSignal } from './hub.mjs'
+import { liveBridgeTokenFor } from './link.mjs'
+import { loadLiveSession } from './session.mjs'
+
+/**
+ * @param {object} options 参数
+ * @returns {Promise<() => void>} closer
+ */
+export async function connectOutboundLiveBridge(options) {
+	const {
+		username,
+		entityHash,
+		liveId,
+		avRoomId,
+		peerBridgeOrigin,
+		peerEntityHash,
+		peerLiveId,
+		linkSecret,
+	} = options
+	const token = liveBridgeTokenFor(linkSecret, peerEntityHash, peerLiveId)
+	const base = String(peerBridgeOrigin || '').replace(/\/$/, '')
+	const wsUrl = `${base.replace(/^http/, 'ws')}/ws/parts/shells:social/live-bridge/${encodeURIComponent(peerEntityHash)}/${encodeURIComponent(peerLiveId)}?token=${encodeURIComponent(token)}`
+
+	const remote = new WebSocket(wsUrl)
+	await new Promise((resolve, reject) => {
+		remote.once('open', resolve)
+		remote.once('error', reject)
+		setTimeout(() => reject(new Error('bridge connect timeout')), 8_000)
+	})
+
+	const unsub = subscribeAvRelayFrames(avRoomId, buf => {
+		if (remote.readyState !== 1) return
+		try { remote.send(buf, { binary: true }) }
+		catch { /* skip */ }
+	})
+	const unsubCtrl = subscribeAvRelayControls(avRoomId, text => {
+		if (remote.readyState !== 1) return
+		try { remote.send(text) }
+		catch { /* skip */ }
+	})
+
+	remote.on('message', (data, isBinary) => {
+		if (isBinary) {
+			injectAvRelayFrame(avRoomId, data)
+			return
+		}
+		let wireMessage
+		try { wireMessage = JSON.parse(String(data)) }
+		catch { return }
+		if (wireMessage?.type === 'publish_meta' || wireMessage?.type === 'publish_meta_revoke') {
+			injectAvRelayControl(avRoomId, wireMessage)
+			return
+		}
+		ingestBridgedLiveSignal(username, entityHash, liveId, wireMessage)
+	})
+
+	const statsTimer = setInterval(() => {
+		const session = loadLiveSession(username, entityHash, liveId)
+		if (!session || remote.readyState !== 1) return
+		try {
+			remote.send(JSON.stringify({
+				type: 'link_stats',
+				viewerCount: session.viewerCount || 0,
+				likeCount: session.likeCount || 0,
+				origin: `${entityHash}:${liveId}`,
+			}))
+		}
+		catch { /* skip */ }
+	}, 3000)
+
+	let closed = false
+	/**
+	 *
+	 */
+	const close = () => {
+		if (closed) return
+		closed = true
+		clearInterval(statsTimer)
+		unsub()
+		unsubCtrl()
+		try { remote.close() } catch { /* ignore */ }
+	}
+	remote.on('close', close)
+	return close
+}

--- a/src/public/parts/shells/social/src/live/feed.mjs
+++ b/src/public/parts/shells/social/src/live/feed.mjs
@@ -1,0 +1,88 @@
+/**
+ * 在播列表：关注优先 + 观众数排序；可选联邦 nearby。
+ */
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { loadFollowingForActor } from '../following.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { getTimelineOwnerIndex } from '../timeline/ownerIndex.mjs'
+
+import { listActiveLiveSessions, loadLiveSession } from './session.mjs'
+
+/**
+ * @param {string} username replica
+ * @param {{ limit?: number, cursor?: string, viewerEntityHash?: string, scope?: string }} [options] 选项
+ * @returns {Promise<{ items: object[], nextCursor: string | null, scope: string }>} 在播列表
+ */
+export async function buildLiveFeed(username, options = {}) {
+	if (String(options.scope || '') === 'nearby') {
+		const { buildNearbyLiveFeed } = await import('./network.mjs')
+		return buildNearbyLiveFeed(username, options)
+	}
+	const limit = Math.min(Math.max(Number(options.limit) || 20, 1), 50)
+	const viewer = options.viewerEntityHash || null
+	const { following } = viewer
+		? await loadFollowingForActor(username, viewer)
+		: { following: [] }
+	const followingSet = new Set(following.map(id => id.toLowerCase()))
+	const owners = (await getTimelineOwnerIndex(username)).all
+
+	/** @type {object[]} */
+	const items = []
+	const seen = new Set()
+	for (const entityHash of owners) {
+		if (!isEntityHash128(entityHash)) continue
+		for (const session of listActiveLiveSessions(username, entityHash)) {
+			const key = `${session.entityHash}:${session.liveId}`
+			if (seen.has(key)) continue
+			seen.add(key)
+			items.push({
+				...session,
+				following: followingSet.has(session.entityHash),
+			})
+		}
+		const view = await getTimelineMaterialized(username, entityHash)
+		for (const [liveId, event] of Object.entries(view.activeLives || {})) {
+			const key = `${entityHash}:${liveId}`
+			if (seen.has(key)) continue
+			const session = loadLiveSession(username, entityHash, liveId)
+			if (session?.status === 'live') {
+				seen.add(key)
+				items.push({ ...session, following: followingSet.has(entityHash) })
+				continue
+			}
+			seen.add(key)
+			items.push({
+				liveId,
+				entityHash,
+				title: event.content?.title || 'Live',
+				visibility: event.content?.visibility || 'public',
+				mediaKind: event.content?.mediaKind || 'av',
+				status: 'live',
+				startedAt: Number(event.hlc?.wall) || Date.now(),
+				viewerCount: 0,
+				avRoomId: event.content?.avRoomId || `social:${entityHash}:${liveId}`,
+				chatMount: event.content?.chatMount || null,
+				following: followingSet.has(entityHash),
+			})
+		}
+	}
+
+	items.sort((a, b) => {
+		if (a.following !== b.following) return a.following ? -1 : 1
+		const vc = (b.viewerCount || 0) - (a.viewerCount || 0)
+		if (vc) return vc
+		return (b.startedAt || 0) - (a.startedAt || 0)
+	})
+
+	let start = 0
+	if (options.cursor) {
+		const idx = items.findIndex(row => `${row.entityHash}:${row.liveId}` === options.cursor)
+		start = idx >= 0 ? idx + 1 : 0
+	}
+	const page = items.slice(start, start + limit)
+	const nextCursor = page.length === limit && start + limit < items.length
+		? `${page[page.length - 1].entityHash}:${page[page.length - 1].liveId}`
+		: null
+	return { items: page, nextCursor, scope: 'local' }
+}

--- a/src/public/parts/shells/social/src/live/hub.mjs
+++ b/src/public/parts/shells/social/src/live/hub.mjs
@@ -1,0 +1,186 @@
+/**
+ * 直播间 JSON 信令 Hub：弹幕 / 点赞 / 观众数 / 连线转发。
+ */
+import { appendLiveDanmaku, loadLiveSession, patchLiveStats } from './session.mjs'
+
+/** @type {Map<string, Set<import('npm:ws').WebSocket>>} */
+const liveRooms = new Map()
+
+/** 连线对端房间桥：roomKey → peer roomKey */
+const signalBridges = new Map()
+
+/**
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {string} room key
+ */
+export function liveSignalRoomKey(entityHash, liveId) {
+	return `${entityHash.toLowerCase()}:${String(liveId).toLowerCase()}`
+}
+
+/**
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @param {import('npm:ws').WebSocket} socket WS
+ * @param {{ username: string, viewerEntityHash: string }} meta 元数据
+ * @returns {void}
+ */
+export function registerLiveSignalSocket(entityHash, liveId, socket, meta) {
+	const key = liveSignalRoomKey(entityHash, liveId)
+	const set = liveRooms.get(key) ?? new Set()
+	set.add(socket)
+	liveRooms.set(key, set)
+	socket.liveMeta = meta
+	broadcast(key, { type: 'viewer_count', count: set.size })
+	const session = patchLiveStats(meta.username, entityHash, liveId, {
+		viewerCount: set.size,
+		viewerEntityHash: meta.viewerEntityHash,
+	})
+	if (session)
+		broadcast(key, { type: 'like_count', count: session.likeCount || 0 })
+
+	socket.on('message', raw => {
+		let wireMessage
+		try { wireMessage = JSON.parse(String(raw)) }
+		catch { return }
+		if (!wireMessage || typeof wireMessage !== 'object') return
+		if (wireMessage.type === 'danmaku') {
+			const text = String(wireMessage.text || '').trim().slice(0, 120)
+			if (!text) return
+			const row = {
+				type: 'danmaku',
+				text,
+				entityHash: meta.viewerEntityHash,
+				at: Date.now(),
+				origin: key,
+			}
+			appendLiveDanmaku(meta.username, entityHash, liveId, row)
+			broadcast(key, row)
+			forwardBridged(key, row)
+			return
+		}
+		if (wireMessage.type === 'like') {
+			const updated = patchLiveStats(meta.username, entityHash, liveId, { likeDelta: 1 })
+			const row = {
+				type: 'like',
+				entityHash: meta.viewerEntityHash,
+				at: Date.now(),
+				origin: key,
+			}
+			broadcast(key, row)
+			if (updated) {
+				broadcast(key, { type: 'like_count', count: updated.likeCount || 0 })
+				forwardBridged(key, { type: 'like_count', count: updated.likeCount || 0, origin: key })
+			}
+			forwardBridged(key, row)
+		}
+	})
+
+	socket.on('close', () => {
+		set.delete(socket)
+		if (!set.size) liveRooms.delete(key)
+		else broadcast(key, { type: 'viewer_count', count: set.size })
+		patchLiveStats(meta.username, entityHash, liveId, { viewerCount: set.size })
+		forwardBridged(key, { type: 'viewer_count', count: set.size, origin: key })
+	})
+}
+
+/**
+ * 同节点连线：合并两个信令房间双向转发。
+ * @param {string} keyA room key
+ * @param {string} keyB room key
+ * @returns {() => void} teardown
+ */
+export function bridgeLiveSignalRooms(keyA, keyB) {
+	if (!keyA || !keyB || keyA === keyB) return () => { }
+	signalBridges.set(keyA, keyB)
+	signalBridges.set(keyB, keyA)
+	return () => {
+		if (signalBridges.get(keyA) === keyB) signalBridges.delete(keyA)
+		if (signalBridges.get(keyB) === keyA) signalBridges.delete(keyB)
+	}
+}
+
+/**
+ * @param {string} key room key
+ * @param {object} payload 推送
+ * @returns {void}
+ */
+export function broadcastLiveSignal(key, payload) {
+	broadcast(key, payload)
+}
+
+/**
+ * 注入对端连线信令（来自 bridge WS），抑制回环。
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @param {object} payload 载荷
+ * @returns {void}
+ */
+export function ingestBridgedLiveSignal(username, entityHash, liveId, payload) {
+	const key = liveSignalRoomKey(entityHash, liveId)
+	if (!payload || typeof payload !== 'object') return
+	const origin = String(payload.origin || '')
+	if (origin === key) return
+	if (payload.type === 'danmaku' && payload.text) {
+		appendLiveDanmaku(username, entityHash, liveId, { ...payload, bridged: true })
+		broadcast(key, { ...payload, bridged: true })
+		return
+	}
+	if (payload.type === 'like') {
+		broadcast(key, { ...payload, bridged: true })
+		return
+	}
+	if (payload.type === 'like_count' || payload.type === 'viewer_count' || payload.type === 'link_stats') {
+		broadcast(key, { ...payload, bridged: true })
+		return
+	}
+	if (payload.type === 'link_ended')
+		broadcast(key, payload)
+}
+
+/**
+ * @param {string} key room key
+ * @param {object} payload 推送
+ * @returns {void}
+ */
+function forwardBridged(key, payload) {
+	const peer = signalBridges.get(key)
+	if (!peer) return
+	if (payload.origin && payload.origin !== key) return
+	broadcast(peer, { ...payload, origin: key })
+}
+
+/**
+ * @param {string} key room key
+ * @param {object} payload 推送
+ * @returns {void}
+ */
+function broadcast(key, payload) {
+	const set = liveRooms.get(key)
+	if (!set) return
+	const text = JSON.stringify(payload)
+	for (const socket of set)
+		if (socket.readyState === 1)
+			try { socket.send(text) } catch { /* skip */ }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {boolean} 是否允许进入
+ */
+export function canJoinLiveRoom(username, entityHash, liveId) {
+	return loadLiveSession(username, entityHash, liveId)?.status === 'live'
+}
+
+/**
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {number} 当前观众连接数
+ */
+export function getLiveSignalViewerCount(entityHash, liveId) {
+	return liveRooms.get(liveSignalRoomKey(entityHash, liveId))?.size || 0
+}

--- a/src/public/parts/shells/social/src/live/link.mjs
+++ b/src/public/parts/shells/social/src/live/link.mjs
@@ -1,0 +1,265 @@
+/**
+ * 双主播直播连线：邀请 / 接受 / 断链；同节点 AV+信令桥，跨节点经 bridge WS。
+ */
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { bridgeAvRooms } from '../../../chat/src/chat/ws/avRelay.mjs'
+import { collectSocialRpcMerged } from '../federation/rpc/wire.mjs'
+import { pushFeedUpdate } from '../ws/feedHub.mjs'
+
+import {
+	bridgeLiveSignalRooms,
+	broadcastLiveSignal,
+	liveSignalRoomKey,
+} from './hub.mjs'
+import {
+	createLinkSecret,
+	loadLiveSession,
+	mintLiveBridgeToken,
+	saveLiveSession,
+} from './session.mjs'
+
+/** @type {Map<string, () => void>} liveKey → teardown */
+const activeTeardowns = new Map()
+
+/**
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {string} map key
+ */
+function liveKey(entityHash, liveId) {
+	return liveSignalRoomKey(entityHash, liveId)
+}
+
+/**
+ * 发起连线邀请（对端须已在播）。
+ * @param {string} username replica
+ * @param {string} entityHash 本端主播
+ * @param {string} liveId 本端直播
+ * @param {{ peerEntityHash: string, peerLiveId: string, bridgeOrigin?: string }} target 对端
+ * @returns {Promise<object>} 邀请结果
+ */
+export async function inviteLiveLink(username, entityHash, liveId, target) {
+	const session = loadLiveSession(username, entityHash, liveId)
+	if (!session || session.status !== 'live') throw httpError(404, 'not live')
+	if (session.link) throw httpError(409, 'already linked')
+	const peerEntityHash = String(target.peerEntityHash || '').toLowerCase()
+	const peerLiveId = String(target.peerLiveId || '').toLowerCase()
+	if (!peerEntityHash || !peerLiveId) throw httpError(400, 'peer required')
+	if (peerEntityHash === entityHash.toLowerCase() && peerLiveId === liveId.toLowerCase())
+		throw httpError(400, 'cannot link self')
+
+	const bridgeOrigin = String(target.bridgeOrigin || session.bridgeOrigin || '').trim().replace(/\/$/, '')
+	const { data, errors } = await collectSocialRpcMerged(username, {
+		type: 'live_link_invite',
+		fromEntityHash: entityHash.toLowerCase(),
+		fromLiveId: liveId.toLowerCase(),
+		fromNodeHash: getNodeHash(),
+		fromAvRoomId: session.avRoomId,
+		fromBridgeOrigin: bridgeOrigin || null,
+		fromTitle: session.title,
+		peerEntityHash,
+		peerLiveId,
+	}, 4000, 12)
+
+	const accepted = data.find(row => row?.type === 'live_link_accept' && row.ok)
+	if (!accepted) {
+		pushFeedUpdate(username, {
+			type: 'live_link_invite_sent',
+			liveId,
+			peerEntityHash,
+			peerLiveId,
+			errors,
+		})
+		return { status: 'invited', errors }
+	}
+
+	await applyLinkPair(username, entityHash, liveId, {
+		peerEntityHash: accepted.peerEntityHash || peerEntityHash,
+		peerLiveId: accepted.peerLiveId || peerLiveId,
+		peerNodeHash: accepted.peerNodeHash || '',
+		peerAvRoomId: accepted.peerAvRoomId || `social:${peerEntityHash}:${peerLiveId}`,
+		peerBridgeOrigin: accepted.peerBridgeOrigin || null,
+		linkSecret: accepted.linkSecret,
+		since: Date.now(),
+	})
+	return { status: 'linked', link: loadLiveSession(username, entityHash, liveId)?.link }
+}
+
+/**
+ * 入站邀请处理（RPC）：若本机有对端场次则自动接受并建立桥。
+ * @param {string} username replica
+ * @param {object} rpc invite 体
+ * @returns {Promise<object>} accept / reject
+ */
+export async function handleLiveLinkInviteRpc(username, rpc) {
+	const peerEntityHash = String(rpc.peerEntityHash || '').toLowerCase()
+	const peerLiveId = String(rpc.peerLiveId || '').toLowerCase()
+	const session = loadLiveSession(username, peerEntityHash, peerLiveId)
+	if (!session || session.status !== 'live')
+		return { type: 'live_link_accept', ok: false, reason: 'not_live' }
+	if (session.link)
+		return { type: 'live_link_accept', ok: false, reason: 'already_linked' }
+
+	const linkSecret = createLinkSecret()
+	const fromEntityHash = String(rpc.fromEntityHash || '').toLowerCase()
+	const fromLiveId = String(rpc.fromLiveId || '').toLowerCase()
+
+	pushFeedUpdate(username, {
+		type: 'live_link_invite',
+		fromEntityHash,
+		fromLiveId,
+		fromTitle: rpc.fromTitle,
+		peerEntityHash,
+		peerLiveId,
+	})
+
+	await applyLinkPair(username, peerEntityHash, peerLiveId, {
+		peerEntityHash: fromEntityHash,
+		peerLiveId: fromLiveId,
+		peerNodeHash: String(rpc.fromNodeHash || ''),
+		peerAvRoomId: String(rpc.fromAvRoomId || `social:${fromEntityHash}:${fromLiveId}`),
+		peerBridgeOrigin: rpc.fromBridgeOrigin || null,
+		linkSecret,
+		since: Date.now(),
+	})
+
+	return {
+		type: 'live_link_accept',
+		ok: true,
+		linkSecret,
+		peerEntityHash,
+		peerLiveId,
+		peerNodeHash: getNodeHash(),
+		peerAvRoomId: session.avRoomId,
+		peerBridgeOrigin: session.bridgeOrigin || null,
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 本端
+ * @param {string} liveId 本端
+ * @param {object} link 连线描述
+ * @returns {Promise<void>}
+ */
+async function applyLinkPair(username, entityHash, liveId, link) {
+	const session = loadLiveSession(username, entityHash, liveId)
+	if (!session || session.status !== 'live') return
+	session.link = link
+	saveLiveSession(username, entityHash, session)
+
+	const key = liveKey(entityHash, liveId)
+	teardownLocal(key)
+
+	const peerKey = liveKey(link.peerEntityHash, link.peerLiveId)
+	const sameNode = !link.peerNodeHash || link.peerNodeHash === getNodeHash()
+		|| Boolean(loadLiveSession(username, link.peerEntityHash, link.peerLiveId))
+
+	/** @type {Array<() => void>} */
+	const teardowns = []
+
+	if (sameNode) {
+		const peerSession = loadLiveSession(username, link.peerEntityHash, link.peerLiveId)
+		if (peerSession?.status === 'live') {
+			teardowns.push(bridgeAvRooms(session.avRoomId, peerSession.avRoomId))
+			teardowns.push(bridgeLiveSignalRooms(key, peerKey))
+			if (!peerSession.link) {
+				peerSession.link = {
+					peerEntityHash: entityHash.toLowerCase(),
+					peerLiveId: liveId.toLowerCase(),
+					peerNodeHash: getNodeHash(),
+					peerAvRoomId: session.avRoomId,
+					peerBridgeOrigin: session.bridgeOrigin,
+					linkSecret: link.linkSecret,
+					since: link.since,
+				}
+				saveLiveSession(username, link.peerEntityHash, peerSession)
+			}
+		}
+	}
+	else if (link.peerBridgeOrigin) {
+		const { connectOutboundLiveBridge } = await import('./bridge.mjs')
+		const closer = await connectOutboundLiveBridge({
+			username,
+			entityHash,
+			liveId,
+			avRoomId: session.avRoomId,
+			peerBridgeOrigin: link.peerBridgeOrigin,
+			peerEntityHash: link.peerEntityHash,
+			peerLiveId: link.peerLiveId,
+			linkSecret: link.linkSecret,
+		})
+		teardowns.push(closer)
+	}
+
+	activeTeardowns.set(key, () => {
+		for (const fn of teardowns) try { fn() } catch { /* ignore */ }
+	})
+
+	broadcastLiveSignal(key, {
+		type: 'link_started',
+		peerEntityHash: link.peerEntityHash,
+		peerLiveId: link.peerLiveId,
+	})
+	pushFeedUpdate(username, {
+		type: 'live_link_started',
+		entityHash: entityHash.toLowerCase(),
+		liveId: liveId.toLowerCase(),
+		link,
+	})
+}
+
+/**
+ * @param {string} key live key
+ * @returns {void}
+ */
+function teardownLocal(key) {
+	const fn = activeTeardowns.get(key)
+	if (fn) {
+		fn()
+		activeTeardowns.delete(key)
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {Promise<object | null>} 清掉后的 session
+ */
+export async function tearDownLiveLink(username, entityHash, liveId) {
+	const session = loadLiveSession(username, entityHash, liveId)
+	if (!session?.link) return session
+	const key = liveKey(entityHash, liveId)
+	teardownLocal(key)
+	const peer = session.link
+	session.link = null
+	saveLiveSession(username, entityHash, session)
+	broadcastLiveSignal(key, { type: 'link_ended' })
+	pushFeedUpdate(username, {
+		type: 'live_link_ended',
+		entityHash: entityHash.toLowerCase(),
+		liveId: String(liveId).toLowerCase(),
+	})
+
+	const peerSession = loadLiveSession(username, peer.peerEntityHash, peer.peerLiveId)
+	if (peerSession?.link) {
+		teardownLocal(liveKey(peer.peerEntityHash, peer.peerLiveId))
+		peerSession.link = null
+		saveLiveSession(username, peer.peerEntityHash, peerSession)
+		broadcastLiveSignal(liveKey(peer.peerEntityHash, peer.peerLiveId), { type: 'link_ended' })
+	}
+	return session
+}
+
+/**
+ * @param {string} linkSecret 密钥
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {string} token
+ */
+export function liveBridgeTokenFor(linkSecret, entityHash, liveId) {
+	return mintLiveBridgeToken(linkSecret, entityHash, liveId)
+}

--- a/src/public/parts/shells/social/src/live/network.mjs
+++ b/src/public/parts/shells/social/src/live/network.mjs
@@ -1,0 +1,89 @@
+/**
+ * 联邦在播列表 part_query。
+ */
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { queryNetwork } from 'npm:@steve02081504/fount-p2p/wire/part_query'
+
+import { buildLiveFeed } from './feed.mjs'
+
+/**
+ *
+ */
+export const LIVE_FEED_KIND = 'live_feed'
+
+/**
+ * @param {{ replicaUsername?: string }} inboundContext 上下文
+ * @param {unknown} query 查询
+ * @returns {Promise<object[]>} rows
+ */
+export async function localLiveFeedHandler(inboundContext, query) {
+	const username = String(inboundContext.replicaUsername || '').trim()
+	if (!username) return []
+	const limit = Math.min(Math.max(Number(
+		query && typeof query === 'object' ? /** @type {{ limit?: unknown }} */query.limit : 20,
+	) || 20, 1), 32)
+	const { items } = await buildLiveFeed(username, { limit, scope: 'local' })
+	const nodeHash = String(getNodeHash() || '').toLowerCase()
+	return items
+		.filter(row => row.visibility === 'public' || !row.visibility)
+		.map(row => ({
+			liveId: row.liveId,
+			entityHash: row.entityHash,
+			title: String(row.title || '').slice(0, 120),
+			viewerCount: Number(row.viewerCount) || 0,
+			likeCount: Number(row.likeCount) || 0,
+			startedAt: Number(row.startedAt) || 0,
+			avRoomId: row.avRoomId,
+			bridgeOrigin: row.bridgeOrigin || null,
+			watchSecret: row.publicWatchSecret || null,
+			nodeHash,
+		}))
+}
+
+/**
+ * @param {string} username replica
+ * @param {{ limit?: number }} [options] 选项
+ * @returns {Promise<{ items: object[], nextCursor: null, scope: 'nearby' }>} 附近在播
+ */
+export async function buildNearbyLiveFeed(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 20, 1), 50)
+	const rows = await queryNetwork(username, getShellPartpath('social'), LIVE_FEED_KIND, { limit }, {
+		maxHits: 64,
+		/**
+		 * @param {object} row 网络行
+		 * @returns {string} 去重键
+		 */
+		rowKey: row => {
+			if (!row || typeof row !== 'object') return ''
+			const entityHash = String(/** @type {{ entityHash?: unknown }} */row.entityHash || '').toLowerCase()
+			const liveId = String(/** @type {{ liveId?: unknown }} */row.liveId || '').toLowerCase()
+			return entityHash && liveId ? `${entityHash}:${liveId}` : ''
+		},
+	})
+	const items = []
+	for (const raw of rows) {
+		if (!raw || typeof raw !== 'object') continue
+		const entityHash = String(/** @type {{ entityHash?: unknown }} */raw.entityHash || '').trim().toLowerCase()
+		const liveId = String(/** @type {{ liveId?: unknown }} */raw.liveId || '').trim().toLowerCase()
+		if (!entityHash || !liveId) continue
+		items.push({
+			liveId,
+			entityHash,
+			title: String(/** @type {{ title?: unknown }} */raw.title || 'Live').slice(0, 120),
+			viewerCount: Math.max(0, Number(/** @type {{ viewerCount?: unknown }} */raw.viewerCount) || 0),
+			likeCount: Math.max(0, Number(/** @type {{ likeCount?: unknown }} */raw.likeCount) || 0),
+			startedAt: Number(/** @type {{ startedAt?: unknown }} */raw.startedAt) || 0,
+			avRoomId: String(/** @type {{ avRoomId?: unknown }} */raw.avRoomId || `social:${entityHash}:${liveId}`),
+			bridgeOrigin: String(/** @type {{ bridgeOrigin?: unknown }} */raw.bridgeOrigin || '') || null,
+			watchSecret: String(/** @type {{ watchSecret?: unknown }} */raw.watchSecret || '') || null,
+			visibility: 'public',
+			status: 'live',
+			federated: true,
+			nodeHash: String(/** @type {{ nodeHash?: unknown }} */raw.nodeHash || '').toLowerCase(),
+		})
+		if (items.length >= limit) break
+	}
+	items.sort((a, b) => (b.viewerCount || 0) - (a.viewerCount || 0) || (b.startedAt || 0) - (a.startedAt || 0))
+	return { items, nextCursor: null, scope: 'nearby' }
+}

--- a/src/public/parts/shells/social/src/live/notify.mjs
+++ b/src/public/parts/shells/social/src/live/notify.mjs
@@ -1,0 +1,59 @@
+/**
+ * 开播通知：本机关注者 inbox + Web Push。
+ */
+import fs from 'node:fs'
+
+import { appendJsonlSynced } from 'npm:@steve02081504/fount-p2p/dag/storage'
+
+import { notifyUser } from '../../../../../../server/web_server/notify/notify.mjs'
+import { listLocalFollowersOf } from '../federation/follower/index.mjs'
+import {
+	computeAggregateKey,
+	inboxDir,
+	inboxEventsPath,
+	normalizeNotificationRow,
+	notificationSnippet,
+} from '../inbox.mjs'
+import { canWriteTimeline } from '../timeline/append.mjs'
+import { pushFeedUpdate } from '../ws/feedHub.mjs'
+
+/**
+ * @param {string} username replica
+ * @param {string} authorEntityHash 主播
+ * @param {object} session 直播会话
+ * @returns {Promise<void>}
+ */
+export async function notifyFollowersLiveStarted(username, authorEntityHash, session) {
+	const author = authorEntityHash.toLowerCase()
+	const followers = await listLocalFollowersOf(author)
+	const at = Date.now()
+	const snippet = notificationSnippet(session.title || 'live')
+	for (const row of followers) {
+		if (row.replicaUsername !== username) continue
+		const recipient = String(row.entityHash || '').toLowerCase()
+		if (!recipient || recipient === author) continue
+		if (!await canWriteTimeline(username, recipient)) continue
+		const notification = {
+			...normalizeNotificationRow('live_started', author, at, null, null),
+			snippet,
+			liveId: session.liveId,
+			aggregateKey: computeAggregateKey({
+				type: 'live_started',
+				actorEntityHash: author,
+				postId: null,
+				targetPostId: null,
+				at,
+				snippet,
+			}, recipient),
+		}
+		fs.mkdirSync(inboxDir(username, recipient), { recursive: true })
+		await appendJsonlSynced(inboxEventsPath(username, recipient), notification)
+		pushFeedUpdate(username, { type: 'notification', notification })
+	}
+	void notifyUser(username, {
+		title: '直播开始',
+		body: snippet,
+		url: `/parts/shells:social/#live:${encodeURIComponent(author)}:${encodeURIComponent(session.liveId)}`,
+		tag: `live:${session.liveId}`,
+	})
+}

--- a/src/public/parts/shells/social/src/live/session.mjs
+++ b/src/public/parts/shells/social/src/live/session.mjs
@@ -1,0 +1,281 @@
+/**
+ * Social 直播会话：原生开播或挂载 chat streaming 频道；统计 / 开播帖 / 连线。
+ */
+import { Buffer } from 'node:buffer'
+import { createHmac, randomBytes, randomUUID } from 'node:crypto'
+import fs from 'node:fs'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import { loadJsonFileIfExists, saveJsonFile } from '../../../../../../scripts/json_loader.mjs'
+import { liveDanmakuPath, liveDir, liveSessionPath } from '../paths.mjs'
+import { commitTimelineEvent } from '../timeline/append.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+import { pushFeedUpdate } from '../ws/feedHub.mjs'
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId id
+ * @returns {object | null} 会话
+ */
+export function loadLiveSession(username, entityHash, liveId) {
+	return loadJsonFileIfExists(liveSessionPath(username, entityHash, liveId))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {object} session 会话
+ * @returns {void}
+ */
+export function saveLiveSession(username, entityHash, session) {
+	saveJsonFile(liveSessionPath(username, entityHash, session.liveId), session)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @returns {object[]} 活跃会话
+ */
+export function listActiveLiveSessions(username, entityHash) {
+	const dir = liveDir(username, entityHash)
+	if (!fs.existsSync(dir)) return []
+	const out = []
+	for (const name of fs.readdirSync(dir)) {
+		if (!name.endsWith('.json') || name.includes('.danmaku.')) continue
+		const row = loadJsonFileIfExists(`${dir}/${name}`)
+		if (row?.status === 'live') out.push(row)
+	}
+	return out
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {object} draft 开播草稿
+ * @returns {Promise<object>} 会话
+ */
+export async function startLiveSession(username, entityHash, draft = {}) {
+	const owner = entityHash.toLowerCase()
+	const existing = listActiveLiveSessions(username, owner)
+	if (existing.length)
+		throw httpError(409, 'already live')
+
+	const liveId = randomUUID()
+	const visibility = draft.visibility === 'followers' ? 'followers' : 'public'
+	const chatMount = draft.groupId && draft.channelId
+		? { groupId: String(draft.groupId), channelId: String(draft.channelId || 'default') }
+		: null
+	const bridgeOrigin = String(draft.bridgeOrigin || '').trim().replace(/\/$/, '')
+	const publicWatchSecret = visibility === 'public' ? createLinkSecret() : null
+	const mediaKind = ['av', 'audio', 'video', 'whip'].includes(draft.mediaKind) ? draft.mediaKind : 'av'
+	const ingestSecret = mediaKind === 'whip' ? createLinkSecret() : null
+	const session = {
+		liveId,
+		entityHash: owner,
+		title: String(draft.title || '').trim().slice(0, 120) || 'Live',
+		visibility,
+		mediaKind,
+		ingestSecret,
+		status: 'live',
+		startedAt: Date.now(),
+		viewerCount: 0,
+		likeCount: 0,
+		bridgeOrigin: bridgeOrigin || null,
+		publicWatchSecret,
+		stats: {
+			viewerHashes: [],
+			peakViewers: 0,
+			likeCount: 0,
+		},
+		chatMount,
+		avRoomId: chatMount
+			? `${chatMount.groupId}:${chatMount.channelId}`
+			: `social:${owner}:${liveId}`,
+		livePostId: null,
+		link: null,
+	}
+	fs.mkdirSync(liveDir(username, owner), { recursive: true })
+	saveLiveSession(username, owner, session)
+
+	await commitTimelineEvent(username, owner, {
+		type: 'live_start',
+		content: {
+			liveId,
+			title: session.title,
+			visibility,
+			mediaKind,
+			avRoomId: session.avRoomId,
+			bridgeOrigin: session.bridgeOrigin,
+			...chatMount ? { chatMount } : {},
+		},
+	})
+
+	const postEvent = await commitTimelineEvent(username, owner, {
+		type: 'post',
+		content: {
+			text: session.title,
+			visibility,
+			liveRef: {
+				entityHash: owner,
+				liveId,
+				status: 'live',
+				startedAt: session.startedAt,
+			},
+		},
+	})
+	session.livePostId = postEvent.id
+	saveLiveSession(username, owner, session)
+
+	const { notifyFollowersLiveStarted } = await import('./notify.mjs')
+	await notifyFollowersLiveStarted(username, owner, session)
+	pushFeedUpdate(username, { type: 'live_started', live: session })
+	return session
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId id
+ * @returns {Promise<object>} 结束结果
+ */
+export async function stopLiveSession(username, entityHash, liveId) {
+	const owner = entityHash.toLowerCase()
+	const id = String(liveId || '').trim().toLowerCase()
+	const session = loadLiveSession(username, owner, id)
+	if (!session) throw httpError(404, 'live not found')
+
+	if (session.link) {
+		const { tearDownLiveLink } = await import('./link.mjs')
+		await tearDownLiveLink(username, owner, id).catch(() => {})
+	}
+
+	session.status = 'ended'
+	session.endedAt = Date.now()
+	const duration = Math.max(0, session.endedAt - (session.startedAt || session.endedAt))
+	const totalViewers = Array.isArray(session.stats?.viewerHashes)
+		? session.stats.viewerHashes.length
+		: 0
+	const totalLikes = Number(session.stats?.likeCount || session.likeCount || 0)
+	session.liveStats = { duration, totalViewers, totalLikes, peakViewers: session.stats?.peakViewers || 0 }
+	saveLiveSession(username, owner, session)
+
+	await commitTimelineEvent(username, owner, {
+		type: 'live_end',
+		content: { liveId: id, ...session.liveStats },
+	})
+
+	if (session.livePostId)
+		await commitTimelineEvent(username, owner, {
+			type: 'post_edit',
+			content: {
+				targetPostId: session.livePostId,
+				text: session.title,
+				liveRef: {
+					entityHash: owner,
+					liveId: id,
+					status: 'ended',
+					startedAt: session.startedAt,
+					endedAt: session.endedAt,
+					...session.liveStats,
+				},
+			},
+		}).catch(error => console.error('live: post_edit on stop failed', error))
+
+	pushFeedUpdate(username, { type: 'live_ended', liveId: id, entityHash: owner, liveStats: session.liveStats })
+	return session
+}
+
+/**
+ * 节流回写观众/点赞统计到 session。
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId id
+ * @param {{ viewerCount?: number, viewerEntityHash?: string, likeDelta?: number }} patch 增量
+ * @returns {object | null} 更新后会话
+ */
+export function patchLiveStats(username, entityHash, liveId, patch = {}) {
+	const session = loadLiveSession(username, entityHash, liveId)
+	if (!session || session.status !== 'live') return null
+	if (!session.stats)
+		session.stats = { viewerHashes: [], peakViewers: 0, likeCount: 0 }
+	if (typeof patch.viewerCount === 'number') {
+		session.viewerCount = Math.max(0, patch.viewerCount)
+		session.stats.peakViewers = Math.max(session.stats.peakViewers || 0, session.viewerCount)
+	}
+	const viewer = String(patch.viewerEntityHash || '').toLowerCase()
+	if (viewer) {
+		const set = new Set(session.stats.viewerHashes || [])
+		set.add(viewer)
+		session.stats.viewerHashes = [...set]
+	}
+	if (patch.likeDelta)
+		session.stats.likeCount = Math.max(0, (session.stats.likeCount || 0) + Number(patch.likeDelta))
+	session.likeCount = session.stats.likeCount || 0
+	saveLiveSession(username, entityHash, session)
+	return session
+}
+
+/**
+ * @param {string} linkSecret 连线密钥
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {string} HMAC token
+ */
+export function mintLiveBridgeToken(linkSecret, entityHash, liveId) {
+	return createHmac('sha256', Buffer.from(String(linkSecret), 'utf8'))
+		.update(`${entityHash.toLowerCase()}\0${String(liveId).toLowerCase()}`)
+		.digest('base64url')
+}
+
+/**
+ * @param {string} token 令牌
+ * @param {string} linkSecret 密钥
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {boolean} 是否有效
+ */
+export function verifyLiveBridgeToken(token, linkSecret, entityHash, liveId) {
+	if (!token || !linkSecret) return false
+	const expect = mintLiveBridgeToken(linkSecret, entityHash, liveId)
+	return token === expect
+}
+
+/**
+ * @returns {string} 随机 linkSecret
+ */
+export function createLinkSecret() {
+	return randomBytes(24).toString('base64url')
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId id
+ * @param {object} row 弹幕
+ * @returns {void}
+ */
+export function appendLiveDanmaku(username, entityHash, liveId, row) {
+	const path = liveDanmakuPath(username, entityHash, liveId)
+	fs.mkdirSync(liveDir(username, entityHash), { recursive: true })
+	fs.appendFileSync(path, `${JSON.stringify(row)}\n`, 'utf8')
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} [liveId] 可选指定
+ * @returns {Promise<object | null>} 活跃会话
+ */
+export async function getActiveLiveForEntity(username, entityHash, liveId = null) {
+	if (liveId) {
+		const session = loadLiveSession(username, entityHash, liveId)
+		return session?.status === 'live' ? session : null
+	}
+	const view = await getTimelineMaterialized(username, entityHash)
+	const lives = Object.values(view.activeLives || {})
+	if (!lives.length) return listActiveLiveSessions(username, entityHash)[0] || null
+	const event = lives[lives.length - 1]
+	const id = String(event.content?.liveId || event.id || '').toLowerCase()
+	return loadLiveSession(username, entityHash, id)
+}

--- a/src/public/parts/shells/social/src/live/viewerProxy.mjs
+++ b/src/public/parts/shells/social/src/live/viewerProxy.mjs
@@ -1,0 +1,112 @@
+/**
+ * 联邦直播观众代理：本节点连主播 public watch bridge，多本地观众复用。
+ */
+import WebSocket from 'npm:ws'
+
+import { httpError } from '../../../../../../scripts/http_error.mjs'
+import {
+	injectAvRelayFrame,
+	injectAvRelayControl,
+} from '../../../chat/src/chat/ws/avRelay.mjs'
+
+import { ingestBridgedLiveSignal } from './hub.mjs'
+import {
+	loadLiveSession,
+	mintLiveBridgeToken,
+	saveLiveSession,
+} from './session.mjs'
+
+/** @type {Map<string, { closer: () => void, session: object }>} */
+const proxies = new Map()
+
+/**
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @returns {string} key
+ */
+function proxyKey(entityHash, liveId) {
+	return `${entityHash.toLowerCase()}:${String(liveId).toLowerCase()}`
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播
+ * @param {{ bridgeOrigin?: string, nodeHash?: string, title?: string, watchSecret?: string }} hint 发现条目
+ * @returns {Promise<object>} session
+ */
+export async function ensureFederatedLiveProxy(username, entityHash, liveId, hint = {}) {
+	const existing = loadLiveSession(username, entityHash, liveId)
+	if (existing?.status === 'live' && !existing.federatedProxy) return existing
+	if (existing?.status === 'live' && existing.federatedProxy && proxies.has(proxyKey(entityHash, liveId)))
+		return existing
+
+	const key = proxyKey(entityHash, liveId)
+	if (proxies.has(key)) return proxies.get(key).session
+
+	const bridgeOrigin = String(hint.bridgeOrigin || '').replace(/\/$/, '')
+	const watchSecret = String(hint.watchSecret || '')
+	if (!bridgeOrigin || !watchSecret) throw httpError(404, 'live not reachable')
+
+	const avRoomId = `social-proxy:${entityHash}:${liveId}`
+	const session = {
+		liveId: String(liveId).toLowerCase(),
+		entityHash: entityHash.toLowerCase(),
+		title: hint.title || 'Live',
+		visibility: 'public',
+		status: 'live',
+		startedAt: Date.now(),
+		viewerCount: 0,
+		likeCount: 0,
+		avRoomId,
+		federatedProxy: true,
+		bridgeOrigin,
+		nodeHash: hint.nodeHash || '',
+		stats: { viewerHashes: [], peakViewers: 0, likeCount: 0 },
+	}
+	saveLiveSession(username, entityHash, session)
+
+	const token = mintLiveBridgeToken(watchSecret, entityHash, liveId)
+	const wsUrl = `${bridgeOrigin.replace(/^http/, 'ws')}/ws/parts/shells:social/live-bridge/${encodeURIComponent(entityHash)}/${encodeURIComponent(liveId)}?token=${encodeURIComponent(token)}`
+
+	let remote
+	try {
+		remote = new WebSocket(wsUrl)
+		await new Promise((resolve, reject) => {
+			remote.once('open', resolve)
+			remote.once('error', reject)
+			setTimeout(() => reject(new Error('proxy timeout')), 8_000)
+		})
+	}
+	catch (error) {
+		session.status = 'ended'
+		saveLiveSession(username, entityHash, session)
+		throw httpError(502, `live proxy failed: ${error?.message || error}`)
+	}
+
+	remote.on('message', (data, isBinary) => {
+		if (isBinary) {
+			injectAvRelayFrame(avRoomId, data)
+			return
+		}
+		let wireMessage
+		try { wireMessage = JSON.parse(String(data)) }
+		catch { return }
+		if (wireMessage?.type === 'publish_meta' || wireMessage?.type === 'publish_meta_revoke') {
+			injectAvRelayControl(avRoomId, wireMessage)
+			return
+		}
+		ingestBridgedLiveSignal(username, entityHash, liveId, wireMessage)
+	})
+
+	/**
+	 *
+	 */
+	const closer = () => {
+		try { remote.close() } catch { /* ignore */ }
+		proxies.delete(key)
+	}
+	remote.on('close', closer)
+	proxies.set(key, { closer, session })
+	return session
+}

--- a/src/public/parts/shells/social/src/manifestAcl.mjs
+++ b/src/public/parts/shells/social/src/manifestAcl.mjs
@@ -1,0 +1,34 @@
+import {
+	registerManifestAcl,
+	registerManifestAclMatcher,
+	unregisterManifestAcl,
+	unregisterManifestAclMatcher,
+} from 'npm:@steve02081504/fount-p2p/files/manifest_acl_registry'
+
+import { canViewVaultFile } from './vaultAcl.mjs'
+
+const OWNER_ID = 'social'
+
+/**
+ * 注册 Social Shell 提供的 vault-wrap manifest ACL。
+ * @returns {void}
+ */
+export function registerSocialManifestAcl() {
+	registerManifestAclMatcher(OWNER_ID, manifest =>
+		manifest?.transferKeyDescriptor?.type === 'vault-wrap' ? 'vault-wrap' : null,
+	)
+	registerManifestAcl('vault-wrap', OWNER_ID, async context =>
+		canViewVaultFile(
+			context.replicaUsername,
+			context.ownerEntityHash,
+			context.manifest,
+			context.viewerEntityHash,
+		),
+	)
+}
+
+/** @returns {void} */
+export function unregisterSocialManifestAcl() {
+	unregisterManifestAclMatcher(OWNER_ID)
+	unregisterManifestAcl('vault-wrap', OWNER_ID)
+}

--- a/src/public/parts/shells/social/src/manifestTransfer.mjs
+++ b/src/public/parts/shells/social/src/manifestTransfer.mjs
@@ -1,0 +1,33 @@
+import {
+	registerManifestOwnerMatcher,
+	registerTransferKeyDependencies,
+	unregisterTransferKeyDependencies,
+} from 'npm:@steve02081504/fount-p2p/files/transfer_key_registry'
+
+import { loadVaultMasterKey } from './vault_crypto/vault.mjs'
+
+const OWNER_ID = 'social'
+
+/**
+ * 注册 Social 提供的 vault-wrap transfer key 依赖。
+ * @returns {void}
+ */
+export function registerSocialManifestTransfer() {
+	registerManifestOwnerMatcher(OWNER_ID, manifest => manifest.transferKeyDescriptor?.type === 'vault-wrap')
+	registerTransferKeyDependencies(OWNER_ID, {
+		/**
+		 * @param {string} replicaUsername replica
+		 * @param {string} entityHash vault entity
+		 * @returns {Promise<Buffer | string | null>} 密钥材料
+		 */
+		async getVaultMasterKey(replicaUsername, entityHash) {
+			const state = await loadVaultMasterKey(replicaUsername, entityHash)
+			return state.masterKey
+		},
+	})
+}
+
+/** @returns {void} */
+export function unregisterSocialManifestTransfer() {
+	unregisterTransferKeyDependencies(OWNER_ID)
+}

--- a/src/public/parts/shells/social/src/mutedKeywords.mjs
+++ b/src/public/parts/shells/social/src/mutedKeywords.mjs
@@ -1,0 +1,52 @@
+import { createShellJsonNamespace } from '../../chat/src/api/client/helpers.mjs'
+
+import { pruneMutedKeywordEntries } from './lib/contentFilter.mjs'
+
+/**
+ * @param {object} stored 原始存储
+ * @returns {{ entries: object[] }} 规范化屏蔽词表
+ */
+function shapeMutedKeywords(stored) {
+	return { entries: pruneMutedKeywordEntries(stored?.entries || []) }
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {{ list: Function, set: Function }} shell JSON 命名空间
+ */
+function mutedKeywordsNamespace(username, entityHash) {
+	return createShellJsonNamespace(username, 'social', entityHash, 'muted_keywords', shapeMutedKeywords)
+}
+
+/**
+ * 读取实体关键词/标签屏蔽表（本地私有，不联邦）。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {Promise<{ entries: object[] }>} 屏蔽词表
+ */
+export async function loadMutedKeywords(username, entityHash) {
+	return mutedKeywordsNamespace(username, entityHash).list()
+}
+
+/**
+ * 持久化关键词屏蔽表。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {{ entries?: object[] }} data 数据
+ * @returns {Promise<{ entries: object[] }>} 写入后的表
+ */
+export async function saveMutedKeywords(username, entityHash, data) {
+	return mutedKeywordsNamespace(username, entityHash).set(shapeMutedKeywords(data || {}))
+}
+
+/**
+ * 覆盖或合并替换屏蔽词表。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {object[]} entries 新条目
+ * @returns {Promise<{ entries: object[] }>} 结果
+ */
+export async function replaceMutedKeywords(username, entityHash, entries) {
+	return saveMutedKeywords(username, entityHash, { entries })
+}

--- a/src/public/parts/shells/social/src/notifications.mjs
+++ b/src/public/parts/shells/social/src/notifications.mjs
@@ -1,0 +1,29 @@
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../chat/src/entity/identity.mjs'
+
+import { readInboxNotifications, notificationCursor } from './inbox.mjs'
+
+/**
+ *
+ */
+export { notificationCursor }
+
+/**
+ * 构建观看者的 Social 通知列表（inbox 持久层）。
+ * @param {string} username 用户
+ * @param {object} [options] 分页选项
+ * @param {string} [options.viewerEntityHash] 观看实体；缺省 = operator
+ * @param {number} [options.limit=30] 条数上限
+ * @param {string} [options.cursor] 分页游标
+ * @param {string[] | null} [options.types] 类型过滤
+ * @returns {Promise<{ notifications: object[], nextCursor: string | null, unreadCount: number, viewerEntityHash: string | null }>} 通知列表
+ */
+export async function buildNotifications(username, options = {}) {
+	const viewerEntityHash = String(options.viewerEntityHash || '').trim().toLowerCase()
+		|| (await resolveOperatorEntityHash(username))?.toLowerCase()
+		|| null
+	if (!viewerEntityHash)
+		return { notifications: [], nextCursor: null, unreadCount: 0, viewerEntityHash: null }
+	const page = await readInboxNotifications(username, viewerEntityHash, options)
+	return { ...page, viewerEntityHash }
+}

--- a/src/public/parts/shells/social/src/paths.mjs
+++ b/src/public/parts/shells/social/src/paths.mjs
@@ -1,0 +1,156 @@
+import { getUserDictionary } from '../../../../../server/auth/index.mjs'
+
+import { timelineGroupId } from './federation/namespace.mjs'
+
+/**
+ * 返回指定 entity 时间线目录路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 128 hex
+ * @returns {string} 时间线目录
+ */
+export function timelineDir(username, entityHash) {
+	return `${getUserDictionary(username)}/shells/social/timelines/${entityHash.toLowerCase()}`
+}
+
+/**
+ * 返回 events.jsonl 文件路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 128 hex
+ * @returns {string} events.jsonl 路径
+ */
+export function timelineEventsPath(username, entityHash) {
+	return `${timelineDir(username, entityHash)}/events.jsonl`
+}
+
+/**
+ * 返回物化快照 JSON 文件路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 128 hex
+ * @returns {string} 物化快照路径
+ */
+export function timelineSnapshotPath(username, entityHash) {
+	return `${timelineDir(username, entityHash)}/snapshot.json`
+}
+
+/**
+ * 返回 GSH vault 状态文件路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 128 hex
+ * @returns {string} GSH vault 状态
+ */
+export function vaultStatePath(username, entityHash) {
+	return `${timelineDir(username, entityHash)}/vault_master_key.json`
+}
+
+/**
+ * 返回实体私有 savedPosts.json 文件路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {string} savedPosts.json
+ */
+export function savedPostsPath(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return `${getUserDictionary(username)}/shells/social/entities/${hash}/savedPosts.json`
+}
+
+/**
+ * 返回实体私有草稿箱 drafts.json 文件路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {string} drafts.json
+ */
+export function draftsPath(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return `${getUserDictionary(username)}/shells/social/entities/${hash}/drafts.json`
+}
+
+/**
+ * 实体本地关键词/标签屏蔽表路径。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {string} muted_keywords.json
+ */
+export function mutedKeywordsPath(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return `${getUserDictionary(username)}/shells/social/entities/${hash}/muted_keywords.json`
+}
+
+/**
+ * Social 全文搜索与辅助索引根目录。
+ * @param {string} username replica
+ * @returns {string} search 目录
+ */
+export function socialSearchIndexPath(username) {
+	return `${getUserDictionary(username)}/shells/social/search`
+}
+
+/**
+ * 回复反向索引文件。
+ * @param {string} username replica
+ * @returns {string} replies.json 路径
+ */
+export function socialReplyIndexPath(username) {
+	return `${socialSearchIndexPath(username)}/replies.json`
+}
+
+/**
+ * 话题计数物化文件。
+ * @param {string} username replica
+ * @returns {string} trending.json 路径
+ */
+export function socialTrendingIndexPath(username) {
+	return `${socialSearchIndexPath(username)}/trending.json`
+}
+
+/**
+ * 定时发帖队列文件。
+ * @param {string} username replica
+ * @param {string} entityHash 实体
+ * @returns {string} scheduled.json
+ */
+export function scheduledPostsPath(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return `${getUserDictionary(username)}/shells/social/scheduled/${hash}.json`
+}
+
+/**
+ * 直播会话目录。
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @returns {string} live 目录
+ */
+export function liveDir(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return `${getUserDictionary(username)}/shells/social/live/${hash}`
+}
+
+/**
+ * 单场直播会话元数据。
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播 id
+ * @returns {string} live.json
+ */
+export function liveSessionPath(username, entityHash, liveId) {
+	return `${liveDir(username, entityHash)}/${String(liveId).trim().toLowerCase()}.json`
+}
+
+/**
+ * 直播弹幕 JSONL。
+ * @param {string} username replica
+ * @param {string} entityHash 主播
+ * @param {string} liveId 直播 id
+ * @returns {string} danmaku.jsonl
+ */
+export function liveDanmakuPath(username, entityHash, liveId) {
+	return `${liveDir(username, entityHash)}/${String(liveId).trim().toLowerCase()}.danmaku.jsonl`
+}
+
+/**
+ * 返回时间线对应的 DAG groupId。
+ * @param {string} entityHash 128 hex
+ * @returns {string} DAG groupId
+ */
+export function groupIdForTimeline(entityHash) {
+	return timelineGroupId(entityHash)
+}

--- a/src/public/parts/shells/social/src/personalBlock.mjs
+++ b/src/public/parts/shells/social/src/personalBlock.mjs
@@ -1,0 +1,58 @@
+import { rebuildPersonalBlockIndex } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+import { applyBlockReputationSignal } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../chat/src/entity/identity.mjs'
+
+import { commitTimelineEvent } from './timeline/append.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * 以指定实体公开拉黑或解除拉黑（联邦时间线事件 + 本地索引 + 信誉）。
+ * @param {string} username replica
+ * @param {string} entityHash 发起方实体
+ * @param {string} targetEntityHash 目标实体
+ * @param {boolean} block true=拉黑
+ * @returns {Promise<string[]>} 物化后的公开拉黑名单
+ */
+export async function setPersonalBlock(username, entityHash, targetEntityHash, block) {
+	const actor = String(entityHash || '').trim().toLowerCase()
+	const target = String(targetEntityHash || '').trim().toLowerCase()
+	await commitTimelineEvent(username, actor, {
+		type: block ? 'block' : 'unblock',
+		content: { targetEntityHash: target },
+	})
+	const view = await getTimelineMaterialized(username, actor)
+	await rebuildPersonalBlockIndex(actor, view.blocked || [])
+	const operator = await resolveOperatorEntityHash(username)
+	const selfTrust = operator?.toLowerCase() === actor
+	await applyBlockReputationSignal({
+		followerEntityHash: actor,
+		targetEntityHash: target,
+		action: block ? 'block' : 'unblock',
+		selfTrust,
+	})
+	return view.blocked || []
+}
+
+/**
+ * 时间线 block/unblock 入站后同步索引与信誉（关注者视角）。
+ * @param {string} username replica
+ * @param {string} ownerEntityHash 时间线 owner
+ * @param {object} event block/unblock 事件
+ * @param {Set<string>} followedEntities 本机关注的实体（含 operator 自身）
+ * @returns {Promise<void>}
+ */
+export async function handleInboundPersonalBlockEvent(username, ownerEntityHash, event, followedEntities) {
+	const owner = String(ownerEntityHash || '').trim().toLowerCase()
+	if (!followedEntities.has(owner)) return
+	const target = String(event?.content?.targetEntityHash || '').trim().toLowerCase()
+	if (!target) return
+	const view = await getTimelineMaterialized(username, owner)
+	await rebuildPersonalBlockIndex(owner, view.blocked || [])
+	await applyBlockReputationSignal({
+		followerEntityHash: owner,
+		targetEntityHash: target,
+		action: event.type === 'block' ? 'block' : 'unblock',
+		selfTrust: false,
+	})
+}

--- a/src/public/parts/shells/social/src/savedPosts.mjs
+++ b/src/public/parts/shells/social/src/savedPosts.mjs
@@ -1,0 +1,231 @@
+import { randomUUID } from 'node:crypto'
+
+import { formatHashShort } from 'fount/public/parts/shells/chat/public/shared/entityHash.mjs'
+
+import { httpError } from '../../../../../scripts/http_error.mjs'
+
+import { loadEntityJson, saveEntityJson } from './lib/entityJson.mjs'
+import { getEntityProfile } from './lib/entityProfile.mjs'
+import { savedPostsPath } from './paths.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+import { maybeDecryptPostContent } from './vault_crypto/vault.mjs'
+
+/**
+ * @returns {{ folders: Record<string, never>, unfiled: object[] }} 空收藏结构（每次新对象，避免跨实体污染）
+ */
+function emptySaved() {
+	return { folders: {}, unfiled: [] }
+}
+
+/**
+ * 为收藏引用补充预览文本与作者名。
+ * @param {string} username 用户
+ * @param {object} ref 帖子引用
+ * @returns {Promise<object>} 带 preview / authorName 的引用
+ */
+async function enrichPostRef(username, ref) {
+	const entityHash = ref.entityHash.toLowerCase()
+	const postId = ref.postId
+	const base = { entityHash, postId }
+	const view = await getTimelineMaterialized(username, entityHash)
+	const post = view.postById?.[postId]
+	if (!post) return base
+	const content = await maybeDecryptPostContent(username, entityHash, post.content)
+	const profile = await getEntityProfile(username, entityHash)
+	let preview = ''
+	if (!content) preview = '[unavailable]'
+	else if (content?.text) preview = content.text.slice(0, 120)
+	else if (content?.mediaRefs?.length) preview = '[media]'
+	return {
+		...base,
+		preview,
+		authorName: profile?.name || formatHashShort(entityHash, { headLen: 8, tailLen: 0 }),
+		savedAt: ref.savedAt,
+	}
+}
+
+/**
+ * 为收藏夹结构中的帖子引用补充预览信息。
+ * @param {string} username 用户
+ * @param {object} data 收藏结构
+ * @returns {Promise<object>} 带预览的收藏结构
+ */
+export async function enrichSavedPosts(username, data) {
+	const folders = {}
+	for (const [folderId, folder] of Object.entries(data.folders)) {
+		const posts = []
+		for (const ref of folder.posts)
+			posts.push(await enrichPostRef(username, ref))
+		folders[folderId] = { name: folder.name, posts }
+	}
+	const unfiled = []
+	for (const ref of data.unfiled)
+		unfiled.push(await enrichPostRef(username, ref))
+	return { folders, unfiled }
+}
+
+/**
+ * 读取实体收藏帖与文件夹结构。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @returns {Promise<{ folders: Record<string, { name: string, posts: object[] }>, unfiled: object[] }>} 收藏结构
+ */
+export async function loadSavedPosts(username, entityHash) {
+	try {
+		return await loadEntityJson(savedPostsPath(username, entityHash), emptySaved)
+	}
+	catch {
+		return emptySaved()
+	}
+}
+
+/**
+ * 持久化实体收藏帖与文件夹结构。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {object} data 收藏结构
+ * @returns {Promise<object>} 写入后的收藏结构
+ */
+export async function saveSavedPosts(username, entityHash, data) {
+	return saveEntityJson(savedPostsPath(username, entityHash), data)
+}
+
+/**
+ * 将帖子引用加入收藏（指定文件夹或未归档）。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {object} postRef { entityHash, postId }
+ * @param {string | null} folderId 文件夹；null=未归档
+ * @returns {Promise<object>} 写入后的收藏结构
+ */
+export async function addSavedPost(username, entityHash, postRef, folderId = null) {
+	const data = await loadSavedPosts(username, entityHash)
+	const ref = {
+		entityHash: postRef.entityHash.toLowerCase(),
+		postId: postRef.postId,
+	}
+	if (folderId) {
+		data.folders[folderId] ??= { name: folderId, posts: [] }
+		if (!data.folders[folderId].posts.some(row =>
+			row.entityHash === ref.entityHash && row.postId === ref.postId))
+			data.folders[folderId].posts.push(ref)
+	}
+	else if (!data.unfiled.some(row =>
+		row.entityHash === ref.entityHash && row.postId === ref.postId))
+		data.unfiled.push(ref)
+	return saveSavedPosts(username, entityHash, data)
+}
+
+/**
+ * 创建新的收藏文件夹。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} name 文件夹名
+ * @returns {Promise<object>} 写入后的收藏结构
+ */
+export async function createSavedFolder(username, entityHash, name) {
+	const data = await loadSavedPosts(username, entityHash)
+	const folderId = randomUUID()
+	data.folders[folderId] = { name: name || 'Folder', posts: [] }
+	return saveSavedPosts(username, entityHash, data)
+}
+
+/**
+ * 从收藏中移除帖子引用。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {object} postRef { entityHash, postId }
+ * @param {string | null} [folderId] 文件夹 id；省略则从所有文件夹与未归档移除
+ * @returns {Promise<object>} 写入后的收藏结构
+ */
+export async function removeSavedPost(username, entityHash, postRef, folderId = undefined) {
+	const data = await loadSavedPosts(username, entityHash)
+	const postEntityHash = postRef.entityHash.toLowerCase()
+	const postId = postRef.postId
+
+	if (folderId) {
+		const folder = data.folders[folderId]
+		if (folder)
+			folder.posts = folder.posts.filter(row =>
+				!(row.entityHash === postEntityHash && row.postId === postId))
+	}
+	else {
+		data.unfiled = data.unfiled.filter(row =>
+			!(row.entityHash === postEntityHash && row.postId === postId))
+		for (const folder of Object.values(data.folders))
+			folder.posts = folder.posts.filter(row =>
+				!(row.entityHash === postEntityHash && row.postId === postId))
+	}
+	return saveSavedPosts(username, entityHash, data)
+}
+
+/**
+ * 重命名收藏文件夹。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} folderId 文件夹 id
+ * @param {string} name 新名称
+ * @returns {Promise<object>} 写入后的收藏结构
+ */
+export async function renameSavedFolder(username, entityHash, folderId, name) {
+	const data = await loadSavedPosts(username, entityHash)
+	const folder = data.folders[folderId]
+	if (!folder) throw httpError(404, 'folder not found')
+	folder.name = (name || folder.name).trim() || folder.name
+	return saveSavedPosts(username, entityHash, data)
+}
+
+/**
+ * 删除收藏文件夹并将其帖子移至未归档。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} folderId 文件夹 id
+ * @returns {Promise<object>} 写入后的收藏结构（帖移至未归档）
+ */
+export async function deleteSavedFolder(username, entityHash, folderId) {
+	const data = await loadSavedPosts(username, entityHash)
+	const folder = data.folders[folderId]
+	if (!folder) return data
+	for (const ref of folder.posts) {
+		if (data.unfiled.some(row => row.entityHash === ref.entityHash && row.postId === ref.postId))
+			continue
+		data.unfiled.push(ref)
+	}
+	delete data.folders[folderId]
+	return saveSavedPosts(username, entityHash, data)
+}
+
+/**
+ * 在已加载的收藏帖中按正文/作者文本匹配搜索。
+ * @param {string} username 用户
+ * @param {string} entityHash 实体
+ * @param {string} query 搜索串
+ * @param {{ limit?: number }} [options] 选项
+ * @returns {Promise<{ posts: object[], query: string }>} 匹配的收藏（含 folderId）
+ */
+export async function searchSavedPosts(username, entityHash, query, options = {}) {
+	const q = String(query || '').trim().toLowerCase()
+	const limit = Math.min(Math.max(Number(options.limit) || 50, 1), 200)
+	const enriched = await enrichSavedPosts(username, await loadSavedPosts(username, entityHash))
+	/** @type {object[]} */
+	const posts = []
+	/**
+	 * @param {object} ref 收藏引用
+	 * @param {string | null} folderId 所在文件夹
+	 */
+	const consider = (ref, folderId) => {
+		const haystack = [
+			ref.preview,
+			ref.authorName,
+			ref.entityHash,
+		].filter(Boolean).join('\n').toLowerCase()
+		if (q && !haystack.includes(q)) return
+		posts.push({ ...ref, folderId })
+	}
+	for (const [folderId, folder] of Object.entries(enriched.folders))
+		for (const ref of folder.posts)
+			consider(ref, folderId)
+	for (const ref of enriched.unfiled)
+		consider(ref, null)
+	return { query: String(query || '').trim(), posts: posts.slice(0, limit) }
+}

--- a/src/public/parts/shells/social/src/search.mjs
+++ b/src/public/parts/shells/social/src/search.mjs
@@ -1,0 +1,103 @@
+/**
+ * 在已知时间线中搜索可见帖子（索引优先；支持结构化过滤与联邦 nearby）。
+ */
+import { buildPostFeedItem } from './feed/buildItem.mjs'
+import { loadViewerContext } from './feed/home.mjs'
+import { createFeedItemBuildContext, iterateVisiblePosts, iterateVisibleTimelineOwners } from './feed/iterate.mjs'
+import { compareFeedItems } from './feedMerge.mjs'
+import { canViewPost } from './feedVisibility.mjs'
+import { postMatchesQuery } from './lib/postQuery.mjs'
+import { hasSearchCriteria, parseSearchFilters, postMatchesFilters } from './lib/searchFilters.mjs'
+import { querySocialPostIndex } from './searchIndex.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * @param {object} item feed 条目
+ * @returns {string} 搜索分页游标
+ */
+export function searchItemCursorKey(item) {
+	const wall = Number(item.hlc?.wall || item.post?.hlc?.wall || 0)
+	return `${wall}:${item.postId}`
+}
+
+/**
+ * @param {string} username 用户
+ * @param {object} [options] 选项
+ * @returns {Promise<{ query: string, items: object[], nextCursor: string | null, scope?: string, filters?: object }>} 搜索结果
+ */
+export async function searchPosts(username, options = {}) {
+	const rawQuery = (options.q || '').trim()
+	const filters = parseSearchFilters(options)
+	if (filters.scope === 'nearby') {
+		const { buildNearbyPostSearch } = await import('./search/network.mjs')
+		return buildNearbyPostSearch(username, { ...options, ...filters, q: rawQuery || filters.q })
+	}
+	if (!hasSearchCriteria(filters))
+		return { query: rawQuery, items: [], nextCursor: null, filters, scope: 'local' }
+
+	const limit = Math.min(Math.max(Number(options.limit) || 30, 1), 100)
+	const indexQuery = filters.q || (filters.tag ? `#${filters.tag}` : filters.author || filters.media || 'a')
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	const itemContext = await createFeedItemBuildContext(username, null, options.viewerEntityHash || null)
+	const owners = []
+	for await (const entityHash of iterateVisibleTimelineOwners(username, options.viewerEntityHash || null))
+		owners.push(entityHash)
+
+	const fetchLimit = options.cursor ? limit * 4 + 50 : limit * 2
+	/** @type {Map<string, object>} */
+	const itemsByKey = new Map()
+
+	if (filters.q.length >= 2 || filters.tag) {
+		const indexedHits = await querySocialPostIndex(username, owners, indexQuery, fetchLimit)
+		for (const hit of indexedHits) {
+			const view = await getTimelineMaterialized(username, hit.entityHash)
+			const post = view.postById?.[hit.postId] || view.posts?.find(row => row.id === hit.postId)
+			if (!post) continue
+			const enriched = { ...post, entityHash: hit.entityHash }
+			if (!canViewPost(enriched, viewerContext)) continue
+			if (!postMatchesFilters(enriched, filters)) continue
+			if (filters.q.length >= 2 && !postMatchesQuery(enriched, filters.q) && !(filters.tag && postMatchesQuery(enriched, `#${filters.tag}`)))
+				continue
+			itemsByKey.set(`${hit.entityHash}:${hit.postId}`, await buildPostFeedItem(username, hit.entityHash, post, itemContext))
+		}
+	}
+
+	if (itemsByKey.size < fetchLimit)
+		for await (const { entityHash, post } of iterateVisiblePosts(username, viewerContext)) {
+			const key = `${entityHash}:${post.id}`
+			if (itemsByKey.has(key)) continue
+			const enriched = { ...post, entityHash }
+			if (!postMatchesFilters(enriched, filters)) continue
+			itemsByKey.set(key, await buildPostFeedItem(username, entityHash, post, itemContext))
+			if (itemsByKey.size >= fetchLimit) break
+		}
+
+	let items = [...itemsByKey.values()]
+	if (filters.sort === 'top')
+		items.sort((left, right) => {
+			const le = (left.engagement?.likes || 0) + 2 * (left.engagement?.reposts || 0) + (left.engagement?.replies || 0)
+			const re = (right.engagement?.likes || 0) + 2 * (right.engagement?.reposts || 0) + (right.engagement?.replies || 0)
+			if (le !== re) return re - le
+			return compareFeedItems(left, right) * -1
+		})
+	else
+		items.sort((left, right) => compareFeedItems(left, right) * -1)
+
+	if (options.cursor) {
+		const cursor = String(options.cursor)
+		const index = items.findIndex(item => searchItemCursorKey(item) === cursor)
+		items = index >= 0 ? items.slice(index + 1) : []
+	}
+
+	const page = items.slice(0, limit)
+	const nextCursor = page.length === limit && items.length > limit
+		? searchItemCursorKey(page[page.length - 1])
+		: null
+	return {
+		query: rawQuery || (filters.tag ? `#${filters.tag}` : ''),
+		items: page,
+		nextCursor,
+		filters,
+		scope: 'local',
+	}
+}

--- a/src/public/parts/shells/social/src/search/network.mjs
+++ b/src/public/parts/shells/social/src/search/network.mjs
@@ -1,0 +1,77 @@
+/**
+ * 联邦帖文搜索 part_query。
+ */
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { queryNetwork } from 'npm:@steve02081504/fount-p2p/wire/part_query'
+
+import { federatedPostQueryRow, federatedPostRowKey, sanitizeFederatedPostQueryRow } from '../federation/postQueryRow.mjs'
+import { searchPosts } from '../search.mjs'
+
+/** part_query kind：联邦帖文搜索 */
+export const POST_SEARCH_KIND = 'post_search'
+
+/**
+ * @param {{ replicaUsername?: string }} apiContext 入站上下文
+ * @param {unknown} query 查询
+ * @returns {Promise<object[]>} 行
+ */
+export async function localPostSearchHandler(apiContext, query) {
+	const username = String(apiContext.replicaUsername || '').trim()
+	if (!username) return []
+	const { q: rawQ, limit: rawLimit, author, media, tag } = query && typeof query === 'object'
+		? /** @type {{ q?: unknown, limit?: unknown, author?: unknown, media?: unknown, tag?: unknown }} */ query
+		: {}
+	const q = String(rawQ || '').trim()
+	const limit = Math.min(Math.max(Number(rawLimit) || 20, 1), 32)
+	const result = await searchPosts(username, {
+		q,
+		limit,
+		author,
+		media,
+		tag,
+		scope: 'local',
+	})
+	const nodeHash = String(getNodeHash() || '').toLowerCase()
+	return result.items
+		.map(item => federatedPostQueryRow(item.post, item.entityHash, nodeHash, { visibilityMode: 'preserve' }))
+		.filter(Boolean)
+}
+
+/**
+ * @param {string} username replica
+ * @param {object} [options] 选项
+ * @returns {Promise<{ query: string, items: object[], nextCursor: null, scope: 'nearby' }>} 附近搜索
+ */
+export async function buildNearbyPostSearch(username, options = {}) {
+	const q = String(options.q || '').trim()
+	const limit = Math.min(Math.max(Number(options.limit) || 30, 1), 100)
+	const partpath = getShellPartpath('social')
+	const rows = await queryNetwork(username, partpath, POST_SEARCH_KIND, {
+		q,
+		limit,
+		author: options.author,
+		media: options.media,
+		tag: options.tag,
+	}, {
+		maxHits: 64,
+		rowKey: federatedPostRowKey,
+	})
+
+	/** @type {object[]} */
+	const items = []
+	for (const raw of rows) {
+		const cleaned = sanitizeFederatedPostQueryRow(raw)
+		if (!cleaned) continue
+		items.push({
+			entityHash: cleaned.entityHash,
+			postId: cleaned.postId,
+			hlc: cleaned.hlc,
+			post: cleaned.event,
+			federated: true,
+			nodeHash: cleaned.nodeHash,
+		})
+		if (items.length >= limit) break
+	}
+	return { query: q, items, nextCursor: null, scope: 'nearby' }
+}

--- a/src/public/parts/shells/social/src/searchIndex.mjs
+++ b/src/public/parts/shells/social/src/searchIndex.mjs
@@ -1,0 +1,275 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+
+import { withAsyncMutex } from 'npm:@steve02081504/fount-p2p/utils/async_mutex'
+
+import { indexDocument, getShardMeta, queryIndex, removeDocument } from '../../../../../scripts/search/invertedIndex.mjs'
+
+import { socialPostKey } from './federation/post_key.mjs'
+import { extractHashtagsFromText } from './lib/hashtags.mjs'
+import { postMatchesQuery } from './lib/postQuery.mjs'
+import {
+	socialReplyIndexPath,
+	socialSearchIndexPath,
+	socialTrendingIndexPath,
+} from './paths.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+import { maybeDecryptPostContent } from './vault_crypto/vault.mjs'
+
+/**
+ * @param {string} username replica
+ * @returns {Promise<Record<string, object[]>>} reply 反向索引
+ */
+async function readReplyIndex(username) {
+	try {
+		return JSON.parse(await readFile(socialReplyIndexPath(username), 'utf8'))
+	}
+	catch {
+		return {}
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {Record<string, object[]>} index reply 索引
+ * @returns {Promise<void>}
+ */
+async function writeReplyIndex(username, index) {
+	await mkdir(socialSearchIndexPath(username), { recursive: true })
+	await writeFile(socialReplyIndexPath(username), `${JSON.stringify(index)}\n`, 'utf8')
+}
+
+/**
+ * @param {string} username replica
+ * @returns {Promise<Record<string, number>>} 话题计数
+ */
+async function readTrendingCounts(username) {
+	try {
+		return JSON.parse(await readFile(socialTrendingIndexPath(username), 'utf8'))
+	}
+	catch {
+		return {}
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {Record<string, number>} counts 计数
+ * @returns {Promise<void>}
+ */
+async function writeTrendingCounts(username, counts) {
+	await mkdir(socialSearchIndexPath(username), { recursive: true })
+	await writeFile(socialTrendingIndexPath(username), `${JSON.stringify(counts)}\n`, 'utf8')
+}
+
+/**
+ * @param {string} username replica
+ * @param {string[]} tags 话题
+ * @param {number} delta 增量
+ * @returns {Promise<void>}
+ */
+async function bumpTrendingTags(username, tags, delta) {
+	if (!tags.length || !delta) return
+	await withAsyncMutex(`social-trending:${username}`, async () => {
+		const counts = await readTrendingCounts(username)
+		for (const tag of tags) {
+			const next = Math.max(0, (counts[tag] || 0) + delta)
+			if (next) counts[tag] = next
+			else delete counts[tag]
+		}
+		await writeTrendingCounts(username, counts)
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} ownerEntityHash 时间线 owner
+ * @returns {Promise<void>}
+ */
+async function ensureTimelineIndexed(username, ownerEntityHash) {
+	const indexDir = socialSearchIndexPath(username)
+	const meta = await getShardMeta(indexDir, ownerEntityHash)
+	if ((meta.docCount || 0) > 0) return
+	const view = await getTimelineMaterialized(username, ownerEntityHash)
+	for (const post of view.posts || []) {
+		const content = await maybeDecryptPostContent(username, ownerEntityHash, post.content)
+		if (!content?.text) continue
+		await indexDocument(indexDir, ownerEntityHash, {
+			id: post.id,
+			text: content.text,
+			ts: Number(post.hlc?.wall || Date.now()),
+			fields: { entityHash: ownerEntityHash, postId: post.id },
+		})
+		const replyTo = content.replyTo
+		if (replyTo?.entityHash && replyTo?.postId)
+			await indexReplyRef(username, ownerEntityHash, post.id, replyTo.entityHash, replyTo.postId, Number(post.hlc?.wall || Date.now()))
+		for (const tag of extractHashtagsFromText(content.text))
+			await bumpTrendingTags(username, [tag], 1)
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} replyEntityHash 回复作者
+ * @param {string} replyPostId 回复帖 ID
+ * @param {string} targetEntityHash 被回复作者
+ * @param {string} targetPostId 被回复帖 ID
+ * @param {number} ts 时间戳
+ * @returns {Promise<void>}
+ */
+async function indexReplyRef(username, replyEntityHash, replyPostId, targetEntityHash, targetPostId, ts) {
+	const key = socialPostKey(targetEntityHash, targetPostId)
+	await withAsyncMutex(`social-reply-index:${username}`, async () => {
+		const index = await readReplyIndex(username)
+		const list = index[key] || []
+		const ref = { entityHash: replyEntityHash.toLowerCase(), postId: replyPostId, ts }
+		if (!list.some(row => row.entityHash === ref.entityHash && row.postId === ref.postId))
+			index[key] = [...list, ref]
+		await writeReplyIndex(username, index)
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 被回复作者
+ * @param {string} targetPostId 被回复帖 ID
+ * @param {string} replyEntityHash 回复作者
+ * @param {string} replyPostId 回复帖 ID
+ * @returns {Promise<void>}
+ */
+async function removeReplyRef(username, targetEntityHash, targetPostId, replyEntityHash, replyPostId) {
+	const key = socialPostKey(targetEntityHash, targetPostId)
+	await withAsyncMutex(`social-reply-index:${username}`, async () => {
+		const index = await readReplyIndex(username)
+		const list = index[key] || []
+		index[key] = list.filter(row => !(row.entityHash === replyEntityHash.toLowerCase() && row.postId === replyPostId))
+		if (!index[key].length) delete index[key]
+		await writeReplyIndex(username, index)
+	})
+}
+
+/**
+ * 时间线事件落盘后的搜索索引增量更新。
+ * @param {string} username replica
+ * @param {string} entityHash 时间线 owner
+ * @param {object} row 签名事件
+ * @returns {Promise<void>}
+ */
+export async function indexTimelineEventForSearch(username, entityHash, row) {
+	const owner = entityHash.toLowerCase()
+	const indexDir = socialSearchIndexPath(username)
+
+	if (row.type === 'post_delete') {
+		const postId = String(row.content?.targetPostId || row.content?.postId || '').trim()
+		if (postId) await removeDocument(indexDir, owner, postId)
+		return
+	}
+
+	if (row.type === 'post_edit') {
+		const postId = String(row.content?.targetPostId || '').trim()
+		if (!postId) return
+		const content = await maybeDecryptPostContent(username, owner, row.content)
+		if (!content?.text) return
+		await indexDocument(indexDir, owner, {
+			id: postId,
+			text: content.text,
+			ts: Number(row.hlc?.wall || row.timestamp || Date.now()),
+			fields: { entityHash: owner, postId },
+		})
+		return
+	}
+
+	if (row.type !== 'post') return
+	const postId = String(row.id || '').trim()
+	if (!postId) return
+
+	const content = await maybeDecryptPostContent(username, owner, row.content)
+	if (!content?.text) return
+
+	await indexDocument(indexDir, owner, {
+		id: postId,
+		text: content.text,
+		ts: Number(row.hlc?.wall || row.timestamp || Date.now()),
+		fields: { entityHash: owner, postId },
+	})
+
+	const tags = extractHashtagsFromText(content.text)
+	if (tags.length) await bumpTrendingTags(username, tags, 1)
+
+	const replyTo = content.replyTo
+	if (replyTo?.entityHash && replyTo?.postId)
+		await indexReplyRef(username, owner, postId, replyTo.entityHash, replyTo.postId, Number(row.hlc?.wall || Date.now()))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string[]} ownerEntityHashes 候选 owner 列表
+ * @param {string} query 查询
+ * @param {number} limit 上限
+ * @returns {Promise<Array<{ entityHash: string, postId: string, ts: number, text: string }>>} 索引命中
+ */
+export async function querySocialPostIndex(username, ownerEntityHashes, query, limit) {
+	const indexDir = socialSearchIndexPath(username)
+	for (const owner of ownerEntityHashes)
+		await ensureTimelineIndexed(username, owner)
+
+	/** @param {object} doc 索引文档
+	 *  @returns {boolean} 是否通过子串真值校验 */
+	const verifyHit = doc => postMatchesQuery({ content: { text: doc.text }, entityHash: doc.fields?.entityHash }, query)
+
+	return queryIndex({
+		indexDir,
+		shardKeys: ownerEntityHashes,
+		query,
+		limit: limit * 3,
+		verify: verifyHit,
+	}).then(hits => hits.slice(0, limit).map(hit => ({
+		entityHash: hit.fields?.entityHash || hit.shardKey,
+		postId: hit.fields?.postId || hit.id,
+		ts: hit.ts,
+		text: hit.text,
+	})))
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} targetEntityHash 被回复作者
+ * @param {string} targetPostId 被回复帖 ID
+ * @returns {Promise<Array<{ entityHash: string, postId: string, ts: number }>>} 回复引用列表
+ */
+export async function queryReplyIndex(username, targetEntityHash, targetPostId) {
+	const key = socialPostKey(targetEntityHash, targetPostId)
+	const index = await readReplyIndex(username)
+	return (index[key] || []).slice().sort((a, b) => Number(b.ts) - Number(a.ts))
+}
+
+/**
+ * @param {string} username replica
+ * @param {number} limit 条数
+ * @returns {Promise<{ tags: { tag: string, count: number }[] }>} 热门话题计数
+ */
+export async function readTrendingHashtagCounts(username, limit = 12) {
+	const counts = await readTrendingCounts(username)
+	const tags = Object.entries(counts)
+		.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+		.slice(0, limit)
+		.map(([tag, count]) => ({ tag, count }))
+	return { tags }
+}
+
+/**
+ * post 删除时清理 reply 索引与 trending。
+ * @param {string} username replica
+ * @param {string} entityHash 作者
+ * @param {object} post 物化帖
+ * @returns {Promise<void>}
+ */
+export async function unindexDeletedPost(username, entityHash, post) {
+	const content = post?.content
+	if (content?.text) {
+		const tags = extractHashtagsFromText(content.text)
+		if (tags.length) await bumpTrendingTags(username, tags, -1)
+	}
+	const replyTo = content?.replyTo
+	if (replyTo?.entityHash && replyTo?.postId)
+		await removeReplyRef(username, replyTo.entityHash, replyTo.postId, entityHash, post.id)
+}

--- a/src/public/parts/shells/social/src/socialMeta.mjs
+++ b/src/public/parts/shells/social/src/socialMeta.mjs
@@ -1,0 +1,24 @@
+import { commitTimelineEvent } from './timeline/append.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * 追加 social_meta 事件更新探索资料。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 时间线 owner
+ * @param {object} patch 可写字段
+ * @param {boolean} [patch.hideFromDiscovery] 是否从探索隐藏
+ * @returns {Promise<object>} 物化后的 socialMeta
+ */
+export async function updateSocialMeta(username, entityHash, patch) {
+	/** @type {Record<string, unknown>} */
+	const content = {}
+	if (patch.hideFromDiscovery !== undefined) content.hideFromDiscovery = patch.hideFromDiscovery
+	if (!Object.keys(content).length)
+		return (await getTimelineMaterialized(username, entityHash)).socialMeta
+
+	await commitTimelineEvent(username, entityHash, {
+		type: 'social_meta',
+		content,
+	})
+	return (await getTimelineMaterialized(username, entityHash)).socialMeta
+}

--- a/src/public/parts/shells/social/src/socialVaultIndex.mjs
+++ b/src/public/parts/shells/social/src/socialVaultIndex.mjs
@@ -1,0 +1,115 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+
+import { buildFileManifestFromEnc, encryptPlaintextToParts, vaultWrapDescriptor } from 'npm:@steve02081504/fount-p2p/files/assemble'
+import { saveFileManifest, storeManifestParts } from 'npm:@steve02081504/fount-p2p/files/evfs'
+
+import { getUserDictionary } from '../../../../../server/auth/index.mjs'
+
+import { vaultGroupId } from './federation/namespace.mjs'
+import { loadVaultMasterKey } from './vault_crypto/vault.mjs'
+
+/**
+ * 返回 vault 文件索引路径。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @returns {string} file index 路径
+ */
+function vaultIndexPath(username, entityHash) {
+	return `${getUserDictionary(username)}/shells/social/timelines/${entityHash}/vault_index.json`
+}
+
+/**
+ * 读取 vault 文件索引。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @returns {Promise<Record<string, object>>} vault 文件索引
+ */
+export async function loadVaultIndex(username, entityHash) {
+	try {
+		return JSON.parse(await readFile(vaultIndexPath(username, entityHash), 'utf8'))
+	}
+	catch {
+		return {}
+	}
+}
+
+/**
+ * 写入 vault 文件索引。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {Record<string, object>} index 索引
+ * @returns {Promise<void>}
+ */
+async function saveVaultIndex(username, entityHash, index) {
+	await mkdir(`${vaultIndexPath(username, entityHash).replace(/[/\\][^/\\]+$/, '')}`, { recursive: true })
+	await writeFile(vaultIndexPath(username, entityHash), JSON.stringify(index, null, '\t'), 'utf8')
+}
+
+/**
+ * 写入 vault EVFS manifest（random + vault-wrap）。
+ * @param {string} username replica
+ * @param {string} entityHash owner
+ * @param {{ fileId?: string, plaintext: Buffer | Uint8Array, name?: string, mimeType?: string, visibility?: string }} options 参数
+ * @returns {Promise<{ fileId: string, logicalPath: string, manifest: object }>} 写入结果
+ */
+export async function putVaultFileManifest(username, entityHash, options) {
+	const fileId = options.fileId || randomUUID()
+	const logicalPath = `shells/social/vault/${fileId}`
+	const { masterKey } = await loadVaultMasterKey(username, entityHash)
+	const enc = encryptPlaintextToParts(options.plaintext, 'random')
+	const descriptor = vaultWrapDescriptor(entityHash, fileId, enc.contentKey, masterKey)
+	const manifest = buildFileManifestFromEnc({
+		ownerEntityHash: entityHash,
+		logicalPath,
+		plaintext: options.plaintext,
+		name: options.name || fileId,
+		mimeType: options.mimeType || 'application/octet-stream',
+		ceMode: 'random',
+		transferKeyDescriptor: descriptor,
+		meta: { fileId, visibility: options.visibility || 'followers', vaultGroupId: vaultGroupId(entityHash) },
+	}, enc)
+	await storeManifestParts(manifest, enc.parts.map(part => part.raw))
+	await saveFileManifest(manifest)
+	return { fileId, logicalPath, manifest }
+}
+
+/**
+ * 注册 vault 文件并写入索引。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {object} manifest 文件元数据
+ * @returns {Promise<object>} 索引项
+ */
+export async function registerVaultFile(username, entityHash, manifest) {
+	if (!manifest.logicalPath) throw new Error('logicalPath required')
+	const fileId = manifest.fileId || randomUUID()
+	const entry = {
+		fileId,
+		name: manifest.name || fileId,
+		mimeType: manifest.mimeType || 'application/octet-stream',
+		size: Number(manifest.size) || 0,
+		evfsPath: manifest.logicalPath,
+		contentHash: manifest.contentHash || '',
+		visibility: manifest.visibility || 'followers',
+		shareId: manifest.shareId || randomUUID(),
+		vaultGroupId: vaultGroupId(entityHash),
+		createdAt: Date.now(),
+	}
+	const index = await loadVaultIndex(username, entityHash)
+	index[fileId] = entry
+	await saveVaultIndex(username, entityHash, index)
+	return entry
+}
+
+/**
+ * 按 shareId 查找 vault 文件索引项。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {string} shareId 分享 id
+ * @returns {Promise<object | null>} 索引项或 null
+ */
+export async function getVaultFileByShareId(username, entityHash, shareId) {
+	const index = await loadVaultIndex(username, entityHash)
+	return Object.values(index).find(entry => entry.shareId === shareId) || null
+}

--- a/src/public/parts/shells/social/src/taste/cluster.mjs
+++ b/src/public/parts/shells/social/src/taste/cluster.mjs
@@ -1,0 +1,404 @@
+/**
+ * 反应图信任加权 Jaccard 聚类 → 本地口味 tag。
+ * 点踩为负向证据；所有计数信任加权；禁止裸全局计数。
+ */
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { loadDwellTagBoosts } from '../engagement/dwell.mjs'
+import { socialPostKey } from '../federation/post_key.mjs'
+import { summarizeReactions } from '../federation/reaction/index.mjs'
+import { pullPostReactions } from '../federation/reaction/pull.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { weightedJaccard } from './jaccard.mjs'
+import { gossipTagMergeClaim, lazyVerifyPendingMergeClaims } from './mergeClaims.mjs'
+import { localTagStats, verifyTagMergeClaimWithStats } from './mergeVerify.mjs'
+import { loadTaste, mutateTaste, resolveTasteAlias, tasteWeightOf } from './store.mjs'
+
+const JACCARD_MERGE = 0.45
+const SENIORITY_MIN_POSTS = 2
+const CLUSTER_STALE_MS = 6 * 60 * 60 * 1000
+const MAX_POSTS_SCAN = 400
+const REACTION_PULL_ON_REBUILD = 30
+const LOCAL_MERGE_MIN_FIT = 0.55
+
+/**
+ * @param {string} entityHash 实体
+ * @returns {number} 信任权重 ∈ (0, 1]
+ */
+function trustWeightOfEntity(entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return 0
+	const score = pickNodeScore(parsed.nodeHash)
+	return Math.max(0.05, Math.min(1, 0.5 + score / 2))
+}
+
+/**
+ * @param {Map<string, number>} likes 正向
+ * @param {Map<string, number>} dislikes 负向
+ * @returns {Map<string, number>} 净受众向量（负权夹到 0 后用于 Jaccard）
+ */
+function audienceVector(likes, dislikes) {
+	/** @type {Map<string, number>} */
+	const out = new Map()
+	for (const [k, w] of likes)
+		out.set(k, (out.get(k) || 0) + w)
+	for (const [k, w] of dislikes)
+		out.set(k, (out.get(k) || 0) - w)
+	for (const [k, w] of [...out.entries()])
+		if (w <= 0) out.delete(k)
+		else out.set(k, w)
+	return out
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {Set<string>} following 关注
+ * @returns {Promise<Map<string, { likes: Map<string, number>, dislikes: Map<string, number>, selfTags: string[] }>>} 帖 → 受众
+ */
+async function collectPostAudiences(username, entityHash, following) {
+	/** @type {Map<string, { likes: Map<string, number>, dislikes: Map<string, number>, selfTags: string[] }>} */
+	const posts = new Map()
+
+	/**
+	 * @param {string} author 作者
+	 * @param {string} postId 帖 id
+	 * @returns {{ likes: Map<string, number>, dislikes: Map<string, number>, selfTags: string[] }} 受众行
+	 */
+	function ensure(author, postId) {
+		const key = socialPostKey(author, postId)
+		let row = posts.get(key)
+		if (!row) {
+			row = { likes: new Map(), dislikes: new Map(), selfTags: [] }
+			posts.set(key, row)
+		}
+		return row
+	}
+
+	const actors = new Set([entityHash, ...following])
+	for (const actor of actors) {
+		if (!parseEntityHash(actor)) continue
+		const view = await getTimelineMaterialized(username, actor)
+		const weight = actor === entityHash ? 1 : trustWeightOfEntity(actor) * (following.has(actor) ? 1 : 0.5)
+		for (const like of view.likes || []) {
+			const target = String(like.content?.targetEntityHash || '').toLowerCase()
+			const postId = String(like.content?.targetPostId || '')
+			if (!parseEntityHash(target) || !postId) continue
+			const row = ensure(target, postId)
+			row.likes.set(actor, (row.likes.get(actor) || 0) + weight)
+		}
+		for (const dislike of view.dislikes || []) {
+			const target = String(dislike.content?.targetEntityHash || '').toLowerCase()
+			const postId = String(dislike.content?.targetPostId || '')
+			if (!parseEntityHash(target) || !postId) continue
+			const row = ensure(target, postId)
+			row.dislikes.set(actor, (row.dislikes.get(actor) || 0) + weight)
+		}
+		for (const post of view.posts || []) {
+			const tags = Array.isArray(post.content?.tags)
+				? post.content.tags.map(t => String(t).trim().toLowerCase()).filter(Boolean)
+				: []
+			if (tags.length) ensure(actor, post.id).selfTags = tags
+		}
+	}
+
+	const scanKeys = [...posts.keys()].slice(0, MAX_POSTS_SCAN)
+	for (const key of scanKeys) {
+		const [author, postId] = key.split(':')
+		if (!author || !postId) continue
+		const row = posts.get(key)
+		if (!row) continue
+		const summary = await summarizeReactions(username, author, postId)
+		for (const reactor of summary.likes) {
+			if (row.likes.has(reactor)) continue
+			const w = trustWeightOfEntity(reactor)
+			row.likes.set(reactor, (row.likes.get(reactor) || 0) + w)
+		}
+		for (const reactor of summary.dislikes) {
+			if (row.dislikes.has(reactor)) continue
+			const w = trustWeightOfEntity(reactor)
+			row.dislikes.set(reactor, (row.dislikes.get(reactor) || 0) + w)
+		}
+	}
+
+	return posts
+}
+
+/**
+ * 选簇代表元：出现次数足够的最小 reactor hash（资历门槛防碾磨）。
+ * @param {Map<string, number>[]} audiences 各帖净受众
+ * @returns {string | null} tag hash
+ */
+export function pickClusterRepresentative(audiences) {
+	/** @type {Map<string, number>} */
+	const appear = new Map()
+	for (const aud of audiences)
+		for (const reactor of aud.keys())
+			appear.set(reactor, (appear.get(reactor) || 0) + 1)
+	const eligible = [...appear.entries()]
+		.filter(([, count]) => count >= SENIORITY_MIN_POSTS)
+		.map(([hash]) => hash)
+		.sort()
+	if (eligible.length) return eligible[0]
+	const all = [...appear.keys()].sort()
+	return all[0] || null
+}
+
+/**
+ * @param {Map<string, Map<string, number>>} postAudiences postKey → audience
+ * @returns {Map<string, string>} postKey → tagHash
+ */
+export function clusterPostsByAudience(postAudiences) {
+	const keys = [...postAudiences.keys()].slice(0, MAX_POSTS_SCAN)
+	/** @type {number[]} */
+	const parent = keys.map((_, i) => i)
+	/**
+	 * @param {number} i 下标
+	 * @returns {number} 根
+	 */
+	function find(i) {
+		while (parent[i] !== i) {
+			parent[i] = parent[parent[i]]
+			i = parent[i]
+		}
+		return i
+	}
+	/**
+	 * @param {number} a 下标 a
+	 * @param {number} b 下标 b
+	 * @returns {void}
+	 */
+	function union(a, b) {
+		const ra = find(a)
+		const rb = find(b)
+		if (ra !== rb) parent[ra] = rb
+	}
+
+	for (let i = 0; i < keys.length; i++)
+		for (let j = i + 1; j < keys.length; j++)
+			if (weightedJaccard(postAudiences.get(keys[i]), postAudiences.get(keys[j])) >= JACCARD_MERGE)
+				union(i, j)
+
+	/** @type {Map<number, string[]>} */
+	const groups = new Map()
+	for (let i = 0; i < keys.length; i++) {
+		const root = find(i)
+		if (!groups.has(root)) groups.set(root, [])
+		groups.get(root).push(keys[i])
+	}
+
+	/** @type {Map<string, string>} */
+	const assignment = new Map()
+	for (const members of groups.values()) {
+		const audiences = members.map(k => postAudiences.get(k))
+		const tag = pickClusterRepresentative(audiences)
+		if (!tag) continue
+		for (const key of members)
+			assignment.set(key, tag)
+	}
+	return assignment
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} actor acting
+ * @returns {Promise<void>}
+ */
+async function pullRecentReactionPosts(username, actor) {
+	const view = await getTimelineMaterialized(username, actor)
+	/** @type {{ key: string, at: number, author: string, postId: string }[]} */
+	const targets = []
+	for (const like of view.likes || []) {
+		const author = String(like.content?.targetEntityHash || '').toLowerCase()
+		const postId = String(like.content?.targetPostId || '')
+		if (!parseEntityHash(author) || !postId) continue
+		targets.push({
+			key: socialPostKey(author, postId),
+			at: Number(like.hlc?.wall || like.timestamp) || 0,
+			author,
+			postId,
+		})
+	}
+	for (const dislike of view.dislikes || []) {
+		const author = String(dislike.content?.targetEntityHash || '').toLowerCase()
+		const postId = String(dislike.content?.targetPostId || '')
+		if (!parseEntityHash(author) || !postId) continue
+		targets.push({
+			key: socialPostKey(author, postId),
+			at: Number(dislike.hlc?.wall || dislike.timestamp) || 0,
+			author,
+			postId,
+		})
+	}
+	targets.sort((a, b) => b.at - a.at)
+	const seen = new Set()
+	let pulled = 0
+	for (const row of targets) {
+		if (seen.has(row.key)) continue
+		seen.add(row.key)
+		await pullPostReactions(username, row.author, row.postId).catch(() => null)
+		pulled++
+		if (pulled >= REACTION_PULL_ON_REBUILD) break
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} actor acting
+ * @param {import('./store.mjs').TasteStore} store 偏好
+ * @param {{ usage: Map<string, number>, audiences: Map<string, Map<string, number>> }} stats 统计
+ * @returns {Promise<void>}
+ */
+async function discoverAndGossipMerges(username, actor, store, stats) {
+	const tags = [...stats.audiences.keys()].sort()
+	for (let i = 0; i < tags.length; i++) 
+		for (let j = i + 1; j < tags.length; j++) {
+			const a = tags[i]
+			const b = tags[j]
+			const fit = weightedJaccard(stats.audiences.get(a), stats.audiences.get(b))
+			if (fit < LOCAL_MERGE_MIN_FIT) continue
+			const from = a < b ? a : b
+			const to = a < b ? b : a
+			const claim = { from, to, evidence: { fit, local: true } }
+			const result = verifyTagMergeClaimWithStats(stats, claim)
+			if (!result.ok) continue
+			await mutateTaste(username, actor, draft => {
+				draft.aliases[from] = {
+					to,
+					confidence: result.confidence,
+					evidence: { fit, verifiedAt: Date.now() },
+				}
+				return draft
+			})
+			if (store.privacy.publishPreferences !== false)
+				await gossipTagMergeClaim(username, claim).catch(() => null)
+		}
+	
+}
+
+/**
+ * 重建实体口味表。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @returns {Promise<import('./store.mjs').TasteStore>} 更新后偏好
+ */
+export async function rebuildTaste(username, entityHash) {
+	const actor = String(entityHash).toLowerCase()
+	await pullRecentReactionPosts(username, actor)
+
+	const { following } = await loadFollowingForActor(username, actor)
+	const followingSet = new Set([...following].map(h => h.toLowerCase()))
+	const raw = await collectPostAudiences(username, actor, followingSet)
+
+	/** @type {Map<string, Map<string, number>>} */
+	const audiences = new Map()
+	/** @type {Map<string, string[]>} */
+	const selfTags = new Map()
+	for (const [key, row] of raw) {
+		audiences.set(key, audienceVector(row.likes, row.dislikes))
+		if (row.selfTags?.length) selfTags.set(key, row.selfTags)
+	}
+
+	const assignment = clusterPostsByAudience(audiences)
+
+	const ownView = await getTimelineMaterialized(username, actor)
+	/** @type {Map<string, number>} */
+	const ownSignal = new Map()
+	for (const like of ownView.likes || []) {
+		const key = socialPostKey(like.content?.targetEntityHash, like.content?.targetPostId)
+		ownSignal.set(key, (ownSignal.get(key) || 0) + 1)
+	}
+	for (const dislike of ownView.dislikes || []) {
+		const key = socialPostKey(dislike.content?.targetEntityHash, dislike.content?.targetPostId)
+		ownSignal.set(key, (ownSignal.get(key) || 0) - 1)
+	}
+
+	const dwellTags = await loadDwellTagBoosts(username, actor)
+	const store = await mutateTaste(username, actor, draft => {
+		/** @type {Record<string, number>} */
+		const computed = {}
+		/** @type {Record<string, { tags: string[], selfWeight: number }>} */
+		const postTags = {}
+
+		for (const [key, signal] of ownSignal) {
+			const clusterTag = assignment.get(key)
+			const declared = selfTags.get(key) || []
+			const reactionCount = Math.abs(signal)
+			const selfWeight = 1 / (1 + reactionCount)
+			/** @type {string[]} */
+			const tagList = []
+			if (clusterTag) tagList.push(clusterTag)
+			for (const t of declared)
+				if (!tagList.includes(t)) tagList.push(t)
+
+			postTags[key] = { tags: tagList, selfWeight }
+
+			for (const rawTag of tagList) {
+				const canon = resolveTasteAlias(rawTag, draft.aliases)
+				const isSelf = declared.includes(rawTag) && rawTag !== clusterTag
+				const delta = signal * (isSelf ? selfWeight : 1)
+				computed[canon] = (computed[canon] || 0) + delta
+			}
+		}
+
+		for (const [rawTag, weight] of dwellTags) {
+			const canon = resolveTasteAlias(rawTag, draft.aliases)
+			computed[canon] = (computed[canon] || 0) + weight
+		}
+
+		draft.computed = computed
+		draft.postTags = postTags
+		draft.clusteredAt = Date.now()
+		return draft
+	})
+
+	const stats = await localTagStats(username, actor, store)
+	await lazyVerifyPendingMergeClaims(username, actor, stats)
+	await discoverAndGossipMerges(username, actor, store, stats)
+	return loadTaste(username, actor)
+}
+
+/**
+ * 若偏好表过期则重建。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @returns {Promise<import('./store.mjs').TasteStore>} 偏好
+ */
+export async function ensureTasteFresh(username, entityHash) {
+	const store = await loadTaste(username, entityHash)
+	if (Date.now() - store.clusteredAt < CLUSTER_STALE_MS) return store
+	return rebuildTaste(username, entityHash)
+}
+
+/**
+ * 帖与观看者偏好的匹配分（可负；名字不参与）。
+ * @param {object} post 物化帖（可含 content.tags）
+ * @param {string} authorEntityHash 作者
+ * @param {import('./store.mjs').TasteStore} taste 观看者偏好
+ * @returns {number} 匹配分（可负）
+ */
+export function computeTasteMatch(post, authorEntityHash, taste) {
+	const key = socialPostKey(authorEntityHash, post.id || post.postId)
+	const inferred = taste.postTags[key]
+	/** @type {string[]} */
+	const tags = []
+	if (inferred?.tags?.length)
+		for (const t of inferred.tags) tags.push(t)
+	const self = Array.isArray(post.content?.tags) ? post.content.tags : []
+	const selfWeight = inferred?.selfWeight ?? 1
+	for (const t of self) {
+		const s = String(t).trim().toLowerCase()
+		if (s && !tags.includes(s)) tags.push(s)
+	}
+
+	let match = 0
+	for (const t of tags) {
+		const w = tasteWeightOf(taste, t)
+		const isSelfOnly = self.map(x => String(x).toLowerCase()).includes(t) && !inferred?.tags?.includes(t)
+		match += w * (isSelfOnly ? selfWeight : 1)
+	}
+	return match
+}

--- a/src/public/parts/shells/social/src/taste/jaccard.mjs
+++ b/src/public/parts/shells/social/src/taste/jaccard.mjs
@@ -1,0 +1,19 @@
+/**
+ * 加权 Jaccard（口味聚类 / 合并验证共用）。
+ * @param {Map<string, number>} left 加权集合
+ * @param {Map<string, number>} right 加权集合
+ * @returns {number} 加权 Jaccard
+ */
+export function weightedJaccard(left, right) {
+	if (!left?.size || !right?.size) return 0
+	let inter = 0
+	let union = 0
+	const keys = new Set([...left.keys(), ...right.keys()])
+	for (const key of keys) {
+		const a = left.get(key) || 0
+		const b = right.get(key) || 0
+		inter += Math.min(a, b)
+		union += Math.max(a, b)
+	}
+	return union > 0 ? inter / union : 0
+}

--- a/src/public/parts/shells/social/src/taste/mergeClaims.mjs
+++ b/src/public/parts/shells/social/src/taste/mergeClaims.mjs
@@ -1,0 +1,218 @@
+/**
+ * Tag 合并声明收件箱（有界、过期、来源限速）。
+ * 已接受别名写入 taste store，持久不过期。
+ */
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+
+import { getNodeDir } from 'npm:@steve02081504/fount-p2p/node/instance'
+import { withAsyncMutex } from 'npm:@steve02081504/fount-p2p/utils/async_mutex'
+
+import { collectSocialRpcMerged } from '../federation/rpc/wire.mjs'
+
+import { localTagStats, verifyTagMergeClaimWithStats } from './mergeVerify.mjs'
+import { loadTaste, mutateTaste, resolveTasteAlias } from './store.mjs'
+
+const CLAIM_INBOX_MAX = 500
+const CLAIM_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const CLAIM_PER_SOURCE_MAX = 20
+
+/**
+ * @returns {string} 收件箱路径
+ */
+function tagClaimsPath() {
+	return path.join(getNodeDir(), 'social', 'tag_claims.jsonl')
+}
+
+/**
+ * @param {object} claim 声明
+ * @returns {boolean} 结构是否可用
+ */
+function isWellFormedClaim(claim) {
+	const from = String(claim?.from || '').trim().toLowerCase()
+	const to = String(claim?.to || '').trim().toLowerCase()
+	return Boolean(from && to && from !== to && from.length <= 128 && to.length <= 128)
+}
+
+/**
+ * 声明两端（经别名折叠）是否触及当前实体已有标签。
+ * @param {string} from 源 tag
+ * @param {string} to 目标 tag
+ * @param {Set<string>} actorTags 实体 canonical tags
+ * @param {Record<string, { to: string, confidence: number }>} aliases 别名表
+ * @returns {boolean} 是否相关
+ */
+export function claimTouchesActorTags(from, to, actorTags, aliases) {
+	return actorTags.has(from)
+		|| actorTags.has(to)
+		|| actorTags.has(resolveTasteAlias(from, aliases))
+		|| actorTags.has(resolveTasteAlias(to, aliases))
+}
+
+/**
+ * @returns {Promise<object[]>} 收件箱行
+ */
+async function readClaimInbox() {
+	try {
+		const text = await readFile(tagClaimsPath(), 'utf8')
+		return text.split('\n').filter(Boolean).map(line => JSON.parse(line))
+	}
+	catch (err) {
+		if (err?.code !== 'ENOENT') throw err
+		return []
+	}
+}
+
+/**
+ * @param {object[]} rows 行
+ * @returns {Promise<void>}
+ */
+async function rewriteClaimInbox(rows) {
+	await mkdir(path.dirname(tagClaimsPath()), { recursive: true })
+	const body = rows.map(row => JSON.stringify(row)).join('\n')
+	await writeFile(tagClaimsPath(), body ? `${body}\n` : '', 'utf8')
+}
+
+/**
+ * 修剪过期 / 超量 / 来源限速后的收件箱。
+ * @param {object[]} rows 原始
+ * @returns {object[]} 修剪后
+ */
+export function pruneClaimInbox(rows) {
+	const now = Date.now()
+	const fresh = rows.filter(row => now - (Number(row.at) || 0) < CLAIM_TTL_MS)
+	/** @type {Map<string, number>} */
+	const perSource = new Map()
+	/** @type {object[]} */
+	const kept = []
+	for (const row of fresh.reverse()) {
+		const source = String(row.sourceNodeHash || row.claim?.annotator || 'unknown')
+		const count = perSource.get(source) || 0
+		if (count >= CLAIM_PER_SOURCE_MAX) continue
+		perSource.set(source, count + 1)
+		kept.push(row)
+		if (kept.length >= CLAIM_INBOX_MAX) break
+	}
+	return kept.reverse()
+}
+
+/**
+ * 入站合并声明：只入收件箱，懒验证另走。
+ * @param {string} _username replica
+ * @param {object} claim 声明体
+ * @param {{ requesterNodeHash?: string | null }} [ingress] 入站
+ * @returns {Promise<{ ok: boolean }>} 是否入箱
+ */
+export async function ingestTagMergeClaim(_username, claim, ingress = {}) {
+	if (!isWellFormedClaim(claim)) return { ok: false }
+	await withAsyncMutex('tag-claim-inbox', async () => {
+		const rows = pruneClaimInbox([
+			...await readClaimInbox(),
+			{
+				at: Date.now(),
+				sourceNodeHash: ingress.requesterNodeHash || null,
+				claim: {
+					from: String(claim.from).trim().toLowerCase(),
+					to: String(claim.to).trim().toLowerCase(),
+					evidence: claim.evidence || {},
+				},
+			},
+		])
+		await rewriteClaimInbox(rows)
+	})
+	return { ok: true }
+}
+
+/**
+ * 对偏好表中出现的 tag 懒验证收件箱声明（供 rebuild 调用；复用预计算 stats）。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {{ usage: Map<string, number>, audiences: Map<string, Map<string, number>> }} [statsHint] 预计算
+ * @returns {Promise<{ accepted: number, rejected: number }>} 计数
+ */
+export async function lazyVerifyPendingMergeClaims(username, entityHash, statsHint = null) {
+	const rows = pruneClaimInbox(await readClaimInbox())
+	await rewriteClaimInbox(rows)
+	let accepted = 0
+	let rejected = 0
+	const taste = await loadTaste(username, entityHash)
+	const stats = statsHint || await localTagStats(username, entityHash, taste)
+	const actorTags = new Set([
+		...Object.keys(taste.computed || {}),
+		...Object.keys(taste.manual || {}),
+	].map(t => resolveTasteAlias(t, taste.aliases)))
+	for (const row of Object.values(taste.postTags || {}))
+		for (const tag of row?.tags || [])
+			actorTags.add(resolveTasteAlias(tag, taste.aliases))
+
+	for (const row of rows) {
+		const from = row.claim?.from
+		const to = row.claim?.to
+		if (!from || !to) continue
+		if (!claimTouchesActorTags(from, to, actorTags, taste.aliases)) continue
+		const result = verifyTagMergeClaimWithStats(stats, row.claim)
+		if (!result.ok) {
+			rejected++
+			continue
+		}
+		await mutateTaste(username, entityHash, store => {
+			const canonTo = resolveTasteAlias(to, store.aliases)
+			store.aliases[from] = {
+				to: canonTo,
+				confidence: result.confidence,
+				evidence: { ...row.claim.evidence, verifiedAt: Date.now() },
+			}
+			return store
+		})
+		accepted++
+	}
+	return { accepted, rejected }
+}
+
+/**
+ * 广播本地发现的合并（验证通过后）。
+ * @param {string} username replica
+ * @param {{ from: string, to: string, evidence?: object }} claim 声明
+ * @returns {Promise<void>}
+ */
+export async function gossipTagMergeClaim(username, claim) {
+	if (!isWellFormedClaim(claim)) return
+	await collectSocialRpcMerged(username, {
+		type: 'social_tag_merge_claim',
+		claim: {
+			from: String(claim.from).trim().toLowerCase(),
+			to: String(claim.to).trim().toLowerCase(),
+			evidence: claim.evidence || {},
+		},
+	}, 2000, 6)
+}
+
+/**
+ * 撤销软别名。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {string} fromTag 别名源
+ * @returns {Promise<import('./store.mjs').TasteStore>} 更新后偏好
+ */
+export async function revokeTasteAlias(username, entityHash, fromTag) {
+	const from = String(fromTag).trim().toLowerCase()
+	return mutateTaste(username, entityHash, store => {
+		delete store.aliases[from]
+		return store
+	})
+}
+
+/**
+ * 追加到收件箱（测试 / 内部）。
+ * @param {object} row 行
+ * @returns {Promise<void>}
+ */
+export async function appendClaimInboxRow(row) {
+	await withAsyncMutex('tag-claim-inbox', async () => {
+		await mkdir(path.dirname(tagClaimsPath()), { recursive: true })
+		await appendFile(tagClaimsPath(), `${JSON.stringify(row)}\n`, 'utf8')
+		const pruned = pruneClaimInbox(await readClaimInbox())
+		await rewriteClaimInbox(pruned)
+	})
+}

--- a/src/public/parts/shells/social/src/taste/mergeVerify.mjs
+++ b/src/public/parts/shells/social/src/taste/mergeVerify.mjs
@@ -1,0 +1,130 @@
+/**
+ * Tag 合并懒验证：用量 / 互斥 / 拟合，一律信任加权本地数据。
+ */
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { socialPostKey } from '../federation/post_key.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { weightedJaccard } from './jaccard.mjs'
+import { loadTaste, resolveTasteAlias } from './store.mjs'
+
+/**
+ *
+ */
+export const MIN_USAGE = 2
+/**
+ *
+ */
+export const MIN_FIT = 0.35
+/**
+ *
+ */
+export const MAX_EXCLUSIVE_OVERLAP = 0.15
+
+/**
+ * @param {string} entityHash 实体
+ * @returns {number} 信任权重
+ */
+function trustWeight(entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed) return 0
+	const score = pickNodeScore(parsed.nodeHash)
+	return Math.max(0.05, Math.min(1, 0.5 + score / 2))
+}
+
+/**
+ * 从本地关注圈积累 tag → 受众向量 / 用量。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {import('./store.mjs').TasteStore} [tasteHint] 可选预载偏好
+ * @returns {Promise<{ usage: Map<string, number>, audiences: Map<string, Map<string, number>> }>} 用量与受众
+ */
+export async function localTagStats(username, entityHash, tasteHint = null) {
+	const taste = tasteHint || await loadTaste(username, entityHash)
+	const { following } = await loadFollowingForActor(username, entityHash)
+	/** @type {Map<string, number>} */
+	const usage = new Map()
+	/** @type {Map<string, Map<string, number>>} */
+	const audiences = new Map()
+
+	/**
+	 * @param {string} tag 标签
+	 * @param {string} reactor 反应者
+	 * @param {number} w 权重
+	 * @returns {void}
+	 */
+	function bump(tag, reactor, w) {
+		const canon = resolveTasteAlias(tag, taste.aliases)
+		usage.set(canon, (usage.get(canon) || 0) + w)
+		if (!audiences.has(canon)) audiences.set(canon, new Map())
+		const aud = audiences.get(canon)
+		aud.set(reactor, (aud.get(reactor) || 0) + w)
+	}
+
+	const actors = [entityHash, ...following]
+	for (const actor of actors) {
+		if (!parseEntityHash(actor)) continue
+		const view = await getTimelineMaterialized(username, actor)
+		const w = trustWeight(actor)
+		for (const like of view.likes || []) {
+			const key = socialPostKey(like.content?.targetEntityHash, like.content?.targetPostId)
+			const tags = taste.postTags[key]?.tags || []
+			for (const tag of tags) bump(tag, actor, w)
+		}
+		for (const post of view.posts || []) {
+			const tags = Array.isArray(post.content?.tags) ? post.content.tags : []
+			for (const tag of tags) bump(String(tag).toLowerCase(), actor, w * 0.5)
+		}
+	}
+	return { usage, audiences }
+}
+
+/**
+ * @param {{ usage: Map<string, number>, audiences: Map<string, Map<string, number>> }} stats 预计算统计
+ * @param {{ from: string, to: string, evidence?: object }} claim 声明
+ * @returns {{ ok: boolean, confidence: number, reason?: string }} 验证结果
+ */
+export function verifyTagMergeClaimWithStats(stats, claim) {
+	const from = String(claim.from || '').trim().toLowerCase()
+	const to = String(claim.to || '').trim().toLowerCase()
+	if (!from || !to || from === to) return { ok: false, confidence: 0, reason: 'malformed' }
+
+	const { usage, audiences } = stats
+	const usageFrom = usage.get(from) || 0
+	const usageTo = usage.get(to) || 0
+	if (usageFrom < MIN_USAGE || usageTo < MIN_USAGE)
+		return { ok: false, confidence: 0, reason: 'usage' }
+
+	const audFrom = audiences.get(from) || new Map()
+	const audTo = audiences.get(to) || new Map()
+	const fit = weightedJaccard(audFrom, audTo)
+	if (fit < MIN_FIT) return { ok: false, confidence: 0, reason: 'fit' }
+
+	let worstExclusive = 0
+	for (const [other, aud] of audiences) {
+		if (other === from || other === to) continue
+		if ((usage.get(other) || 0) < MIN_USAGE) continue
+		const overlapFrom = weightedJaccard(audFrom, aud)
+		const overlapTo = weightedJaccard(audTo, aud)
+		if (overlapFrom > 0.5 && overlapTo < MAX_EXCLUSIVE_OVERLAP)
+			worstExclusive = Math.max(worstExclusive, overlapFrom - overlapTo)
+	}
+	if (worstExclusive > 0.4) return { ok: false, confidence: 0, reason: 'exclusive' }
+
+	const confidence = Math.min(1, fit * Math.log1p(Math.min(usageFrom, usageTo)) / 3)
+	return { ok: true, confidence }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {{ from: string, to: string, evidence?: object }} claim 声明
+ * @returns {Promise<{ ok: boolean, confidence: number, reason?: string }>} 验证结果
+ */
+export async function verifyTagMergeClaim(username, entityHash, claim) {
+	const stats = await localTagStats(username, entityHash)
+	return verifyTagMergeClaimWithStats(stats, claim)
+}

--- a/src/public/parts/shells/social/src/taste/nameClaims.mjs
+++ b/src/public/parts/shells/social/src/taste/nameClaims.mjs
@@ -1,0 +1,94 @@
+/**
+ * Tag 命名：签名时间线事件 tag_name（locale 区分）。名字永不进入聚类/打分。
+ */
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { FALLBACK_LOCALE } from '../../../../../../scripts/locale.mjs'
+import { loadFollowingForActor } from '../following.mjs'
+import { commitTimelineEvent } from '../timeline/append.mjs'
+import { getTimelineMaterialized } from '../timeline/materialize.mjs'
+
+import { collapseTasteWeights, loadTaste, resolveTasteAlias } from './store.mjs'
+
+/**
+ * 发布本地命名（tag_name 事件）；受 publishPreferences 控制是否 fanout。
+ * @param {string} username replica
+ * @param {string} entityHash 标注者
+ * @param {{ tagHash: string, locale: string, label: string }} input 命名
+ * @returns {Promise<object>} 签名事件
+ */
+export async function publishTagName(username, entityHash, input) {
+	const tagHash = String(input.tagHash || '').trim().toLowerCase()
+	const locale = String(input.locale || '').trim()
+	const label = String(input.label || '').trim().slice(0, 64)
+	const actor = String(entityHash).toLowerCase()
+	if (!tagHash || !locale || !label || !parseEntityHash(actor))
+		throw new Error('invalid tag name claim')
+	const taste = await loadTaste(username, actor)
+	const fanout = taste.privacy.publishPreferences !== false
+	return commitTimelineEvent(username, actor, {
+		type: 'tag_name',
+		content: { tagHash, locale, label },
+	}, { fanout })
+}
+
+/**
+ * 信任加权解析显示名（自己 → 好友标注优先）。
+ * @param {string} username replica
+ * @param {string} viewerEntityHash 观看者
+ * @param {string} tagHash tag
+ * @param {string} [locale] locale；缺省 en-UK
+ * @returns {Promise<string | null>} 显示名
+ */
+export async function resolveTagDisplayName(username, viewerEntityHash, tagHash, locale = FALLBACK_LOCALE) {
+	const viewer = String(viewerEntityHash).toLowerCase()
+	const taste = await loadTaste(username, viewer)
+	const canon = resolveTasteAlias(tagHash, taste.aliases)
+	const ownView = await getTimelineMaterialized(username, viewer)
+	const ownNames = ownView.tagNames || {}
+	if (ownNames[canon]?.[locale]) return ownNames[canon][locale]
+	if (ownNames[String(tagHash).toLowerCase()]?.[locale])
+		return ownNames[String(tagHash).toLowerCase()][locale]
+
+	const { following } = await loadFollowingForActor(username, viewer)
+	/** @type {{ label: string, weight: number }[]} */
+	const candidates = []
+	for (const friend of following) {
+		const view = await getTimelineMaterialized(username, friend)
+		const names = view.tagNames || {}
+		const friendTaste = await loadTaste(username, friend)
+		const friendCanon = resolveTasteAlias(canon, friendTaste.aliases)
+		const label = names[friendCanon]?.[locale] || names[canon]?.[locale]
+		if (!label) continue
+		const parsed = parseEntityHash(friend)
+		const score = parsed ? pickNodeScore(parsed.nodeHash) : 0
+		candidates.push({ label, weight: Math.max(0.05, 0.5 + score / 2) })
+	}
+	if (!candidates.length) return null
+	candidates.sort((a, b) => b.weight - a.weight)
+	return candidates[0].label
+}
+
+/**
+ * 列出观看者偏好 tags（含解析名）。
+ * @param {string} username replica
+ * @param {string} entityHash acting
+ * @param {string} [locale] locale；缺省 en-UK
+ * @returns {Promise<{ tagHash: string, weight: number, label: string | null }[]>} 标签列表
+ */
+export async function listTasteTags(username, entityHash, locale = FALLBACK_LOCALE) {
+	const taste = await loadTaste(username, entityHash)
+	const collapsed = collapseTasteWeights(taste)
+	const rows = []
+	for (const [tagHash, weight] of collapsed) {
+		if (!weight) continue
+		rows.push({
+			tagHash,
+			weight,
+			label: await resolveTagDisplayName(username, entityHash, tagHash, locale),
+		})
+	}
+	rows.sort((a, b) => Math.abs(b.weight) - Math.abs(a.weight))
+	return rows
+}

--- a/src/public/parts/shells/social/src/taste/store.mjs
+++ b/src/public/parts/shells/social/src/taste/store.mjs
@@ -1,0 +1,179 @@
+/**
+ * 实体口味偏好表存储（计算权重 / 手动覆盖 / 软别名 / 隐私）。
+ * 别名表持久不过期；声明收件箱另行有界。
+ * 标签显示名由时间线 tag_name 事件承载，不写入本文件。
+ */
+import path from 'node:path'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { writeJsonAtomic } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { withAsyncMutex } from 'npm:@steve02081504/fount-p2p/utils/async_mutex'
+
+import { getUserDictionary } from '../../../../../../server/auth/index.mjs'
+
+/**
+ * @typedef {{
+ *   computed: Record<string, number>,
+ *   manual: Record<string, number>,
+ *   aliases: Record<string, { to: string, confidence: number, evidence?: object }>,
+ *   privacy: { publishPreferences: boolean, publishReactions: boolean },
+ *   clusteredAt: number,
+ *   postTags: Record<string, { tags: string[], selfWeight: number }>,
+ * }} TasteStore
+ */
+
+/** @returns {TasteStore} 空偏好表 */
+export function emptyTasteStore() {
+	return {
+		computed: {},
+		manual: {},
+		aliases: {},
+		privacy: { publishPreferences: true, publishReactions: true },
+		clusteredAt: 0,
+		postTags: {},
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting entity
+ * @returns {string} 偏好文件路径
+ */
+export function tasteStorePath(username, entityHash) {
+	return path.join(
+		getUserDictionary(username),
+		'shells/social/taste',
+		`${String(entityHash).toLowerCase()}.json`,
+	)
+}
+
+/**
+ * @param {unknown} value 候选记录
+ * @returns {Record<string, *>} 浅拷贝或空对象
+ */
+function asRecord(value) {
+	return value && typeof value === 'object' ? { .../** @type {object} */ value } : {}
+}
+
+/**
+ * @param {object | null | undefined} raw 磁盘数据
+ * @returns {TasteStore} 规范化
+ */
+export function normalizeTasteStore(raw) {
+	const base = emptyTasteStore()
+	if (!raw || typeof raw !== 'object') return base
+	return {
+		computed: asRecord(raw.computed),
+		manual: asRecord(raw.manual),
+		aliases: asRecord(raw.aliases),
+		privacy: {
+			publishPreferences: raw.privacy?.publishPreferences !== false,
+			publishReactions: raw.privacy?.publishReactions !== false,
+		},
+		clusteredAt: Number(raw.clusteredAt) || 0,
+		postTags: asRecord(raw.postTags),
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting entity
+ * @returns {Promise<TasteStore>} 偏好表
+ */
+export async function loadTaste(username, entityHash) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(hash)) return emptyTasteStore()
+	const { readFile } = await import('node:fs/promises')
+	try {
+		return normalizeTasteStore(JSON.parse(await readFile(tasteStorePath(username, hash), 'utf8')))
+	}
+	catch (err) {
+		if (err?.code !== 'ENOENT') throw err
+		return emptyTasteStore()
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting entity
+ * @param {TasteStore} store 偏好表
+ * @returns {Promise<TasteStore>} 落盘后规范化结果
+ */
+export async function saveTaste(username, entityHash, store) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	if (!parseEntityHash(hash)) throw new Error('invalid entityHash')
+	const normalized = normalizeTasteStore(store)
+	await withAsyncMutex(`taste-store:${username}:${hash}`, async () => {
+		const { mkdir } = await import('node:fs/promises')
+		const filePath = tasteStorePath(username, hash)
+		await mkdir(path.dirname(filePath), { recursive: true })
+		await writeJsonAtomic(filePath, normalized)
+	})
+	return normalized
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash acting entity
+ * @param {(store: TasteStore) => TasteStore | void | Promise<TasteStore | void>} mutator 突变
+ * @returns {Promise<TasteStore>} 写入后偏好
+ */
+export async function mutateTaste(username, entityHash, mutator) {
+	const hash = String(entityHash || '').trim().toLowerCase()
+	return withAsyncMutex(`taste-store:${username}:${hash}`, async () => {
+		const current = await loadTaste(username, hash)
+		const next = await mutator(current) || current
+		const normalized = normalizeTasteStore(next)
+		const { mkdir } = await import('node:fs/promises')
+		const filePath = tasteStorePath(username, hash)
+		await mkdir(path.dirname(filePath), { recursive: true })
+		await writeJsonAtomic(filePath, normalized)
+		return normalized
+	})
+}
+
+/**
+ * 沿软别名表解析 canonical tag（有环则停）。
+ * @param {string} tagHash tag
+ * @param {Record<string, { to: string, confidence: number }>} aliases 别名表
+ * @returns {string} canonical
+ */
+export function resolveTasteAlias(tagHash, aliases) {
+	let current = String(tagHash || '').trim().toLowerCase()
+	const seen = new Set()
+	while (aliases[current]?.to && !seen.has(current)) {
+		seen.add(current)
+		current = String(aliases[current].to).trim().toLowerCase()
+	}
+	return current
+}
+
+/**
+ * computed + manual 合计权重（经别名）。
+ * @param {TasteStore} store 偏好
+ * @param {string} tagHash tag
+ * @returns {number} 权重
+ */
+export function tasteWeightOf(store, tagHash) {
+	const canon = resolveTasteAlias(tagHash, store.aliases)
+	return (Number(store.computed[canon]) || 0) + (Number(store.manual[canon]) || 0)
+}
+
+/**
+ * 折叠全部 tag 权重（computed + manual）。
+ * @param {TasteStore} store 偏好
+ * @returns {Map<string, number>} canonical → 合计权重
+ */
+export function collapseTasteWeights(store) {
+	/** @type {Map<string, number>} */
+	const collapsed = new Map()
+	for (const [raw, weight] of Object.entries(store.computed || {})) {
+		const canon = resolveTasteAlias(raw, store.aliases)
+		collapsed.set(canon, (collapsed.get(canon) || 0) + (Number(weight) || 0))
+	}
+	for (const [raw, weight] of Object.entries(store.manual || {})) {
+		const canon = resolveTasteAlias(raw, store.aliases)
+		collapsed.set(canon, (collapsed.get(canon) || 0) + (Number(weight) || 0))
+	}
+	return collapsed
+}

--- a/src/public/parts/shells/social/src/timeline/append.mjs
+++ b/src/public/parts/shells/social/src/timeline/append.mjs
@@ -1,0 +1,245 @@
+import { Buffer } from 'node:buffer'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pubKeyHash, publicKeyFromSeed } from 'npm:@steve02081504/fount-p2p/crypto'
+import { appendJsonlSynced, readJsonl } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { computeAppendHlcAndPrev, signTimelineEvent } from 'npm:@steve02081504/fount-p2p/timeline/append_core'
+
+import {
+	consumePendingRecoverySecret,
+	getEntityRecoverySecretKey,
+	getEntitySecretKey,
+	getRecoveryPubKeyHex,
+	loadEntityIdentity,
+	resolveCharPartNameForEntity,
+} from '../../../chat/src/entity/identity.mjs'
+import { projectFollowerIndexFromTimelineEvent } from '../federation/follower/index.mjs'
+import { projectNoteFromTimelineEvent } from '../federation/note/index.mjs'
+import { projectPollVoteFromTimelineEvent } from '../federation/poll/index.mjs'
+import { projectReactionFromTimelineEvent } from '../federation/reaction/index.mjs'
+import { getEntityProfile } from '../lib/entityProfile.mjs'
+import { groupIdForTimeline, timelineEventsPath } from '../paths.mjs'
+
+import { canonicalizeLocalTimelineEvent } from './canonicalizeEvent.mjs'
+import { publishTimelineEvent } from './fanout.mjs'
+import { invalidateTimelineMaterializedCache, maintainSocialTimeline } from './materialize.mjs'
+import { invalidateTimelineOwnerIndex } from './ownerIndex.mjs'
+
+const NODE_ID = 'social-local'
+
+/**
+ * @param {Uint8Array} secretKey 签名私钥
+ * @returns {{ sender: string, secretKey: Uint8Array }} 时间线签名者
+ */
+function timelineSignerFromSecret(secretKey) {
+	return { sender: pubKeyHash(publicKeyFromSeed(secretKey)), secretKey }
+}
+
+/**
+ * 按目标 entityHash 解析本机实体活跃钥签名者。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<{ sender: string, secretKey: Uint8Array }>} 活跃钥签名者
+ */
+async function resolveActiveTimelineSigner(username, entityHash) {
+	const secretHex = await getEntitySecretKey(username, entityHash)
+	if (!secretHex || secretHex.length !== 64) throw new Error('configure entity identity before posting')
+	return timelineSignerFromSecret(new Uint8Array(Buffer.from(secretHex, 'hex')))
+}
+
+/**
+ * 本 replica 是否可写该 entity 的时间线（本机托管且持有活跃私钥）。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 128 位 entityHash
+ * @returns {Promise<boolean>} 是否可写
+ */
+export async function canWriteTimeline(username, entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed || parsed.nodeHash !== getNodeHash()) return false
+	try {
+		await loadEntityIdentity(username, parsed.entityHash)
+		const secretHex = await getEntitySecretKey(username, parsed.entityHash)
+		return !!(secretHex && secretHex.length === 64)
+	}
+	catch {
+		return false
+	}
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 128 hex
+ * @returns {Promise<void>}
+ */
+export async function assertWritableTimeline(username, entityHash) {
+	if (!await canWriteTimeline(username, entityHash))
+		throw new Error('cannot write timeline for this entity on this replica')
+}
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 未签名事件
+ * @param {Uint8Array} secretKey 签名私钥
+ * @returns {Promise<object>} 签名事件
+ */
+async function appendSignedTimelineEvent(username, entityHash, event, secretKey) {
+	await assertWritableTimeline(username, entityHash)
+	if (event.type !== 'social_meta' && event.type !== 'entity_key_rotate')
+		await assertSocialMetaExists(username, entityHash)
+	const groupId = groupIdForTimeline(entityHash)
+	const previous = await readJsonl(timelineEventsPath(username, entityHash))
+	const { hlc, prev_event_ids } = computeAppendHlcAndPrev(previous, event)
+	const { sender } = timelineSignerFromSecret(secretKey)
+	const charPartName = event.charPartName
+		?? await resolveCharPartNameForEntity(username, entityHash)
+	const base = {
+		type: event.type,
+		groupId,
+		sender,
+		charPartName: charPartName ?? null,
+		timestamp: event.timestamp ?? Date.now(),
+		hlc,
+		prev_event_ids,
+		content: event.content ?? {},
+		node_id: NODE_ID,
+	}
+	const signed = await signTimelineEvent(base, secretKey)
+	const row = canonicalizeLocalTimelineEvent(signed)
+	await appendJsonlSynced(timelineEventsPath(username, entityHash), row)
+	invalidateTimelineMaterializedCache(username, entityHash)
+	invalidateTimelineOwnerIndex(username)
+	await projectFollowerIndexFromTimelineEvent(username, entityHash, row)
+	await projectPollVoteFromTimelineEvent(username, entityHash, row)
+	await projectReactionFromTimelineEvent(username, entityHash, row)
+	await projectNoteFromTimelineEvent(username, entityHash, row)
+	await maintainSocialTimeline(username, entityHash)
+	const { appendInboxFromTimelineEvent } = await import('../inbox.mjs')
+	await appendInboxFromTimelineEvent(username, entityHash, row)
+	const { indexTimelineEventForSearch } = await import('../searchIndex.mjs')
+	await indexTimelineEventForSearch(username, entityHash, row)
+	return row
+}
+
+/**
+ * 解析写事件签名者：缺省为时间线 owner；owner 改/删所属实体帖时可指定 signerEntityHash。
+ * @param {string} username replica 登录名
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 未签名事件
+ * @param {string} [signerEntityHash] 签名实体（缺省 = 时间线 owner）
+ * @returns {Promise<string>} 规范化 signer entityHash
+ */
+async function resolveTimelineEventSigner(username, entityHash, event, signerEntityHash) {
+	const timelineOwner = String(entityHash || '').trim().toLowerCase()
+	const signer = String(signerEntityHash || timelineOwner).trim().toLowerCase()
+	if (signer === timelineOwner) return signer
+	if (event?.type !== 'post_delete' && event?.type !== 'post_edit')
+		throw new Error('foreign signer only allowed for post_delete or post_edit')
+	const profile = await getEntityProfile(username, timelineOwner)
+	const owner = String(profile?.ownerEntityHash || '').trim().toLowerCase()
+	if (!owner || owner !== signer)
+		throw new Error('signer is not owner of timeline entity')
+	return signer
+}
+
+/**
+ * 向时间线追加一条签名事件（缺省实体自身活跃钥；owner 删帖可改 signer）。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 未签名事件（type/content/timestamp）
+ * @param {{ signerEntityHash?: string }} [options] 签名选项
+ * @returns {Promise<object>} 签名事件
+ */
+export async function appendTimelineEvent(username, entityHash, event, options = {}) {
+	const signer = await resolveTimelineEventSigner(username, entityHash, event, options.signerEntityHash)
+	const { secretKey } = await resolveActiveTimelineSigner(username, signer)
+	return appendSignedTimelineEvent(username, entityHash, event, secretKey)
+}
+
+/**
+ * 创建 social_meta + entity_key_rotate 创世事件。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<void>}
+ */
+export async function ensureSocialMeta(username, entityHash) {
+	const previous = await readJsonl(timelineEventsPath(username, entityHash))
+	if (previous.some(event => event.type === 'social_meta')) return
+
+	const recoveryPubKeyHex = await getRecoveryPubKeyHex(username, entityHash)
+	const { secretKey: activeSecret } = await resolveActiveTimelineSigner(username, entityHash)
+	const activePubKeyHex = Buffer.from(publicKeyFromSeed(activeSecret)).toString('hex')
+
+	// 创世 social_meta 必须 recovery 签，远端 pull 才能无先验链引导
+	let recoverySecretHex = consumePendingRecoverySecret(username, entityHash)
+	if (!recoverySecretHex)
+		recoverySecretHex = await getEntityRecoverySecretKey(username, entityHash)
+	const recoverySecret = new Uint8Array(Buffer.from(recoverySecretHex, 'hex'))
+
+	await appendSignedTimelineEvent(username, entityHash, {
+		type: 'social_meta',
+		content: {
+			hideFromDiscovery: false,
+			createdAt: Date.now(),
+			recoveryPubKeyHex,
+		},
+	}, recoverySecret)
+
+	if (!previous.some(event => event.type === 'entity_key_rotate'))
+		await appendSignedTimelineEvent(username, entityHash, {
+			type: 'entity_key_rotate',
+			content: {
+				generation: 0,
+				activePubKeyHex,
+				prevGeneration: null,
+			},
+		}, recoverySecret)
+}
+
+/**
+ * 校验时间线已有 social_meta 创世事件。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<void>}
+ */
+async function assertSocialMetaExists(username, entityHash) {
+	const previous = await readJsonl(timelineEventsPath(username, entityHash))
+	if (!previous.some(event => event.type === 'social_meta'))
+		throw new Error('timeline missing social_meta; call ensureEntitySocialReady first')
+}
+
+/**
+ * 读取时间线全部 events.jsonl 事件。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<object[]>} 全部事件
+ */
+export async function readTimelineEvents(username, entityHash) {
+	return readJsonl(timelineEventsPath(username, entityHash))
+}
+
+/**
+ * 签名写盘并按需联邦 fanout。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 未签名事件
+ * @param {{ fanout?: boolean, signerEntityHash?: string }} [options] 默认 fanout=true
+ * @returns {Promise<object>} 签名事件
+ */
+export async function commitTimelineEvent(username, entityHash, event, options = {}) {
+	const signed = await appendTimelineEvent(username, entityHash, event, {
+		signerEntityHash: options.signerEntityHash,
+	})
+	if (options.fanout !== false)
+		await publishTimelineEvent(username, entityHash, signed)
+	if (signed.type === 'post') {
+		const { dispatchSocialMessage } = await import('../dispatch.mjs')
+		await dispatchSocialMessage(username, entityHash, signed)
+		if (signed.content?.poll) {
+			const { schedulePollDeadlineForPost } = await import('../lib/pollDeadlineWatcher.mjs')
+			void schedulePollDeadlineForPost(username, entityHash, signed)
+		}
+	}
+	return signed
+}

--- a/src/public/parts/shells/social/src/timeline/canonicalizeEvent.mjs
+++ b/src/public/parts/shells/social/src/timeline/canonicalizeEvent.mjs
@@ -1,0 +1,34 @@
+/**
+ * Social 时间线事件入库 canonicalize。
+ */
+import { canonicalizeSignedRow } from 'npm:@steve02081504/fount-p2p/dag/canonicalize_row'
+import { validateRemoteEventShape } from 'npm:@steve02081504/fount-p2p/schemas/remote_event'
+
+/** Social 时间线 canonicalize 选项 */
+export const SOCIAL_TIMELINE_ROW_OPTS = {
+	contentHexKeys: new Set([
+		'targetPostId',
+		'targetId',
+		'noteEventId',
+	]),
+	entityHashKeys: new Set([
+		'targetEntityHash',
+	]),
+}
+
+/**
+ * @param {object} event 签名事件
+ * @returns {object} canonical 行
+ */
+export function canonicalizeLocalTimelineEvent(event) {
+	return canonicalizeSignedRow(event, SOCIAL_TIMELINE_ROW_OPTS)
+}
+
+/**
+ * @param {object} event 远程入站事件
+ * @returns {object} canonical 行
+ */
+export function canonicalizeSignedTimelineEvent(event) {
+	validateRemoteEventShape(event)
+	return canonicalizeLocalTimelineEvent(event)
+}

--- a/src/public/parts/shells/social/src/timeline/entityKey/commit.mjs
+++ b/src/public/parts/shells/social/src/timeline/entityKey/commit.mjs
@@ -1,0 +1,113 @@
+import { Buffer } from 'node:buffer'
+
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pubKeyHash, publicKeyFromSeed } from 'npm:@steve02081504/fount-p2p/crypto'
+import { appendJsonlSynced, readJsonl } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { computeAppendHlcAndPrev, signTimelineEvent } from 'npm:@steve02081504/fount-p2p/timeline/append_core'
+
+import { getEntitySecretKey } from '../../../../chat/src/entity/identity.mjs'
+import { groupIdForTimeline, timelineEventsPath } from '../../paths.mjs'
+import { canonicalizeLocalTimelineEvent } from '../canonicalizeEvent.mjs'
+import { publishTimelineEvent } from '../fanout.mjs'
+
+const NODE_ID = 'social-local'
+
+/**
+ * @param {Uint8Array} secretKey 私钥
+ * @returns {{ sender: string, secretKey: Uint8Array }} 签名者
+ */
+function timelineSignerFromSecret(secretKey) {
+	return { sender: pubKeyHash(publicKeyFromSeed(secretKey)), secretKey }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 128 hex
+ * @returns {Promise<{ sender: string, secretKey: Uint8Array }>} 实体活跃钥签名者
+ */
+async function resolveEntityTimelineSigner(username, entityHash) {
+	const secretHex = await getEntitySecretKey(username, entityHash)
+	if (!secretHex || secretHex.length !== 64) throw new Error('configure entity identity before key commit')
+	const secretKey = new Uint8Array(Buffer.from(secretHex, 'hex'))
+	return timelineSignerFromSecret(secretKey)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 128 hex
+ * @returns {Promise<void>}
+ */
+async function assertWritableEntityTimeline(username, entityHash) {
+	const parsed = parseEntityHash(entityHash)
+	if (!parsed || parsed.nodeHash !== getNodeHash()) throw new Error('cannot write timeline for this entity on this replica')
+	await resolveEntityTimelineSigner(username, entityHash)
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 128 hex
+ * @param {object} event 未签名事件
+ * @param {Uint8Array} secretKey 签名私钥
+ * @returns {Promise<object>} 签名事件
+ */
+async function appendSignedEntityTimelineEvent(username, entityHash, event, secretKey) {
+	await assertWritableEntityTimeline(username, entityHash)
+	const groupId = groupIdForTimeline(entityHash)
+	const previous = await readJsonl(timelineEventsPath(username, entityHash))
+	const { hlc, prev_event_ids } = computeAppendHlcAndPrev(previous, event)
+	const { sender } = timelineSignerFromSecret(secretKey)
+	const base = {
+		type: event.type,
+		groupId,
+		sender,
+		charId: event.charId ?? null,
+		timestamp: event.timestamp ?? Date.now(),
+		hlc,
+		prev_event_ids,
+		content: event.content ?? {},
+		node_id: NODE_ID,
+	}
+	const signed = await signTimelineEvent(base, secretKey)
+	const row = canonicalizeLocalTimelineEvent(signed)
+	await appendJsonlSynced(timelineEventsPath(username, entityHash), row)
+	return row
+}
+
+/**
+ * 主动轮换实体活跃钥并广播时间线事件。
+ * @param {string} username replica
+ * @param {string} entityHash 实体 entityHash
+ * @param {object} rotation 轮换结果
+ * @returns {Promise<object>} 签名事件
+ */
+export async function commitEntityKeyRotate(username, entityHash, rotation) {
+	const { secretKey } = await resolveEntityTimelineSigner(username, entityHash)
+	const signed = await appendSignedEntityTimelineEvent(username, entityHash, {
+		type: 'entity_key_rotate',
+		content: {
+			generation: rotation.keyGeneration,
+			activePubKeyHex: rotation.activePubKeyHex,
+			prevGeneration: rotation.prevGeneration,
+		},
+	}, secretKey)
+	await publishTimelineEvent(username, entityHash, signed)
+	return signed
+}
+
+/**
+ * recovery 钥签发 revoke + 新活跃钥。
+ * @param {string} username replica
+ * @param {string} entityHash 实体 entityHash
+ * @param {object} revokeBody 吊销正文
+ * @param {Uint8Array} recoverySecretKey recovery 私钥
+ * @returns {Promise<object>} revoke 事件
+ */
+export async function commitEntityKeyRevoke(username, entityHash, revokeBody, recoverySecretKey) {
+	const signed = await appendSignedEntityTimelineEvent(username, entityHash, {
+		type: 'entity_key_revoke',
+		content: revokeBody,
+	}, recoverySecretKey)
+	await publishTimelineEvent(username, entityHash, signed)
+	return signed
+}

--- a/src/public/parts/shells/social/src/timeline/fanout.mjs
+++ b/src/public/parts/shells/social/src/timeline/fanout.mjs
@@ -1,0 +1,20 @@
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { DEFAULT_TRUST_GRAPH_OWNER, requireTrustGraphProvider } from 'npm:@steve02081504/fount-p2p/trust_graph/registry'
+import { TIMELINE_FANOUT_LIMIT } from 'npm:@steve02081504/fount-p2p/wire/part_common'
+
+/**
+ * 将签名时间线事件 fanout 到信任图 Top 节点。
+ * @param {string} username replica
+ * @param {string} entityHash owner
+ * @param {object} signedEvent 签名事件
+ * @returns {Promise<number>} 发送次数
+ */
+export async function publishTimelineEvent(username, entityHash, signedEvent) {
+	return requireTrustGraphProvider(DEFAULT_TRUST_GRAPH_OWNER).fanoutToTopNodes(username, 'part_timeline_put', {
+		nodeHash: getNodeHash(),
+		partpath: getShellPartpath('social'),
+		timelineEntityHash: entityHash.toLowerCase(),
+		event: signedEvent,
+	}, TIMELINE_FANOUT_LIMIT)
+}

--- a/src/public/parts/shells/social/src/timeline/federationExport.mjs
+++ b/src/public/parts/shells/social/src/timeline/federationExport.mjs
@@ -1,0 +1,119 @@
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+
+import { getOperatorEntityHashProvider } from '../federation/follower/registry.mjs'
+import { filterTimelineEventsForFederation } from '../federation/visibility.mjs'
+import { canViewPost } from '../feedVisibility.mjs'
+import { latestFollowWallForAuthor } from '../lib/replyPolicy.mjs'
+
+import { getTimelineMaterialized } from './materialize.mjs'
+import { listLocalEntitiesForNode } from './ownerIndex.mjs'
+
+/**
+ * federation_visibility 使用的 (post, requesterEntityHash, blocked, following, followSince) 形状适配。
+ * @param {object} post 帖子视图
+ * @param {string | null} requesterEntityHash 请求者 entityHash
+ * @param {Set<string>} blocked 个人拉黑集合
+ * @param {Set<string>} following 请求者关注集合
+ * @param {Map<string, number>} [followSince] 关注起始 wall
+ * @returns {boolean} 是否可见
+ */
+function canViewPostForFederationExport(post, requesterEntityHash, blocked, following, followSince = new Map()) {
+	return canViewPost(post, {
+		viewerEntityHash: requesterEntityHash,
+		following,
+		followSince,
+		at: Date.now(),
+		personalFilter: {
+			blockedEntityHashes: blocked,
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		},
+	})
+}
+
+/**
+ * @param {string} username replica
+ * @param {string | null | undefined} requesterNodeHash 64 hex
+ * @param {string} ownerEntityHash 时间线 owner
+ * @returns {Promise<object>} 请求者上下文
+ */
+async function resolveFederationRequesterContext(username, requesterNodeHash, ownerEntityHash) {
+	const owner = String(ownerEntityHash).toLowerCase()
+	const localNode = getNodeHash()
+	const requesterNode = requesterNodeHash?.trim().toLowerCase() || null
+	const ownerView = await getTimelineMaterialized(username, owner)
+	const hideFromDiscovery = Boolean(ownerView.socialMeta?.hideFromDiscovery)
+	const { loadTaste } = await import('../taste/store.mjs')
+	const taste = await loadTaste(username, owner)
+	const publishReactions = taste.privacy.publishReactions !== false
+	const publishPreferences = taste.privacy.publishPreferences !== false
+	const albums = ownerView.albums || {}
+
+	/**
+	 * @param {string | null} entityHash 请求者
+	 * @param {boolean} followsOwner 是否关注
+	 * @param {boolean} isOwner 是否 owner
+	 * @param {Map<string, number>} [followSince] 关注时长
+	 * @returns {object} context
+	 */
+	function base(entityHash, followsOwner, isOwner, followSince = new Map()) {
+		return {
+			requesterEntityHash: entityHash,
+			followsOwner,
+			isOwner,
+			hideFromDiscovery,
+			publishReactions,
+			publishPreferences,
+			followSince,
+			albums,
+		}
+	}
+
+	if (!requesterNode)
+		return base(null, false, false)
+
+	if (requesterNode === localNode) {
+		const resolveOperator = getOperatorEntityHashProvider()
+		const operator = resolveOperator ? await resolveOperator(username) : null
+		const operatorView = operator ? await getTimelineMaterialized(username, operator) : null
+		const followsOwner = operatorView?.following?.includes(owner) ?? false
+		/** @type {Map<string, number>} */
+		const followSince = new Map()
+		if (followsOwner && operatorView) {
+			const wall = latestFollowWallForAuthor(operatorView, owner)
+			if (wall != null) followSince.set(owner, wall)
+			else if (operator?.toLowerCase() === owner) followSince.set(owner, 0)
+		}
+		return base(operator, followsOwner, operator?.toLowerCase() === owner, followSince)
+	}
+
+	for (const entityHash of await listLocalEntitiesForNode(username, requesterNode)) {
+		const view = await getTimelineMaterialized(username, entityHash)
+		const followsOwner = view.following.includes(owner)
+		/** @type {Map<string, number>} */
+		const followSince = new Map()
+		if (followsOwner) {
+			const wall = latestFollowWallForAuthor(view, owner)
+			if (wall != null) followSince.set(owner, wall)
+			else if (entityHash === owner) followSince.set(owner, 0)
+		}
+		return base(entityHash, followsOwner, entityHash === owner, followSince)
+	}
+
+	return base(null, false, false)
+}
+
+/**
+ * 联邦 RPC 出站：按可见性过滤时间线事件（外来 ingress 响应边界）。
+ * @param {string} username 本地 replica
+ * @param {string} ownerEntityHash 时间线 owner
+ * @param {object[]} events 原始事件
+ * @param {string | null | undefined} requesterNodeHash 请求方 nodeHash
+ * @returns {Promise<object[]>} 过滤后的事件
+ */
+export async function filterEventsForFederatedPull(username, ownerEntityHash, events, requesterNodeHash) {
+	const owner = String(ownerEntityHash).toLowerCase()
+	const requesterContext = await resolveFederationRequesterContext(username, requesterNodeHash, owner)
+	return filterTimelineEventsForFederation(events, owner, requesterContext, canViewPostForFederationExport)
+}

--- a/src/public/parts/shells/social/src/timeline/materialize.mjs
+++ b/src/public/parts/shells/social/src/timeline/materialize.mjs
@@ -1,0 +1,153 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { readJsonlTipId } from 'npm:@steve02081504/fount-p2p/dag/storage'
+import { materializeFromEvents } from 'npm:@steve02081504/fount-p2p/timeline/materialize_runner'
+
+import { createLruMap } from '../../../../../../scripts/memo.mjs'
+import { timelineEventsPath, timelineSnapshotPath } from '../paths.mjs'
+
+import { readTimelineEvents } from './append.mjs'
+import {
+	createSocialTimelineState,
+	finalizeSocialTimelineView,
+	SOCIAL_TIMELINE_REDUCERS,
+} from './reducers.mjs'
+
+const TIMELINE_VIEW_CACHE_MAX = 256
+
+/** @type {ReturnType<typeof createLruMap<Map<string, { tipId: string | null, view: object }>>>} */
+const timelineViewCache = createLruMap(TIMELINE_VIEW_CACHE_MAX)
+
+/**
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Map<string, { tipId: string | null, view: object }>} 该用户的 entity 物化缓存桶
+ */
+function timelineCacheBucket(username) {
+	let bucket = timelineViewCache.get(username)
+	if (!bucket) {
+		bucket = new Map()
+		timelineViewCache.touch(username, bucket)
+	}
+	return bucket
+}
+
+/**
+ * 时间线 events 变更后失效内存物化缓存。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {void}
+ */
+export function invalidateTimelineMaterializedCache(username, entityHash) {
+	const target = String(entityHash).toLowerCase()
+	const inner = timelineViewCache.get(username)
+	if (!inner) return
+	inner.delete(target)
+	if (!inner.size) timelineViewCache.delete(username)
+}
+
+/**
+ * 将原始时间线事件物化为 reducer 视图。
+ * @param {object[]} events 原始事件
+ * @returns {object} 物化视图
+ */
+export function materializeTimeline(events) {
+	const { state, order } = materializeFromEvents(events, SOCIAL_TIMELINE_REDUCERS, createSocialTimelineState)
+	return finalizeSocialTimelineView(state, order)
+}
+
+/**
+ * 读取磁盘上的物化快照（不重新计算）。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<object | null>} 缓存快照
+ */
+export async function loadTimelineSnapshot(username, entityHash) {
+	try {
+		const { readFile } = await import('node:fs/promises')
+		return JSON.parse(await readFile(timelineSnapshotPath(username, entityHash), 'utf8'))
+	}
+	catch {
+		return null
+	}
+}
+
+/**
+ * @param {object | null} cached 磁盘快照
+ * @param {string | null} tipId 当前 events.jsonl DAG tip
+ * @returns {boolean} 快照是否与 tip 一致
+ */
+function snapshotMatchesTip(cached, tipId) {
+	return cached?.checkpoint_event_id === tipId
+}
+
+/**
+ * 读取并物化时间线（只读：不写 snapshot、不跑 retention）。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<object>} 物化视图
+ */
+export async function getTimelineMaterialized(username, entityHash) {
+	if (!parseEntityHash(entityHash)) throw new Error('invalid entityHash')
+	const eventsPath = timelineEventsPath(username, entityHash)
+	const entityKey = String(entityHash).toLowerCase()
+	const tipId = await readJsonlTipId(eventsPath)
+
+	const bucket = timelineCacheBucket(username)
+	const memoryHit = bucket.get(entityKey)
+	if (memoryHit && memoryHit.tipId === tipId)
+		return ensureTimelineViewDefaults(memoryHit.view)
+
+	const cached = await loadTimelineSnapshot(username, entityHash)
+	if (snapshotMatchesTip(cached, tipId)) {
+		const view = ensureTimelineViewDefaults(cached)
+		const entry = { tipId, view }
+		bucket.set(entityKey, entry)
+		timelineViewCache.touch(username, bucket)
+		return entry.view
+	}
+
+	const events = await readTimelineEvents(username, entityHash)
+	const view = ensureTimelineViewDefaults(materializeTimeline(events))
+	bucket.set(entityKey, { tipId, view })
+	timelineViewCache.touch(username, bucket)
+	return view
+}
+
+/**
+ * @param {object} view 物化视图
+ * @returns {object} 补齐新字段默认值
+ */
+function ensureTimelineViewDefaults(view) {
+	if (!view) return view
+	if (!view.followedTags) view.followedTags = []
+	if (!view.featuredReplies) view.featuredReplies = {}
+	if (!view.activeLives) view.activeLives = {}
+	return view
+}
+
+/**
+ * 显式维护：写 signed snapshot + 运行 retention（写路径或独立 endpoint 调用）。
+ * @param {string} username 用户
+ * @param {string} entityHash 时间线 owner
+ * @returns {Promise<object>} 落盘后的 signed snapshot
+ */
+export async function maintainSocialTimeline(username, entityHash) {
+	const entityKey = String(entityHash).toLowerCase()
+	const eventsPath = timelineEventsPath(username, entityHash)
+	const tipId = await readJsonlTipId(eventsPath)
+	const view = await getTimelineMaterialized(username, entityKey)
+	const snapshot = {
+		entityHash: entityKey,
+		checkpoint_event_id: tipId,
+		materializedAt: Date.now(),
+		...view,
+	}
+	const { rebuildSignedTimelineSnapshot } = await import('./rebuildCheckpoint.mjs')
+	const signedSnapshot = await rebuildSignedTimelineSnapshot(username, entityKey, snapshot)
+	const { runSocialTimelineMaintenance } = await import('./retention.mjs')
+	await runSocialTimelineMaintenance(username, entityKey, signedSnapshot, view.socialMeta)
+	const bucket = timelineCacheBucket(username)
+	bucket.set(entityKey, { tipId, view: signedSnapshot })
+	timelineViewCache.touch(username, bucket)
+	return signedSnapshot
+}

--- a/src/public/parts/shells/social/src/timeline/ownerIndex.mjs
+++ b/src/public/parts/shells/social/src/timeline/ownerIndex.mjs
@@ -1,0 +1,101 @@
+import { readdir } from 'node:fs/promises'
+
+import { isEntityHash128, parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { createLruMap } from '../../../../../../scripts/memo.mjs'
+import { getUserDictionary } from '../../../../../../server/auth/index.mjs'
+
+const INDEX_CACHE_MAX = 64
+
+/**
+ * @typedef {{ all: string[], byNode: Map<string, string[]> }} TimelineOwnerIndex
+ */
+
+/** @type {ReturnType<typeof createLruMap<TimelineOwnerIndex>>} */
+const indexByUser = createLruMap(INDEX_CACHE_MAX)
+
+/**
+ * @param {string} username replica 登录名
+ * @returns {string} timelines 根目录
+ */
+function timelinesRoot(username) {
+	return `${getUserDictionary(username)}/shells/social/timelines`
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @returns {Promise<TimelineOwnerIndex>} 重建索引
+ */
+async function rebuildTimelineOwnerIndex(username) {
+	/** @type {string[]} */
+	const all = []
+	/** @type {Map<string, string[]>} */
+	const byNode = new Map()
+	try {
+		const entries = await readdir(timelinesRoot(username), { withFileTypes: true })
+		for (const entry of entries) {
+			if (!entry.isDirectory()) continue
+			const entityHash = entry.name.toLowerCase()
+			if (!isEntityHash128(entityHash)) continue
+			const parsed = parseEntityHash(entityHash)
+			if (!parsed) continue
+			all.push(entityHash)
+			let list = byNode.get(parsed.nodeHash)
+			if (!list) {
+				list = []
+				byNode.set(parsed.nodeHash, list)
+			}
+			list.push(entityHash)
+		}
+		all.sort()
+		for (const list of byNode.values())
+			list.sort()
+	}
+	catch { /* missing root */ }
+	return { all, byNode }
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @returns {void}
+ */
+export function invalidateTimelineOwnerIndex(username) {
+	indexByUser.delete(username)
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @returns {Promise<TimelineOwnerIndex>} 本地 timeline owner 索引
+ */
+export async function getTimelineOwnerIndex(username) {
+	let index = indexByUser.get(username)
+	if (!index) {
+		index = await rebuildTimelineOwnerIndex(username)
+		indexByUser.touch(username, index)
+	}
+	else indexByUser.touch(username, index)
+	return index
+}
+
+/**
+ * @param {string} username replica 登录名
+ * @param {string} nodeHash 64 hex
+ * @returns {Promise<string[]>} 该节点在本 replica 托管的 entityHash
+ */
+export async function listLocalEntitiesForNode(username, nodeHash) {
+	const key = nodeHash?.toLowerCase()
+	if (!key) return []
+	return [...(await getTimelineOwnerIndex(username)).byNode.get(key) || []]
+}
+
+/**
+ * 列出磁盘上全部时间线 owner（探索/热搜用）。
+ * @param {string} username 用户
+ * @param {{ nodeHashPrefix?: string | null }} [options] 仅返回该 nodeHash 托管的 entity
+ * @returns {Promise<string[]>} 本地 timelines 目录下的 entityHash
+ */
+export async function listLocalTimelineDirs(username, options = {}) {
+	const prefix = (options.nodeHashPrefix || '').trim().toLowerCase() || null
+	if (prefix) return listLocalEntitiesForNode(username, prefix)
+	return [...(await getTimelineOwnerIndex(username)).all]
+}

--- a/src/public/parts/shells/social/src/timeline/rebuildCheckpoint.mjs
+++ b/src/public/parts/shells/social/src/timeline/rebuildCheckpoint.mjs
@@ -1,0 +1,32 @@
+import { Buffer } from 'node:buffer'
+
+import { signCheckpoint } from 'npm:@steve02081504/fount-p2p/crypto/checkpoint_sign'
+import { writeJsonAtomicSynced } from 'npm:@steve02081504/fount-p2p/dag/storage'
+
+import { getEntitySecretKey } from '../../../chat/src/entity/identity.mjs'
+import { timelineSnapshotPath } from '../paths.mjs'
+
+/**
+ * 将物化视图写成带 owner 签名的 snapshot.json。
+ * @param {string} username replica
+ * @param {string} entityHash 时间线 owner
+ * @param {object} view 物化视图（含 checkpoint_event_id）
+ * @returns {Promise<object>} 落盘快照
+ */
+export async function rebuildSignedTimelineSnapshot(username, entityHash, view) {
+	let secretHex = ''
+	try {
+		secretHex = await getEntitySecretKey(username, entityHash)
+	}
+	catch {
+		/* 远端/未托管实体无本地密钥，落未签名快照 */
+	}
+	if (!secretHex || secretHex.length !== 64) {
+		await writeJsonAtomicSynced(timelineSnapshotPath(username, entityHash), view)
+		return view
+	}
+	const secretKey = new Uint8Array(Buffer.from(secretHex, 'hex'))
+	const signed = await signCheckpoint(view, secretKey)
+	await writeJsonAtomicSynced(timelineSnapshotPath(username, entityHash), signed)
+	return signed
+}

--- a/src/public/parts/shells/social/src/timeline/reducers.mjs
+++ b/src/public/parts/shells/social/src/timeline/reducers.mjs
@@ -1,0 +1,557 @@
+import { reduceEntityKeyRevoke, reduceEntityKeyRotate } from 'npm:@steve02081504/fount-p2p/federation/entity_key_chain'
+
+import { socialPostKey } from '../federation/post_key.mjs'
+import { normalizeVisibilitySpec, visibilitySpecToContentFields } from '../lib/visibilitySpec.mjs'
+
+/** 虚拟默认相册 id（无事件、不参与密级派生） */
+export const DEFAULT_ALBUM_ID = 'default'
+
+/**
+ * Social 时间线物化 reducer 表。
+ */
+
+/**
+ * @returns {object} social 时间线物化初始状态
+ */
+export function createSocialTimelineState() {
+	return {
+		socialMeta: {},
+		posts: new Map(),
+		postEdits: new Map(),
+		deletedPostIds: new Set(),
+		likes: new Map(),
+		dislikes: new Map(),
+		pollVotes: new Map(),
+		reposts: [],
+		followEvents: [],
+		following: new Set(),
+		blocked: new Set(),
+		/** @type {Set<string>} */
+		followedTags: new Set(),
+		/** @type {Map<string, Set<string>>} targetPostId → featured reply keys */
+		featuredReplies: new Map(),
+		/** @type {Map<string, object>} liveId → live_start event */
+		activeLives: new Map(),
+		/** @type {Map<string, Record<string, string>>} tagHash → locale → label */
+		tagNames: new Map(),
+		/** @type {Map<string, object>} albumId → album */
+		albums: new Map(),
+		/** @type {Map<string, Set<string>>} postId → albumIds */
+		albumsByPost: new Map(),
+		entityKeyHistory: [],
+		recoveryPubKeyHex: null,
+	}
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceSocialMeta(state, event) {
+	Object.assign(state.socialMeta, event.content)
+	if (event.content?.recoveryPubKeyHex)
+		state.recoveryPubKeyHex = String(event.content.recoveryPubKeyHex).trim().toLowerCase()
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reducePost(state, event) {
+	state.posts.set(event.id, { ...event, postId: event.id })
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reducePostDelete(state, event) {
+	const postId = event.content.targetPostId
+	state.deletedPostIds.add(postId)
+	const albumIds = state.albumsByPost.get(postId)
+	if (albumIds) {
+		for (const albumId of albumIds) {
+			const album = state.albums.get(albumId)
+			if (album) album.postIds = album.postIds.filter(id => id !== postId)
+		}
+		state.albumsByPost.delete(postId)
+	}
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reducePostVisibilitySet(state, event) {
+	const targetPostId = event.content?.targetPostId
+	if (!targetPostId) return state
+	const base = state.posts.get(targetPostId)
+	if (!base) return state
+	const nextContent = event.content?.content
+	if (!nextContent || typeof nextContent !== 'object') return state
+	// 完整 content 快照已含历史编辑；清空 postEdits 避免 finalize 把明文 patch 叠到密文信封上
+	state.postEdits.delete(targetPostId)
+	state.posts.set(targetPostId, {
+		...base,
+		content: nextContent,
+		edited: base.edited || Boolean(base.revisions?.length),
+	})
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceAlbumCreate(state, event) {
+	const albumId = String(event.content?.albumId || event.id || '').trim()
+	if (!albumId || albumId === DEFAULT_ALBUM_ID) return state
+	const spec = normalizeVisibilitySpec(event.content)
+	state.albums.set(albumId, {
+		albumId,
+		name: String(event.content?.name || albumId).trim().slice(0, 80) || albumId,
+		description: String(event.content?.description || '').trim().slice(0, 500),
+		...visibilitySpecToContentFields(spec),
+		postIds: [],
+		createdEventId: event.id,
+	})
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceAlbumUpdate(state, event) {
+	const albumId = String(event.content?.albumId || '').trim()
+	if (!albumId || albumId === DEFAULT_ALBUM_ID) return state
+	const existing = state.albums.get(albumId)
+	if (!existing) return reduceAlbumCreate(state, event)
+	const spec = normalizeVisibilitySpec({ ...existing, ...event.content })
+	const name = event.content?.name != null
+		? String(event.content.name).trim().slice(0, 80) || existing.name
+		: existing.name
+	const description = event.content?.description != null
+		? String(event.content.description).trim().slice(0, 500)
+		: existing.description
+	state.albums.set(albumId, {
+		...existing,
+		name,
+		description,
+		...visibilitySpecToContentFields(spec),
+	})
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceAlbumDelete(state, event) {
+	const albumId = String(event.content?.albumId || '').trim()
+	if (!albumId || albumId === DEFAULT_ALBUM_ID) return state
+	const album = state.albums.get(albumId)
+	if (!album) return state
+	for (const postId of album.postIds) {
+		const set = state.albumsByPost.get(postId)
+		if (!set) continue
+		set.delete(albumId)
+		if (!set.size) state.albumsByPost.delete(postId)
+	}
+	state.albums.delete(albumId)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceAlbumPostAdd(state, event) {
+	const albumId = String(event.content?.albumId || '').trim()
+	const postId = String(event.content?.postId || '').trim()
+	if (!albumId || !postId || albumId === DEFAULT_ALBUM_ID) return state
+	const album = state.albums.get(albumId)
+	if (!album) return state
+	if (!album.postIds.includes(postId)) album.postIds.push(postId)
+	const set = state.albumsByPost.get(postId) || new Set()
+	set.add(albumId)
+	state.albumsByPost.set(postId, set)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceAlbumPostRemove(state, event) {
+	const albumId = String(event.content?.albumId || '').trim()
+	const postId = String(event.content?.postId || '').trim()
+	if (!albumId || !postId) return state
+	const album = state.albums.get(albumId)
+	if (album) album.postIds = album.postIds.filter(id => id !== postId)
+	const set = state.albumsByPost.get(postId)
+	if (set) {
+		set.delete(albumId)
+		if (!set.size) state.albumsByPost.delete(postId)
+	}
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reducePostEdit(state, event) {
+	const targetPostId = event.content.targetPostId
+	if (!targetPostId) return state
+	const list = state.postEdits.get(targetPostId) || []
+	list.push(event)
+	state.postEdits.set(targetPostId, list)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reducePollVote(state, event) {
+	const key = socialPostKey(event.content.targetEntityHash, event.content.targetPostId)
+	state.pollVotes.set(key, {
+		choices: [...event.content.choices || []],
+		at: event.hlc?.wall || event.timestamp || Date.now(),
+	})
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceLike(state, event) {
+	const key = socialPostKey(event.content.targetEntityHash, event.content.targetPostId)
+	state.likes.set(key, event)
+	state.dislikes.delete(key)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceUnlike(state, event) {
+	state.likes.delete(socialPostKey(event.content.targetEntityHash, event.content.targetPostId))
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceDislike(state, event) {
+	const key = socialPostKey(event.content.targetEntityHash, event.content.targetPostId)
+	state.dislikes.set(key, event)
+	state.likes.delete(key)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceUndislike(state, event) {
+	state.dislikes.delete(socialPostKey(event.content.targetEntityHash, event.content.targetPostId))
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceTagName(state, event) {
+	const tagHash = String(event.content?.tagHash || '').trim().toLowerCase()
+	const locale = String(event.content?.locale || '').trim()
+	const label = String(event.content?.label || '').trim().slice(0, 64)
+	if (!tagHash || !locale || !label) return state
+	const existing = state.tagNames.get(tagHash) || {}
+	state.tagNames.set(tagHash, { ...existing, [locale]: label })
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceRepost(state, event) {
+	state.reposts.push(event)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceFollow(state, event) {
+	state.following.add(event.content.targetEntityHash.toLowerCase())
+	state.followEvents.push(event)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceUnfollow(state, event) {
+	state.following.delete(event.content.targetEntityHash.toLowerCase())
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceTagFollow(state, event) {
+	const tag = String(event.content?.tag || '').trim().toLowerCase()
+	if (tag) state.followedTags.add(tag)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceTagUnfollow(state, event) {
+	const tag = String(event.content?.tag || '').trim().toLowerCase()
+	if (tag) state.followedTags.delete(tag)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceReplyFeature(state, event) {
+	const targetPostId = String(event.content?.targetPostId || '').trim()
+	const replier = String(event.content?.replierEntityHash || '').trim().toLowerCase()
+	const replyPostId = String(event.content?.replyPostId || '').trim()
+	if (!targetPostId || !replier || !replyPostId) return state
+	const key = `${replier}:${replyPostId}`
+	const set = state.featuredReplies.get(targetPostId) || new Set()
+	set.add(key)
+	state.featuredReplies.set(targetPostId, set)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceReplyUnfeature(state, event) {
+	const targetPostId = String(event.content?.targetPostId || '').trim()
+	const replier = String(event.content?.replierEntityHash || '').trim().toLowerCase()
+	const replyPostId = String(event.content?.replyPostId || '').trim()
+	if (!targetPostId || !replier || !replyPostId) return state
+	const set = state.featuredReplies.get(targetPostId)
+	if (!set) return state
+	set.delete(`${replier}:${replyPostId}`)
+	if (!set.size) state.featuredReplies.delete(targetPostId)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceLiveStart(state, event) {
+	const liveId = String(event.content?.liveId || event.id || '').trim().toLowerCase()
+	if (liveId) state.activeLives.set(liveId, event)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceLiveEnd(state, event) {
+	const liveId = String(event.content?.liveId || '').trim().toLowerCase()
+	if (liveId) state.activeLives.delete(liveId)
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceBlock(state, event) {
+	state.blocked.add(event.content.targetEntityHash.toLowerCase())
+	return state
+}
+
+/**
+ * @param {object} state 折叠状态
+ * @param {object} event DAG 事件
+ * @returns {object} 更新后状态
+ */
+function reduceUnblock(state, event) {
+	state.blocked.delete(event.content.targetEntityHash.toLowerCase())
+	return state
+}
+
+/**
+ * @param {object} state 物化状态
+ * @returns {object} 原样返回
+ */
+function passthroughReducer(state) {
+	return state
+}
+
+/** @type {Record<string, (state: object, event: object) => object>} */
+export const SOCIAL_TIMELINE_REDUCERS = {
+	social_meta: reduceSocialMeta,
+	post: reducePost,
+	post_edit: reducePostEdit,
+	post_delete: reducePostDelete,
+	post_visibility_set: reducePostVisibilitySet,
+	poll_vote: reducePollVote,
+	post_note: passthroughReducer,
+	note_vote: passthroughReducer,
+	like: reduceLike,
+	unlike: reduceUnlike,
+	dislike: reduceDislike,
+	undislike: reduceUndislike,
+	tag_name: reduceTagName,
+	repost: reduceRepost,
+	follow: reduceFollow,
+	unfollow: reduceUnfollow,
+	tag_follow: reduceTagFollow,
+	tag_unfollow: reduceTagUnfollow,
+	reply_feature: reduceReplyFeature,
+	reply_unfeature: reduceReplyUnfeature,
+	live_start: reduceLiveStart,
+	live_end: reduceLiveEnd,
+	block: reduceBlock,
+	unblock: reduceUnblock,
+	entity_key_rotate: reduceEntityKeyRotate,
+	entity_key_revoke: reduceEntityKeyRevoke,
+	state_summary: reduceSocialMeta,
+	file_share: passthroughReducer,
+	follow_approve: passthroughReducer,
+	album_create: reduceAlbumCreate,
+	album_update: reduceAlbumUpdate,
+	album_delete: reduceAlbumDelete,
+	album_post_add: reduceAlbumPostAdd,
+	album_post_remove: reduceAlbumPostRemove,
+}
+
+/**
+ * @param {object} state materializeFromEvents 的原始折叠状态
+ * @param {string[]} order 拓扑序 event id 列表
+ * @returns {object} 对外物化视图
+ */
+export function finalizeSocialTimelineView(state, order) {
+	for (const deletedId of state.deletedPostIds)
+		state.posts.delete(deletedId)
+
+	for (const [postId, edits] of state.postEdits.entries()) {
+		const base = state.posts.get(postId)
+		if (!base || !edits.length) continue
+		const latest = edits[edits.length - 1]
+		const { targetPostId: _ignored, ...patch } = latest.content || {}
+		const revisions = edits.slice(0, -1).map(edit => ({
+			text: edit.content?.text,
+			mediaRefs: edit.content?.mediaRefs,
+			contentWarning: edit.content?.contentWarning,
+			locale: edit.content?.locale,
+			at: edit.hlc?.wall || edit.timestamp,
+			eventId: edit.id,
+		}))
+		state.posts.set(postId, {
+			...base,
+			content: { ...base.content, ...patch },
+			edited: true,
+			revisions,
+		})
+	}
+
+	const visiblePosts = [...state.posts.values()]
+		.sort((earlierPost, laterPost) => {
+			const earlierWall = earlierPost.hlc?.wall || 0
+			const laterWall = laterPost.hlc?.wall || 0
+			if (earlierWall !== laterWall) return laterWall - earlierWall
+			return laterPost.id.localeCompare(earlierPost.id)
+		})
+
+	const linkedPostIds = new Set(state.albumsByPost.keys())
+	const defaultPostIds = visiblePosts
+		.filter(post => {
+			if (linkedPostIds.has(post.id)) return false
+			if (post.content?.hasMedia) return true
+			const refs = post.content?.mediaRefs
+			return Array.isArray(refs) && refs.length > 0
+		})
+		.map(post => post.id)
+
+	const albums = Object.fromEntries(state.albums)
+	albums[DEFAULT_ALBUM_ID] = {
+		albumId: DEFAULT_ALBUM_ID,
+		name: 'default',
+		description: '',
+		visibility: 'public',
+		postIds: defaultPostIds,
+		virtual: true,
+	}
+
+	return {
+		socialMeta: state.socialMeta,
+		posts: visiblePosts,
+		postById: Object.fromEntries(state.posts),
+		likes: [...state.likes.values()],
+		dislikes: [...state.dislikes.values()],
+		tagNames: Object.fromEntries(state.tagNames),
+		pollVotes: state.pollVotes,
+		reposts: state.reposts,
+		followEvents: state.followEvents,
+		following: [...state.following],
+		followedTags: [...state.followedTags],
+		featuredReplies: Object.fromEntries(
+			[...state.featuredReplies.entries()].map(([postId, set]) => [postId, [...set]]),
+		),
+		activeLives: Object.fromEntries(state.activeLives),
+		blocked: [...state.blocked],
+		albums,
+		albumsByPost: Object.fromEntries(
+			[...state.albumsByPost.entries()].map(([postId, set]) => [postId, [...set]]),
+		),
+		entityKeyHistory: state.entityKeyHistory,
+		recoveryPubKeyHex: state.recoveryPubKeyHex,
+		tipIds: order.length ? [order[order.length - 1]] : [],
+	}
+}

--- a/src/public/parts/shells/social/src/timeline/retention.mjs
+++ b/src/public/parts/shells/social/src/timeline/retention.mjs
@@ -1,0 +1,52 @@
+import { runTimelineMaintenance } from 'npm:@steve02081504/fount-p2p/timeline/retention_runner'
+
+import { timelineEventsPath } from '../paths.mjs'
+
+import { canonicalizeSignedTimelineEvent } from './canonicalizeEvent.mjs'
+
+/** @type {Set<string>} */
+export const SOCIAL_TIMELINE_ANCHOR_TYPES = new Set([
+	'social_meta',
+	'state_summary',
+	'follow',
+	'unfollow',
+])
+
+const DEFAULT_RETENTION_DEPTH = 200_000
+const DEFAULT_RETENTION_MS = 365 * 24 * 3600 * 1000
+const DEFAULT_COMPACT_TRIGGER = 100_000
+
+/**
+ * @param {object} socialMeta 时间线 meta
+ * @returns {{ maxDepth: number, maxMs: number, compactTrigger: number }} 保留策略
+ */
+export function socialRetentionPolicy(socialMeta = {}) {
+	return {
+		maxDepth: Math.max(256, Number(socialMeta.eventRetentionDepth ?? socialMeta.event_retention_depth) || DEFAULT_RETENTION_DEPTH),
+		maxMs: Math.max(3_600_000, Number(socialMeta.eventRetentionMs ?? socialMeta.event_retention_ms) || DEFAULT_RETENTION_MS),
+		compactTrigger: Math.max(256, Number(socialMeta.compactTriggerEventDepth) || DEFAULT_COMPACT_TRIGGER),
+	}
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash owner
+ * @param {object | null} checkpoint 快照
+ * @param {object} socialMeta 物化 meta
+ * @returns {Promise<void>} 无返回值
+ */
+export async function runSocialTimelineMaintenance(username, entityHash, checkpoint, socialMeta) {
+	const path = timelineEventsPath(username, entityHash)
+	const policy = socialRetentionPolicy(socialMeta)
+	await runTimelineMaintenance({
+		eventsFilePath: path,
+		checkpoint,
+		policy: {
+			maxDepth: policy.maxDepth,
+			maxMs: policy.maxMs,
+			anchorTypes: SOCIAL_TIMELINE_ANCHOR_TYPES,
+		},
+		sanitize: canonicalizeSignedTimelineEvent,
+		compactTrigger: policy.compactTrigger,
+	})
+}

--- a/src/public/parts/shells/social/src/timeline/sync.mjs
+++ b/src/public/parts/shells/social/src/timeline/sync.mjs
@@ -1,0 +1,198 @@
+import { appendJsonlSynced, readJsonl } from 'npm:@steve02081504/fount-p2p/dag/storage'
+
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../../chat/src/entity/identity.mjs'
+import { projectFollowerIndexFromTimelineEvent } from '../federation/follower/index.mjs'
+import { listLocalAgentEntities } from '../federation/hosting.mjs'
+import { validateRemoteTimelineEvent } from '../federation/ingest/remote.mjs'
+import { projectNoteFromTimelineEvent } from '../federation/note/index.mjs'
+import { projectPollVoteFromTimelineEvent } from '../federation/poll/index.mjs'
+import { projectReactionFromTimelineEvent } from '../federation/reaction/index.mjs'
+import { collectSocialRpcMerged } from '../federation/rpc/wire.mjs'
+import { loadFollowing, loadFollowingForActor } from '../following.mjs'
+import { sanitizeMediaRefs } from '../lib/mediaRefs.mjs'
+import { timelineEventsPath } from '../paths.mjs'
+import { handleInboundPersonalBlockEvent } from '../personalBlock.mjs'
+import { tryImportFollowApproveVault } from '../vault_crypto/followApproveImport.mjs'
+
+import { canonicalizeSignedTimelineEvent } from './canonicalizeEvent.mjs'
+import { filterEventsForFederatedPull } from './federationExport.mjs'
+import { invalidateTimelineMaterializedCache, maintainSocialTimeline } from './materialize.mjs'
+import { invalidateTimelineOwnerIndex } from './ownerIndex.mjs'
+
+/** 联邦 RPC 单次 pull 响应上限（客户端循环 afterEventId 直至空批）。 */
+export const FEDERATED_TIMELINE_PULL_BATCH = 200
+
+const FEDERATED_TIMELINE_PULL_MAX_ROUNDS = 8
+
+/**
+ * 导入远程时间线事件（part_timeline_put / RPC pull 入站边界）。
+ * @param {string} username 本地用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 签名事件
+ * @returns {Promise<boolean>} 是否成功入站（含幂等重复）
+ */
+export async function ingestRemoteTimelineEvent(username, entityHash, event) {
+	const existing = await readJsonl(timelineEventsPath(username, entityHash))
+	const validated = await validateRemoteTimelineEvent(event, entityHash, {
+		canonicalize: canonicalizeSignedTimelineEvent,
+		priorEvents: existing,
+		username,
+	})
+	if (!validated.accepted) return false
+	if (validated.row.content?.mediaRefs)
+		validated.row.content.mediaRefs = sanitizeMediaRefs(validated.row.content.mediaRefs)
+	if (validated.row.content && 'sensitiveMedia' in validated.row.content)
+		validated.row.content.sensitiveMedia = validated.row.content.sensitiveMedia === true
+	if (validated.row.content?.embeds != null)
+		delete validated.row.content.embeds
+	if (validated.row.type === 'post_note' && validated.row.content)
+		validated.row.content.text = String(validated.row.content.text || '').trim().slice(0, 2000)
+	if (existing.some(row => row.id === validated.row.id)) return true
+	if (validated.row.type === 'poll_vote') {
+		const { assertPollVoteAllowed } = await import('../lib/poll.mjs')
+		try {
+			await assertPollVoteAllowed(
+				username,
+				validated.row.content.targetEntityHash,
+				validated.row.content.targetPostId,
+				validated.row.content.choices,
+				validated.row.hlc?.wall || validated.row.timestamp || Date.now(),
+			)
+		}
+		catch {
+			return false
+		}
+	}
+	await appendJsonlSynced(timelineEventsPath(username, entityHash), validated.row)
+	invalidateTimelineMaterializedCache(username, entityHash)
+	invalidateTimelineOwnerIndex(username)
+	await tryImportFollowApproveVault(username, entityHash, event)
+	await projectFollowerIndexFromTimelineEvent(username, entityHash, validated.row)
+	await projectPollVoteFromTimelineEvent(username, entityHash, validated.row)
+	await projectReactionFromTimelineEvent(username, entityHash, validated.row)
+	await projectNoteFromTimelineEvent(username, entityHash, validated.row)
+	if (validated.row.type === 'block' || validated.row.type === 'unblock') {
+		const { following } = await loadFollowing(username)
+		await handleInboundPersonalBlockEvent(username, entityHash, validated.row, new Set(following))
+	}
+	await maintainSocialTimeline(username, entityHash)
+	const { appendInboxFromTimelineEvent } = await import('../inbox.mjs')
+	await appendInboxFromTimelineEvent(username, entityHash, validated.row)
+	const { indexTimelineEventForSearch } = await import('../searchIndex.mjs')
+	await indexTimelineEventForSearch(username, entityHash, validated.row)
+	if (validated.row.type === 'post') {
+		const { dispatchSocialMessage } = await import('../dispatch.mjs')
+		await dispatchSocialMessage(username, entityHash, validated.row)
+	}
+	return true
+}
+
+/**
+ * 经 TrustGraph RPC 拉取并导入远程时间线事件。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @returns {Promise<number>} 导入条数
+ */
+export async function syncTimelineForEntity(username, entityHash) {
+	const timelineOwner = entityHash.toLowerCase()
+	const { readTimelineEvents } = await import('./append.mjs')
+
+	let imported = 0
+	let afterEventId = null
+	const local = await readTimelineEvents(username, timelineOwner)
+	const knownIds = new Set(local.map(row => row.id))
+	if (local.length) afterEventId = local[local.length - 1].id
+
+	for (let round = 0; round < FEDERATED_TIMELINE_PULL_MAX_ROUNDS; round++) {
+		const { data: responses, errors } = await collectSocialRpcMerged(username, {
+			type: 'social_timeline_pull_request',
+			entityHash: timelineOwner,
+			afterEventId,
+		}, 3000, 8)
+		if (errors.length)
+			console.warn('social: timeline pull neighbor errors', { entityHash: timelineOwner, count: errors.length })
+
+		let roundImported = 0
+		for (const row of responses)
+			for (const event of row.events || []) {
+				if (!await ingestRemoteTimelineEvent(username, timelineOwner, event)) continue
+				if (!knownIds.has(event.id)) {
+					knownIds.add(event.id)
+					roundImported++
+				}
+				afterEventId = event.id
+			}
+
+		imported += roundImported
+		if (!roundImported) break
+	}
+
+	const { reprocessFollowApproveVaults } = await import('../vault_crypto/followApproveImport.mjs')
+	await reprocessFollowApproveVaults(username, timelineOwner)
+	return imported
+}
+
+/**
+ * @param {string} username replica
+ * @returns {Promise<string[]>} 本机 operator + agent 关注目标的并集
+ */
+async function unionFollowingTargetsForLocalEntities(username) {
+	/** @type {Set<string>} */
+	const targets = new Set()
+	const operator = await resolveOperatorEntityHash(username)
+	const actors = []
+	if (operator) actors.push(operator.toLowerCase())
+	for (const { entityHash } of listLocalAgentEntities(username))
+		actors.push(entityHash.toLowerCase())
+	for (const actor of actors) {
+		const { following } = await loadFollowingForActor(username, actor)
+		for (const hash of following)
+			if (hash !== actor) targets.add(hash)
+	}
+	return [...targets]
+}
+
+/**
+ * 加载首页前同步本机全部 acting entity 关注目标的远程时间线。
+ * @param {string} username 用户
+ * @param {object} [options] 选项
+ * @param {number} [options.max=24] 最多同步多少个关注
+ * @returns {Promise<{ attempted: number, imported: number }>} 同步统计
+ */
+export async function syncFollowingTimelines(username, options = {}) {
+	const max = Math.min(Math.max(Number(options.max) || 24, 1), 64)
+	const targets = (await unionFollowingTargetsForLocalEntities(username)).slice(0, max)
+	const results = await Promise.allSettled(
+		targets.map(entityHash => syncTimelineForEntity(username, entityHash)),
+	)
+	return {
+		attempted: targets.length,
+		imported: results.reduce(
+			(sum, result) => sum + (result.status === 'fulfilled' ? result.value : 0),
+			0,
+		),
+	}
+}
+
+/**
+ * 联邦 RPC 响应：按可见性过滤后返回时间线切片。
+ * @param {string} username replica
+ * @param {string} entityHash owner
+ * @param {string | null | undefined} afterEventId 增量游标
+ * @param {string | null | undefined} requesterNodeHash 请求方 nodeHash
+ * @returns {Promise<object[]>} 可见事件切片
+ */
+export async function buildFederatedTimelinePullResponse(username, entityHash, afterEventId, requesterNodeHash) {
+	const timelineOwner = entityHash.toLowerCase()
+	const { readTimelineEvents } = await import('./append.mjs')
+	const events = await readTimelineEvents(username, timelineOwner)
+	const start = afterEventId
+		? Math.max(0, events.findIndex(event => event.id === afterEventId.trim()) + 1)
+		: 0
+	return filterEventsForFederatedPull(
+		username,
+		timelineOwner,
+		events.slice(start, start + FEDERATED_TIMELINE_PULL_BATCH),
+		requesterNodeHash,
+	)
+}

--- a/src/public/parts/shells/social/src/topics.mjs
+++ b/src/public/parts/shells/social/src/topics.mjs
@@ -1,0 +1,123 @@
+/**
+ * 话题订阅：tag_follow / tag_unfollow + 话题帖流。
+ */
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+
+import { buildPostFeedItem } from './feed/buildItem.mjs'
+import { createFeedItemBuildContext, iterateVisiblePosts } from './feed/iterate.mjs'
+import { compareFeedItems } from './feedMerge.mjs'
+import { loadFollowingForActor } from './following.mjs'
+import { extractHashtagsFromText } from './lib/hashtags.mjs'
+import { postMatchesQuery } from './lib/postQuery.mjs'
+import { querySocialPostIndex } from './searchIndex.mjs'
+import { commitTimelineEvent } from './timeline/append.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * @param {string} tag 原始话题
+ * @returns {string} 规范化 tag
+ */
+export function normalizeTopicTag(tag) {
+	return String(tag || '').trim().replace(/^#/u, '').toLowerCase()
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 实体
+ * @returns {Promise<{ tags: string[] }>} 已订阅
+ */
+export async function listFollowedTags(username, entityHash) {
+	const view = await getTimelineMaterialized(username, entityHash)
+	return { tags: [...view.followedTags || []].sort() }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} entityHash 实体
+ * @param {string} tag 话题
+ * @param {boolean} follow 是否订阅
+ * @returns {Promise<{ tag: string, isFollowing: boolean, tags: string[] }>} 结果
+ */
+export async function setTagFollow(username, entityHash, tag, follow) {
+	const cleaned = normalizeTopicTag(tag)
+	if (cleaned.length < 2) throw new Error('tag too short')
+	const { tags } = await listFollowedTags(username, entityHash)
+	const already = tags.includes(cleaned)
+	if (follow === already) return { tag: cleaned, isFollowing: follow, tags }
+	await commitTimelineEvent(username, entityHash, {
+		type: follow ? 'tag_follow' : 'tag_unfollow',
+		content: { tag: cleaned },
+	})
+	const next = follow
+		? [...tags, cleaned].sort()
+		: tags.filter(row => row !== cleaned)
+	return { tag: cleaned, isFollowing: follow, tags: next }
+}
+
+/**
+ * @param {string} username replica
+ * @param {string} tag 话题
+ * @param {{ limit?: number, cursor?: string, viewerEntityHash?: string }} [options] 分页
+ * @returns {Promise<{ tag: string, items: object[], nextCursor: string | null }>} 话题帖
+ */
+export async function buildTopicFeed(username, tag, options = {}) {
+	const cleaned = normalizeTopicTag(tag)
+	const limit = Math.min(Math.max(Number(options.limit) || 30, 1), 100)
+	const query = `#${cleaned}`
+	const viewer = options.viewerEntityHash || null
+	const { following } = viewer
+		? await loadFollowingForActor(username, viewer)
+		: { following: [] }
+	const owners = following.filter(isEntityHash128)
+	const hits = await querySocialPostIndex(username, owners, query, limit * 4)
+	/** @type {object[]} */
+	const candidates = []
+	const seen = new Set()
+	const itemContext = await createFeedItemBuildContext(username, new Set(owners), viewer)
+
+	for (const hit of hits) {
+		const key = `${hit.entityHash}:${hit.postId}`
+		if (seen.has(key)) continue
+		seen.add(key)
+		const view = await getTimelineMaterialized(username, hit.entityHash)
+		const post = view.postById?.[hit.postId]
+		if (!post || !postMatchesQuery({ ...post, entityHash: hit.entityHash }, query)) continue
+		const item = await buildPostFeedItem(username, hit.entityHash, post, itemContext)
+		if (!item) continue
+		item.via = 'topic'
+		candidates.push(item)
+	}
+
+	if (candidates.length < limit) {
+		const { loadViewerContext } = await import('./feed/home.mjs')
+		const viewerContext = await loadViewerContext(username, viewer)
+		for await (const { entityHash, post } of iterateVisiblePosts(username, viewerContext)) {
+			const key = `${entityHash}:${post.id}`
+			if (seen.has(key)) continue
+			const text = post.content?.text || ''
+			const tags = [
+				...extractHashtagsFromText(text),
+				...Array.isArray(post.content?.tags) ? post.content.tags.map(t => String(t).toLowerCase()) : [],
+			]
+			if (!tags.includes(cleaned)) continue
+			seen.add(key)
+			const item = await buildPostFeedItem(username, entityHash, post, itemContext)
+			if (!item) continue
+			item.via = 'topic'
+			candidates.push(item)
+			if (candidates.length >= limit * 3) break
+		}
+	}
+
+	candidates.sort((a, b) => -compareFeedItems(a, b))
+	let start = 0
+	if (options.cursor) {
+		const idx = candidates.findIndex(item => `${item.hlc?.wall || 0}:${item.postId}` === options.cursor)
+		start = idx >= 0 ? idx + 1 : 0
+	}
+	const page = candidates.slice(start, start + limit)
+	const nextCursor = page.length === limit && start + limit < candidates.length
+		? `${page[page.length - 1].hlc?.wall || 0}:${page[page.length - 1].postId}`
+		: null
+	return { tag: cleaned, items: page, nextCursor }
+}

--- a/src/public/parts/shells/social/src/translate.mjs
+++ b/src/public/parts/shells/social/src/translate.mjs
@@ -1,0 +1,38 @@
+import {
+	cacheTranslation as cacheTranslationBase,
+	getCachedTranslation as getCachedTranslationBase,
+	translateText,
+} from '../../../../../server/translate.mjs'
+
+const CACHE_DATANAME = 'socialTranslateCache'
+
+/**
+ * 写入翻译结果到 Social 用户缓存。
+ * @param {string} username 用户
+ * @param {string} cacheKey 缓存键
+ * @param {string} translated 译文
+ * @returns {void}
+ */
+export function cacheTranslation(username, cacheKey, translated) {
+	cacheTranslationBase(username, CACHE_DATANAME, cacheKey, translated)
+}
+
+/**
+ * 按缓存键读取 Social 已缓存的译文。
+ * @param {string} username 用户
+ * @param {string} cacheKey 缓存键
+ * @returns {string | null} 缓存译文或 null
+ */
+export function getCachedTranslation(username, cacheKey) {
+	return getCachedTranslationBase(username, CACHE_DATANAME, cacheKey)
+}
+
+/**
+ *
+ */
+export const translatePostText = translateText
+
+/**
+ *
+ */
+export { translateText }

--- a/src/public/parts/shells/social/src/trending/hashtags.mjs
+++ b/src/public/parts/shells/social/src/trending/hashtags.mjs
@@ -1,0 +1,35 @@
+import { loadViewerContext } from '../feed/home.mjs'
+import { iterateVisiblePosts } from '../feed/iterate.mjs'
+import { extractHashtagsFromText } from '../lib/hashtags.mjs'
+import { readTrendingHashtagCounts } from '../searchIndex.mjs'
+
+/**
+ * 从观看者可见帖子统计热门话题（索引计数优先，空则回退扫描）。
+ * @param {string} username 用户
+ * @param {object} [options] 选项
+ * @param {number} [options.limit=12] 返回条数
+ * @param {string} [options.viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<{ tags: { tag: string, count: number }[] }>} 热门话题
+ */
+export async function buildTrendingHashtags(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 12, 1), 32)
+	const indexed = await readTrendingHashtagCounts(username, limit)
+	if (indexed.tags.length) return indexed
+
+	const viewerContext = await loadViewerContext(username, options.viewerEntityHash || null)
+	/** @type {Map<string, number>} */
+	const counts = new Map()
+
+	for await (const { post } of iterateVisiblePosts(username, viewerContext)) {
+		if (!post.content?.text) continue
+		for (const tag of extractHashtagsFromText(post.content.text))
+			counts.set(tag, (counts.get(tag) || 0) + 1)
+	}
+
+	const tags = [...counts.entries()]
+		.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+		.slice(0, limit)
+		.map(([tag, count]) => ({ tag, count }))
+
+	return { tags }
+}

--- a/src/public/parts/shells/social/src/trending/network.mjs
+++ b/src/public/parts/shells/social/src/trending/network.mjs
@@ -1,0 +1,89 @@
+/**
+ * 联邦话题热度 part_query。
+ */
+import { getNodeHash } from 'npm:@steve02081504/fount-p2p/node/identity'
+import { getShellPartpath } from 'npm:@steve02081504/fount-p2p/registries/part_path'
+import { queryNetwork } from 'npm:@steve02081504/fount-p2p/wire/part_query'
+
+import { buildTrendingHashtags } from './hashtags.mjs'
+
+/**
+ *
+ */
+export const TRENDING_HASHTAGS_KIND = 'trending_hashtags'
+
+const TAG_MAX_LEN = 32
+const TAG_RE = /^[\p{L}\p{N}_-]{2,32}$/u
+
+/**
+ * @param {unknown} raw 原始行
+ * @returns {{ tag: string, count: number, nodeHash: string } | null} 清洗后行
+ */
+function sanitizeTrendingRow(raw) {
+	if (!raw || typeof raw !== 'object') return null
+	const tag = String(/** @type {{ tag?: unknown }} */raw.tag || '').trim().toLowerCase().slice(0, TAG_MAX_LEN)
+	if (!TAG_RE.test(tag)) return null
+	const count = Math.min(Math.max(Number(/** @type {{ count?: unknown }} */raw.count) || 0, 0), 1_000_000)
+	if (!count) return null
+	const nodeHash = String(/** @type {{ nodeHash?: unknown }} */raw.nodeHash || '').trim().toLowerCase().slice(0, 128)
+	return { tag, count, nodeHash }
+}
+
+/**
+ * 本机应答：公开可见话题计数（带本节点 hash 以免聚合时被去重吞并）。
+ * @param {{ replicaUsername?: string }} inboundContext 入站上下文
+ * @param {unknown} query 查询
+ * @returns {Promise<object[]>} rows
+ */
+export async function localTrendingHashtagsHandler(inboundContext, query) {
+	const username = String(inboundContext.replicaUsername || '').trim()
+	if (!username) return []
+	const limit = Math.min(Math.max(Number(
+		query && typeof query === 'object' ? /** @type {{ limit?: unknown }} */query.limit : 12,
+	) || 12, 1), 32)
+	const { tags } = await buildTrendingHashtags(username, { limit })
+	const nodeHash = String(getNodeHash() || '').toLowerCase()
+	return tags.map(row => ({
+		tag: row.tag,
+		count: row.count,
+		nodeHash,
+	}))
+}
+
+/**
+ * 聚合本机与邻居话题热度。
+ * @param {string} username 用户
+ * @param {{ limit?: number, viewerEntityHash?: string }} [options] 选项
+ * @returns {Promise<{ tags: { tag: string, count: number }[], scope: 'nearby' }>} 附近热搜
+ */
+export async function buildNearbyTrendingHashtags(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 12, 1), 32)
+	const partpath = getShellPartpath('social')
+	const rows = await queryNetwork(username, partpath, TRENDING_HASHTAGS_KIND, { limit }, {
+		maxHits: 128,
+		/**
+		 * @param {unknown} row 行
+		 * @returns {string} 去重键（同 tag 不同节点保留）
+		 */
+		rowKey: row => {
+			const cleaned = sanitizeTrendingRow(row)
+			if (!cleaned) return ''
+			return `${cleaned.nodeHash || 'anon'}:${cleaned.tag}`
+		},
+	})
+
+	/** @type {Map<string, number>} */
+	const counts = new Map()
+	for (const raw of rows) {
+		const row = sanitizeTrendingRow(raw)
+		if (!row) continue
+		counts.set(row.tag, (counts.get(row.tag) || 0) + row.count)
+	}
+
+	const tags = [...counts.entries()]
+		.sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+		.slice(0, limit)
+		.map(([tag, count]) => ({ tag, count }))
+
+	return { tags, scope: 'nearby' }
+}

--- a/src/public/parts/shells/social/src/vaultAcl.mjs
+++ b/src/public/parts/shells/social/src/vaultAcl.mjs
@@ -1,0 +1,28 @@
+import { resolveOperatorEntityHashForUser as resolveOperatorEntityHash } from '../../chat/src/entity/identity.mjs'
+
+import { loadViewerContext } from './feed/home.mjs'
+import { canViewByVisibility } from './lib/visibilitySpec.mjs'
+
+
+/**
+ * Social vault 文件 ACL（EVFS manifest 读权限）。
+ * @param {string} replicaUsername 观看者 replica
+ * @param {string} ownerEntityHash vault owner
+ * @param {import('npm:@steve02081504/fount-p2p/files/manifest').FileManifest} manifest manifest
+ * @param {string} [viewerEntityHash] 观看实体；缺省为 operator
+ * @returns {Promise<boolean>} 观看者是否可读该 vault 文件
+ */
+export async function canViewVaultFile(replicaUsername, ownerEntityHash, manifest, viewerEntityHash) {
+	const visibility = manifest.meta?.visibility || 'followers'
+	const owner = ownerEntityHash.toLowerCase()
+	const viewer = viewerEntityHash
+		? String(viewerEntityHash).trim().toLowerCase()
+		: await resolveOperatorEntityHash(replicaUsername)
+	if (viewer === owner) return true
+	const viewerContext = await loadViewerContext(replicaUsername, viewer)
+	return canViewByVisibility(
+		{ visibility, minFollowMs: manifest.meta?.minFollowMs, allow: manifest.meta?.allow, except: manifest.meta?.except },
+		viewerContext,
+		owner,
+	)
+}

--- a/src/public/parts/shells/social/src/vault_crypto/followApprove.mjs
+++ b/src/public/parts/shells/social/src/vault_crypto/followApprove.mjs
@@ -1,0 +1,18 @@
+import { commitTimelineEvent } from '../timeline/append.mjs'
+
+import { buildFollowApprovePayload } from './vault.mjs'
+
+/**
+ * 为关注者签发 follow_approve 并 fanout（本机托管的时间线 owner）。
+ * @param {string} replicaUsername owner 所在 replica
+ * @param {string} ownerEntityHash 时间线 owner
+ * @param {string} followerPubKeyHex 关注者 Ed25519 公钥 hex
+ * @returns {Promise<object>} 签名事件
+ */
+export async function autoApproveFollower(replicaUsername, ownerEntityHash, followerPubKeyHex) {
+	const payload = await buildFollowApprovePayload(replicaUsername, ownerEntityHash, followerPubKeyHex)
+	return commitTimelineEvent(replicaUsername, ownerEntityHash, {
+		type: 'follow_approve',
+		content: payload,
+	})
+}

--- a/src/public/parts/shells/social/src/vault_crypto/followApproveImport.mjs
+++ b/src/public/parts/shells/social/src/vault_crypto/followApproveImport.mjs
@@ -1,0 +1,59 @@
+import { Buffer } from 'node:buffer'
+
+import { normalizeHex64, isHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import { publicKeyFromSeed } from 'npm:@steve02081504/fount-p2p/crypto'
+import { unwrapKeyEcies } from 'npm:@steve02081504/fount-p2p/crypto/key'
+import { isPlainObject } from 'npm:@steve02081504/fount-p2p/wire/ingress'
+
+import { getOperatorSecretKey } from '../../../chat/src/entity/identity.mjs'
+
+import { saveVaultMasterKey } from './vault.mjs'
+
+/**
+ * 从 follow_approve 事件导入 vault 主密钥（关注者侧解密）。
+ * @param {string} username 本地用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object} event 签名事件
+ * @returns {Promise<boolean>} 是否成功导入
+ */
+export async function tryImportFollowApproveVault(username, entityHash, event) {
+	if (event?.type !== 'follow_approve') return false
+	const encrypted = event.content?.encrypted_H
+	const targetPubKeyHex = normalizeHex64(event.content?.targetPubKeyHex)
+	if (!isPlainObject(encrypted) || !targetPubKeyHex) return false
+
+	const secretHex = await getOperatorSecretKey(username)
+	if (!secretHex || secretHex.length !== 64) return false
+	const secretKey = new Uint8Array(Buffer.from(secretHex, 'hex'))
+
+	const myPubHex = normalizeHex64(Buffer.from(publicKeyFromSeed(secretKey)).toString('hex'))
+	if (myPubHex !== targetPubKeyHex) return false
+
+	const masterKeyHex = unwrapKeyEcies(encrypted, secretKey)
+	if (!masterKeyHex || !isHex64(masterKeyHex)) return false
+
+	const generation = Number(event.content?.generation)
+	if (!Number.isFinite(generation) || generation < 0) return false
+
+	await saveVaultMasterKey(username, entityHash, {
+		masterKey: masterKeyHex,
+		generation: Math.floor(generation),
+	})
+	return true
+}
+
+/**
+ * 扫描时间线中全部 follow_approve 并尝试导入 vault。
+ * @param {string} username 本地用户
+ * @param {string} entityHash 时间线 owner
+ * @param {object[]} [events] 可选事件列表
+ * @returns {Promise<number>} 成功导入次数
+ */
+export async function reprocessFollowApproveVaults(username, entityHash, events) {
+	const rows = events || await import('../timeline/append.mjs').then(m => m.readTimelineEvents(username, entityHash))
+	let imported = 0
+	for (const event of rows)
+		if (await tryImportFollowApproveVault(username, entityHash, event))
+			imported++
+	return imported
+}

--- a/src/public/parts/shells/social/src/vault_crypto/vault.mjs
+++ b/src/public/parts/shells/social/src/vault_crypto/vault.mjs
@@ -1,0 +1,275 @@
+import { Buffer } from 'node:buffer'
+import { randomUUID, createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+
+import { isHex64, normalizeHex64 } from 'npm:@steve02081504/fount-p2p/core/hexIds'
+import {
+	deriveSocialPostKey,
+	generateFileMasterKey,
+	wrapKeyEcies,
+	unwrapKeyEcies,
+} from 'npm:@steve02081504/fount-p2p/crypto/key'
+
+import { vaultGroupId } from '../federation/namespace.mjs'
+import {
+	normalizeVisibilitySpec,
+	visibilitySpecToContentFields,
+} from '../lib/visibilitySpec.mjs'
+import { vaultStatePath } from '../paths.mjs'
+
+/** @type {'gsh'} followers 帖文 content 加密 scheme */
+const GSH_SCHEME = 'gsh'
+/** @type {'pkw'} 按接收者包裹帖钥 scheme */
+const PKW_SCHEME = 'pkw'
+
+/**
+ * 读取或初始化 vault 主密钥状态。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @returns {Promise<{ masterKey: string, generation: number }>} vault 主密钥状态
+ */
+export async function loadVaultMasterKey(username, entityHash) {
+	try {
+		const raw = JSON.parse(await readFile(vaultStatePath(username, entityHash), 'utf8'))
+		return {
+			masterKey: String(raw.masterKey || ''),
+			generation: Number(raw.generation) || 0,
+		}
+	}
+	catch {
+		const state = { masterKey: generateFileMasterKey(), generation: 0 }
+		await saveVaultMasterKey(username, entityHash, state)
+		return state
+	}
+}
+
+/**
+ * 持久化 vault 主密钥状态。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {{ masterKey: string, generation: number }} state vault 状态
+ * @returns {Promise<void>}
+ */
+export async function saveVaultMasterKey(username, entityHash, state) {
+	await mkdir(`${vaultStatePath(username, entityHash).replace(/[/\\][^/\\]+$/, '')}`, { recursive: true })
+	await writeFile(vaultStatePath(username, entityHash), JSON.stringify({
+		masterKey: state.masterKey,
+		generation: state.generation,
+	}, null, '\t'), 'utf8')
+}
+
+/**
+ * 使用 AES-GCM 加密 UTF-8 明文。
+ * @param {string} plaintext UTF-8 明文
+ * @param {Buffer} key AES key
+ * @returns {{ iv: string, ciphertext: string, authTag: string }} AES-GCM 密文信封
+ */
+function encryptAesGcm(plaintext, key) {
+	const iv = randomBytes(12)
+	const cipher = createCipheriv('aes-256-gcm', key, iv)
+	const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+	return {
+		iv: iv.toString('base64'),
+		ciphertext: ciphertext.toString('base64'),
+		authTag: cipher.getAuthTag().toString('base64'),
+	}
+}
+
+/**
+ * 使用 AES-GCM 解密密文信封。
+ * @param {object} envelope 密文信封
+ * @param {Buffer} key AES key
+ * @returns {string} 明文
+ */
+function decryptAesGcm(envelope, key) {
+	const iv = Buffer.from(envelope.iv, 'base64')
+	const decipher = createDecipheriv('aes-256-gcm', key, iv)
+	decipher.setAuthTag(Buffer.from(envelope.authTag, 'base64'))
+	return Buffer.concat([
+		decipher.update(Buffer.from(envelope.ciphertext, 'base64')),
+		decipher.final(),
+	]).toString('utf8')
+}
+
+/**
+ * 解析实体活跃公钥（本地 identity → profile.json）。
+ * @param {string} username replica
+ * @param {string} entityHash 实体
+ * @returns {Promise<string | null>} 64 hex pubKey
+ */
+async function resolveEntityPubKeyHex(username, entityHash) {
+	const hash = String(entityHash).toLowerCase()
+	try {
+		const { getEntityActivePubKey } = await import('../../../chat/src/entity/identity.mjs')
+		const pub = await getEntityActivePubKey(username, hash)
+		if (isHex64(normalizeHex64(pub))) return normalizeHex64(pub)
+	}
+	catch { /* 非本机实体 */ }
+	try {
+		const { createFsEntityStore } = await import('npm:@steve02081504/fount-p2p/node/entity_store')
+		const { entitiesRoot } = await import('../../../chat/src/entity/store.mjs')
+		const profile = await createFsEntityStore(entitiesRoot(username)).readEntityJson(hash, 'profile.json')
+		const pub = normalizeHex64(profile?.activePubKeyHex || '')
+		if (isHex64(pub)) return pub
+	}
+	catch { /* 无缓存 profile */ }
+	return null
+}
+
+/**
+ * 对受限可见帖加密 content。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {string} postKeyId 帖子密钥 id（client 生成 UUID，独立于 event.id）
+ * @param {object} content 明文 content
+ * @param {object | string} visibilityOrSpec public|followers|… 或 spec
+ * @returns {Promise<object>} 加密后的 content 或原文
+ */
+export async function maybeEncryptPostContent(username, entityHash, postKeyId, content, visibilityOrSpec) {
+	const spec = normalizeVisibilitySpec(
+		typeof visibilityOrSpec === 'string'
+			? { ...visibilitySpecToContentFields(normalizeVisibilitySpec(visibilityOrSpec)), ...content }
+			: { ...content, ...normalizeVisibilitySpec(visibilityOrSpec) },
+	)
+	const visibility = spec.visibility
+
+	if (visibility === 'public' || visibility === 'unlisted')
+		return { ...content, ...visibilitySpecToContentFields(spec) }
+
+	const plainPayload = { ...content, ...visibilitySpecToContentFields(spec) }
+	const outerMeta = {
+		...visibilitySpecToContentFields(spec),
+		...Array.isArray(content.mediaRefs) && content.mediaRefs.length ? { hasMedia: true } : {},
+	}
+
+	if (visibility === 'followers' || visibility === 'followers_since') {
+		const { masterKey } = await loadVaultMasterKey(username, entityHash)
+		const key = deriveSocialPostKey(masterKey, postKeyId)
+		const encrypted = encryptAesGcm(JSON.stringify(plainPayload), key)
+		return {
+			scheme: GSH_SCHEME,
+			postKeyId,
+			generation: 0,
+			...outerMeta,
+			...encrypted,
+		}
+	}
+
+	if (visibility === 'selected' || visibility === 'private') {
+		const postKeyHex = generateFileMasterKey()
+		const postKey = Buffer.from(postKeyHex, 'hex')
+		const encrypted = encryptAesGcm(JSON.stringify(plainPayload), postKey)
+		/** @type {Record<string, object>} */
+		const wraps = {}
+		const recipients = new Set(spec.allow || [])
+		recipients.add(String(entityHash).toLowerCase())
+		for (const recipient of recipients) {
+			const pub = await resolveEntityPubKeyHex(username, recipient)
+			if (!pub) {
+				if (recipient === String(entityHash).toLowerCase())
+					throw new Error(`cannot resolve author pubkey for pkw: ${recipient}`)
+				continue
+			}
+			wraps[pub] = wrapKeyEcies(postKeyHex, pub)
+		}
+		if (!Object.keys(wraps).length)
+			throw new Error('pkw encryption produced no wraps')
+		return {
+			scheme: PKW_SCHEME,
+			...outerMeta,
+			wraps,
+			...encrypted,
+		}
+	}
+
+	return plainPayload
+}
+
+/**
+ * 尝试用本地实体私钥解 pkw wraps。
+ * @param {string} username replica
+ * @param {string} entityHash 尝试者
+ * @param {Record<string, object>} wraps wraps
+ * @returns {Promise<string | null>} postKeyHex
+ */
+async function tryUnwrapPkw(username, entityHash, wraps) {
+	if (!entityHash || !wraps) return null
+	try {
+		const { getEntitySecretKey, getEntityActivePubKey } = await import('../../../chat/src/entity/identity.mjs')
+		const pub = normalizeHex64(await getEntityActivePubKey(username, entityHash))
+		const wrapped = wraps[pub]
+		if (!wrapped) return null
+		const secretHex = await getEntitySecretKey(username, entityHash)
+		if (!secretHex || secretHex.length !== 64) return null
+		const keyHex = unwrapKeyEcies(wrapped, new Uint8Array(Buffer.from(secretHex, 'hex')))
+		return isHex64(normalizeHex64(keyHex || '')) ? normalizeHex64(keyHex) : null
+	}
+	catch {
+		return null
+	}
+}
+
+/**
+ * 解密 vault 加密帖 content；失败返回 null。
+ * @param {string} username 用户
+ * @param {string} entityHash owner
+ * @param {object} content 事件 content
+ * @param {string | null} [viewerEntityHash] 观看者（pkw 解包用；缺省尝试 owner）
+ * @returns {object | null} 解密后 content；无法解密返回 null
+ */
+export async function maybeDecryptPostContent(username, entityHash, content, viewerEntityHash = null) {
+	if (!content) return null
+	if (content.scheme !== GSH_SCHEME && content.scheme !== PKW_SCHEME) return content
+
+	if (content.scheme === GSH_SCHEME) {
+		const { masterKey } = await loadVaultMasterKey(username, entityHash)
+		const key = deriveSocialPostKey(masterKey, content.postKeyId)
+		try {
+			return JSON.parse(decryptAesGcm(content, key))
+		}
+		catch {
+			return null
+		}
+	}
+
+	const candidates = [
+		viewerEntityHash && String(viewerEntityHash).toLowerCase(),
+		String(entityHash).toLowerCase(),
+	].filter(Boolean)
+	const seen = new Set()
+	for (const candidate of candidates) {
+		if (seen.has(candidate)) continue
+		seen.add(candidate)
+		const postKeyHex = await tryUnwrapPkw(username, candidate, content.wraps)
+		if (!postKeyHex) continue
+		try {
+			return JSON.parse(decryptAesGcm(content, Buffer.from(postKeyHex, 'hex')))
+		}
+		catch { /* try next */ }
+	}
+	return null
+}
+
+/**
+ * 构建 follow_approve 事件的 vault 载荷片段。
+ * @param {string} username owner 用户
+ * @param {string} entityHash owner
+ * @param {string} followerPubKeyHex 关注者公钥
+ * @returns {Promise<object>} follow_approve 载荷片段
+ */
+export async function buildFollowApprovePayload(username, entityHash, followerPubKeyHex) {
+	const { masterKey } = await loadVaultMasterKey(username, entityHash)
+	return {
+		targetPubKeyHex: followerPubKeyHex,
+		encrypted_H: wrapKeyEcies(masterKey, followerPubKeyHex),
+		vaultGroupId: vaultGroupId(entityHash),
+	}
+}
+
+/**
+ * 生成新的 vault 文件 UUID。
+ * @returns {string} 新 fileId
+ */
+export function newVaultFileId() {
+	return randomUUID()
+}

--- a/src/public/parts/shells/social/src/videosFeed.mjs
+++ b/src/public/parts/shells/social/src/videosFeed.mjs
@@ -1,0 +1,99 @@
+/**
+ * 短视频竖屏流：含 video mediaRef 的公开帖，按 for_you 启发式排序。
+ */
+import { isEntityHash128 } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { isEntityHashBlocked } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import { pickNodeScore } from 'npm:@steve02081504/fount-p2p/node/reputation_store'
+
+import { discoverPosts } from './discover/local.mjs'
+import { shouldHideAuthorByReputation } from './federation/reputation/index.mjs'
+import { buildPostFeedItem } from './feed/buildItem.mjs'
+import { buildEngagementIndex, loadViewerContext } from './feed/home.mjs'
+import { createFeedItemBuildContext } from './feed/iterate.mjs'
+import { scorePostForYou } from './feed/ranking.mjs'
+import { canViewPost } from './feedVisibility.mjs'
+import { loadFollowingForActor } from './following.mjs'
+import { isPublicDiscoverable } from './lib/visibilitySpec.mjs'
+import { computeTasteMatch, ensureTasteFresh } from './taste/cluster.mjs'
+import { getTimelineMaterialized } from './timeline/materialize.mjs'
+
+/**
+ * @param {object} post 帖
+ * @returns {boolean} 是否含视频
+ */
+function postHasVideo(post) {
+	const refs = Array.isArray(post.content?.mediaRefs) ? post.content.mediaRefs : []
+	return refs.some(ref => String(ref?.kind || '').toLowerCase() === 'video')
+}
+
+/**
+ * @param {string} username replica
+ * @param {{ limit?: number, cursor?: string, viewerEntityHash?: string }} [options] 分页
+ * @returns {Promise<{ items: object[], nextCursor: string | null }>} 短视频流
+ */
+export async function buildVideosFeed(username, options = {}) {
+	const limit = Math.min(Math.max(Number(options.limit) || 20, 1), 50)
+	const viewer = options.viewerEntityHash || null
+	const viewerContext = await loadViewerContext(username, viewer)
+	const { following } = await loadFollowingForActor(username, viewer || viewerContext.viewerEntityHash)
+	const feedSources = new Set(following)
+	const taste = viewer ? await ensureTasteFresh(username, viewer) : null
+	const engagement = await buildEngagementIndex(username, feedSources)
+	const itemContext = await createFeedItemBuildContext(username, feedSources, viewer)
+
+	/** @type {Map<string, { entityHash: string, post: object, score: number }>} */
+	const scored = new Map()
+
+	for (const entityHash of feedSources) {
+		if (!isEntityHash128(entityHash)) continue
+		if (isEntityHashBlocked(entityHash)) continue
+		if (shouldHideAuthorByReputation(entityHash, pickNodeScore)) continue
+		const view = await getTimelineMaterialized(username, entityHash)
+		for (const post of view.posts || []) {
+			if (!postHasVideo(post)) continue
+			const enriched = { ...post, entityHash }
+			if (!canViewPost(enriched, viewerContext)) continue
+			if (!isPublicDiscoverable(enriched.content)) continue
+			const affinity = 1
+			const tasteMatch = taste ? computeTasteMatch(post, entityHash, taste) : 0
+			const score = scorePostForYou(enriched, engagement, affinity, tasteMatch)
+			scored.set(`${entityHash}:${post.id}`, { entityHash, post, score })
+		}
+	}
+
+	try {
+		const explore = await discoverPosts(username, { n: 40, mediaOnly: true })
+		for (const row of explore.posts || []) {
+			const entityHash = String(row.entityHash || '').toLowerCase()
+			const postId = String(row.postId || '')
+			if (!entityHash || !postId) continue
+			const key = `${entityHash}:${postId}`
+			if (scored.has(key)) continue
+			const view = await getTimelineMaterialized(username, entityHash)
+			const post = view.postById?.[postId]
+			if (!post || !postHasVideo(post)) continue
+			const enriched = { ...post, entityHash }
+			if (!canViewPost(enriched, viewerContext)) continue
+			const score = scorePostForYou(enriched, engagement, 0.5, taste ? computeTasteMatch(post, entityHash, taste) : 0) * 0.85
+			scored.set(key, { entityHash, post: enriched, score })
+		}
+	}
+	catch { /* explore 可选 */ }
+
+	const ranked = [...scored.values()].sort((a, b) => b.score - a.score || String(b.post.id).localeCompare(String(a.post.id)))
+	let start = 0
+	if (options.cursor) {
+		const idx = ranked.findIndex(row => `${row.entityHash}:${row.post.id}` === options.cursor)
+		start = idx >= 0 ? idx + 1 : 0
+	}
+	const pageRows = ranked.slice(start, start + limit)
+	const items = []
+	for (const row of pageRows) {
+		const item = await buildPostFeedItem(username, row.entityHash, row.post, itemContext)
+		if (item) items.push({ ...item, score: row.score })
+	}
+	const nextCursor = pageRows.length === limit && start + limit < ranked.length
+		? `${pageRows[pageRows.length - 1].entityHash}:${pageRows[pageRows.length - 1].post.id}`
+		: null
+	return { items, nextCursor }
+}

--- a/src/public/parts/shells/social/src/ws/feedHub.mjs
+++ b/src/public/parts/shells/social/src/ws/feedHub.mjs
@@ -1,0 +1,34 @@
+/** @type {Map<string, Set<import('npm:ws').WebSocket>>} */
+const feedSockets = new Map()
+
+/**
+ * 注册用户的 feed WebSocket 连接。
+ * @param {string} username 用户
+ * @param {import('npm:ws').WebSocket} socket WS
+ * @returns {void}
+ */
+export function registerFeedSocket(username, socket) {
+	const set = feedSockets.get(username) ?? new Set()
+	set.add(socket)
+	feedSockets.set(username, set)
+	socket.on('close', () => {
+		set.delete(socket)
+		if (!set.size) feedSockets.delete(username)
+	})
+}
+
+/**
+ * 向已连接的 feed WebSocket 推送更新。
+ * @param {string} username 用户
+ * @param {object} payload 推送载荷
+ * @returns {void}
+ */
+export function pushFeedUpdate(username, payload) {
+	const set = feedSockets.get(username)
+	if (!set) return
+	const text = JSON.stringify(payload)
+	for (const socket of set)
+		if (socket.readyState === 1)
+			socket.send(text)
+
+}

--- a/src/public/parts/shells/social/test/afterInit.mjs
+++ b/src/public/parts/shells/social/test/afterInit.mjs
@@ -1,0 +1,13 @@
+/**
+ * Social 集成 / live 测试共用的 init 后引导（与 node_bootstrap 一致）。
+ * @param {string} username replica 登录名
+ */
+export async function ensureSocialTestReady(username) {
+	const { ensureOperatorPubKey, resolveOperatorEntityHashForUser } =
+		await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+	const { ensureOperatorSocialReady } = await import('../src/lib/bootstrap.mjs')
+	await ensureOperatorPubKey(username)
+	if (!await resolveOperatorEntityHashForUser(username))
+		throw new Error('operator entityHash not resolved after ensureOperatorPubKey')
+	await ensureOperatorSocialReady(username)
+}

--- a/src/public/parts/shells/social/test/federation/remote_timeline.mjs
+++ b/src/public/parts/shells/social/test/federation/remote_timeline.mjs
@@ -1,0 +1,64 @@
+/**
+ * 联邦时间线测试辅助：构造并 ingest 远程签名事件。
+ */
+import { Buffer } from 'node:buffer'
+
+/**
+ * 生成随机 32 字节种子。
+ * @returns {Uint8Array} 32 字节随机种子。
+ */
+export function randomSeed() {
+	return new Uint8Array(Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32))))
+}
+
+/**
+ * 构造远程签名时间线事件（不经过本地 ingest）。
+ * @param {Uint8Array} secretKey - 发送方私钥种子。
+ * @param {string} ownerEntityHash - 时间线所属实体 hash。
+ * @param {object} event - 事件字段（type、content 等）。
+ * @returns {Promise<object>} 已签名事件对象。
+ */
+export async function makeRemoteSignedEvent(secretKey, ownerEntityHash, event) {
+	const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+	const { signTimelineEvent } = await import('npm:@steve02081504/fount-p2p/timeline/append_core')
+	const { timelineGroupId } = await import('fount/public/parts/shells/social/src/federation/namespace.mjs')
+	const sender = pubKeyHash(publicKeyFromSeed(secretKey))
+	return signTimelineEvent({
+		type: event.type,
+		groupId: timelineGroupId(ownerEntityHash),
+		sender,
+		charPartName: event.charPartName ?? null,
+		timestamp: event.timestamp ?? Date.now(),
+		hlc: event.hlc ?? { wall: Date.now(), counter: 0, node: sender.slice(0, 8) },
+		prev_event_ids: event.prev_event_ids ?? [],
+		content: event.content ?? {},
+		node_id: event.node_id ?? 'remote-test',
+	}, secretKey)
+}
+
+/**
+ * 按序 ingest 多条远程签名事件到本地时间线。
+ * @param {string} username - 目标用户。
+ * @param {Uint8Array} seed - 远程发送方私钥种子。
+ * @param {string} ownerEntityHash - 时间线所属实体 hash。
+ * @param {object[]} eventSpecs - 事件规格列表（按序链接 prev_event_ids）。
+ * @returns {Promise<object[]>} 已 ingest 的签名事件数组。
+ */
+export async function seedRemoteTimeline(username, seed, ownerEntityHash, eventSpecs) {
+	const { ingestRemoteTimelineEvent } = await import('fount/public/parts/shells/social/src/timeline/sync.mjs')
+	const signed = []
+	let previousEventId = null
+	let wallClock = Date.now() - eventSpecs.length
+	for (const spec of eventSpecs) {
+		const event = await makeRemoteSignedEvent(seed, ownerEntityHash, {
+			...spec,
+			prev_event_ids: previousEventId ? [previousEventId] : [],
+			hlc: { wall: wallClock++, counter: 0, node: 'remote-test' },
+		})
+		if (!await ingestRemoteTimelineEvent(username, ownerEntityHash, event))
+			throw new Error(`seedRemoteTimeline: ingest rejected ${spec.type}`)
+		previousEventId = event.id
+		signed.push(event)
+	}
+	return signed
+}

--- a/src/public/parts/shells/social/test/fixtures/chars/mention_getreply_agent/fount.json
+++ b/src/public/parts/shells/social/test/fixtures/chars/mention_getreply_agent/fount.json
@@ -1,0 +1,4 @@
+{
+	"type": "chars",
+	"dirname": "mention_getreply_agent"
+}

--- a/src/public/parts/shells/social/test/fixtures/chars/mention_getreply_agent/main.mjs
+++ b/src/public/parts/shells/social/test/fixtures/chars/mention_getreply_agent/main.mjs
@@ -1,0 +1,33 @@
+/**
+ * 仅 chat.GetReply、无 social.OnMessage；捕获请求身份字段供回归断言。
+ */
+import { getReplyIdentityProbe } from 'fount/public/parts/shells/social/test/fixtures/probes/getReplyIdentityProbe.mjs'
+
+/**
+ *
+ */
+export default {
+	info: {
+		'zh-CN': { name: 'Mention fallback agent', avatar: '🤖', description: '', version: '1', author: 'fount', tags: ['test'] },
+		'en-US': { name: 'Mention fallback agent', avatar: '🤖', description: '', version: '1', author: 'fount', tags: ['test'] },
+	},
+	interfaces: {
+		chat: {
+			/**
+			 * @param {import('../../../../../../../../../decl/chatLog.ts').chatReplyRequest_t} req 请求
+			 * @returns {Promise<object>} 固定回复
+			 */
+			GetReply: async req => {
+				getReplyIdentityProbe.last = {
+					UserUid: req.UserUid,
+					CharUid: req.CharUid,
+					ReplyToUid: req.ReplyToUid,
+					UserCharname: req.UserCharname,
+					ReplyToCharname: req.ReplyToCharname,
+					chatLogUids: (req.chat_log || []).map(entry => entry.uid),
+				}
+				return { content: 'mention-getreply-fallback' }
+			},
+		},
+	},
+}

--- a/src/public/parts/shells/social/test/fixtures/chars/social_on_message_probe/fount.json
+++ b/src/public/parts/shells/social/test/fixtures/chars/social_on_message_probe/fount.json
@@ -1,0 +1,4 @@
+{
+	"type": "chars",
+	"dirname": "social_on_message_probe"
+}

--- a/src/public/parts/shells/social/test/fixtures/chars/social_on_message_probe/main.mjs
+++ b/src/public/parts/shells/social/test/fixtures/chars/social_on_message_probe/main.mjs
@@ -1,0 +1,37 @@
+import { socialOnMessageProbe } from 'fount/public/parts/shells/social/test/fixtures/probes/socialOnMessageProbe.mjs'
+
+/** @type {import('../../../../../../../../../decl/charAPI.ts').CharAPI_t} */
+export default {
+	info: {
+		'zh-CN': {
+			name: 'Social OnMessage probe',
+			avatar: '🔬',
+			description: 'social OnMessage probe',
+			version: '1.0.0',
+			author: 'fount',
+			tags: ['test'],
+		},
+	},
+	interfaces: {
+		chat: {
+			/** @returns {Promise<{ content: string }>} 回复对象 */
+			GetReply: async () => ({ content: 'social-on-message-reply' }),
+		},
+		social: {
+			/**
+			 * @param {import('../../../../../../../../../decl/socialAPI.ts').SocialMessageEvent} event 事件
+			 * @returns {Promise<boolean>} 是否应处理该消息
+			 */
+			OnMessage: async event => {
+				socialOnMessageProbe.events.push({
+					authorEntityHash: event.authorEntityHash,
+					postText: event.postText,
+					mentions: event.mentions,
+					viewerEntityHash: event.viewerEntityHash,
+					postId: event.post?.id,
+				})
+				return !!socialOnMessageProbe.returnValue
+			},
+		},
+	},
+}

--- a/src/public/parts/shells/social/test/fixtures/probes/getReplyIdentityProbe.mjs
+++ b/src/public/parts/shells/social/test/fixtures/probes/getReplyIdentityProbe.mjs
@@ -1,0 +1,11 @@
+/**
+ * mention_getreply_agent 捕获的 GetReply 身份字段（模块级单例）。
+ */
+export const getReplyIdentityProbe = {
+	/** @type {object | null} */
+	last: null,
+	/** 清空探针状态。 */
+	reset() {
+		this.last = null
+	},
+}

--- a/src/public/parts/shells/social/test/fixtures/probes/socialOnMessageProbe.mjs
+++ b/src/public/parts/shells/social/test/fixtures/probes/socialOnMessageProbe.mjs
@@ -1,0 +1,12 @@
+/**
+ * Social OnMessage 探针状态（模块级单例）。
+ */
+export const socialOnMessageProbe = {
+	events: [],
+	returnValue: true,
+	/** 清空探针状态。 */
+	reset() {
+		this.events = []
+		this.returnValue = true
+	},
+}

--- a/src/public/parts/shells/social/test/frontend/composer.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/composer.spec.mjs
@@ -1,0 +1,191 @@
+import {
+	test,
+	expect,
+	openHome,
+	expectPostInFeed,
+	findPostCard,
+	createTestGroup,
+	TINY_PNG_BUFFER,
+	waitForFeedLoad,
+	postIdFromResponse,
+	openPostMoreMenu,
+} from './fixtures.mjs'
+
+test.describe('Social composer', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('publishes a post via composer', async ({ publishPost }) => {
+		const text = `playwright e2e ${Date.now()}`
+		const { postJson } = await publishPost(text)
+		expect(postJson.event?.type).toBe('post')
+		expect(postJson.event?.content?.text).toBe(text)
+	})
+
+	test('does not submit empty composer', async ({ page }) => {
+		await page.locator('#postText').fill('')
+		let posted = false
+		page.on('request', req => {
+			if (req.url().includes('/posts') && req.method() === 'POST')
+				posted = true
+		})
+		await page.locator('#postButton').click()
+		await page.waitForTimeout(500)
+		expect(posted).toBe(false)
+	})
+
+	test('published post appears in feed', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`feed-visible ${Date.now()}`)
+		await expectPostInFeed(page, postId)
+	})
+
+	test('quote preview opens from post card', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`quote-src ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await openPostMoreMenu(card)
+		await card.locator('[data-quote]').click()
+		await expect(page.locator('#quotePreview')).toBeVisible()
+	})
+
+	test('clears quote preview', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`clear-quote ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await openPostMoreMenu(card)
+		await card.locator('[data-quote]').click()
+		await expect(page.locator('#quotePreview')).toBeVisible()
+		await page.locator('.clear-quote-btn').click()
+		await expect(page.locator('#quotePreview')).toBeHidden()
+	})
+
+	test('publishes post with quote reference', async ({ page, publishPost }) => {
+		const { postId: srcId } = await publishPost(`quote-parent ${Date.now()}`)
+		const srcCard = await findPostCard(page, srcId)
+		await openPostMoreMenu(srcCard)
+		await srcCard.locator('[data-quote]').click()
+		await expect(page.locator('#quotePreview')).toBeVisible()
+		const text = `quote-child ${Date.now()}`
+		await page.locator('#postText').fill(text)
+		const postResponsePromise = page.waitForResponse(res => {
+			if (res.request().method() !== 'POST' || res.status() !== 200) return false
+			return new URL(res.url()).pathname === '/api/parts/shells:social/posts'
+		}, { timeout: 60_000 })
+		await page.locator('#postButton').click()
+		const [postResponse] = await Promise.all([postResponsePromise, waitForFeedLoad(page)])
+		const childId = postIdFromResponse(await postResponse.json())
+		await expect(page.locator('#postText')).toHaveValue('')
+		await expectPostInFeed(page, childId)
+	})
+
+	test('mention autocomplete suggests on @', async ({ page }) => {
+		await page.locator('#postText').fill('@')
+		await expect(page.locator('.mention-panel')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('.mention-option').first()).toBeVisible()
+	})
+
+	test('mention autocomplete inserts selected entity', async ({ page }) => {
+		await page.locator('#postText').fill('@')
+		await expect(page.locator('.mention-panel .mention-option').first()).toBeVisible({ timeout: 20_000 })
+		await page.locator('.mention-panel .mention-option').first().click()
+		const value = await page.locator('#postText').inputValue()
+		expect(value).toMatch(/^@\[entity:[\da-f]{128}\]$/iu)
+	})
+
+	test('visibility selector is available', async ({ page }) => {
+		const select = page.locator('#postVisibility')
+		await expect(select).toBeVisible()
+		await select.selectOption('followers')
+		await expect(select).toHaveValue('followers')
+		await select.selectOption('unlisted')
+		await expect(select).toHaveValue('unlisted')
+		await select.selectOption('private')
+		await expect(select).toHaveValue('private')
+		await select.selectOption('public')
+	})
+
+	test('publishes followers-only post with visibility label', async ({ page, publishPost }) => {
+		await page.locator('#postVisibility').selectOption('followers')
+		const { postId } = await publishPost(`followers-only ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await expect(card).toHaveAttribute('data-visibility', 'followers')
+	})
+
+	test('content warning toggle reveals and clears input', async ({ page }) => {
+		const cwInput = page.locator('#postContentWarning')
+		await expect(cwInput).toBeHidden()
+		await page.locator('#composerCwToggle').click()
+		await expect(cwInput).toBeVisible()
+		await cwInput.fill('spoiler')
+		await page.locator('#composerCwToggle').click()
+		await expect(cwInput).toBeHidden()
+		await page.locator('#composerCwToggle').click()
+		await expect(cwInput).toHaveValue('')
+	})
+
+	test('advanced panel holds reply policy and opens on selected visibility', async ({ page }) => {
+		const panel = page.locator('#composerAdvancedPanel')
+		await expect(panel).toBeHidden()
+		await page.locator('#composerAdvancedToggle').click()
+		await expect(panel).toBeVisible()
+		await expect(page.locator('#postReplyPolicy')).toBeVisible()
+		await page.locator('#composerAdvancedToggle').click()
+		await expect(panel).toBeHidden()
+		// 选择「指定人员可见」时自动展开高级面板并显示 allow 输入
+		await page.locator('#postVisibility').selectOption('selected')
+		await expect(panel).toBeVisible()
+		await expect(page.locator('[data-visibility-allow]')).toBeVisible()
+		await page.locator('#postVisibility').selectOption('public')
+	})
+
+	test('emoji picker opens from composer', async ({ page }) => {
+		await page.locator('#emojiPickButton').click()
+		await expect(page.locator('#fount-shared-emoji-picker')).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('emoji picker inserts token into composer', async ({ page }) => {
+		await page.locator('#postText').fill('hello ')
+		await page.locator('#emojiPickButton').click()
+		const picker = page.locator('#fount-shared-emoji-picker')
+		await expect(picker).toBeVisible({ timeout: 20_000 })
+		// Recent tab may be empty; switch to first non-recent tab (unicode emoji group)
+		const firstNonRecentTab = picker.locator('.emoji-tab:not([data-tab="__recent__"])').first()
+		await expect(firstNonRecentTab).toBeVisible({ timeout: 30_000 })
+		await firstNonRecentTab.click()
+		const gridButton = picker.locator('.emoji-grid-button').first()
+		await expect(gridButton).toBeVisible({ timeout: 30_000 })
+		await gridButton.click()
+		await expect(page.locator('#postText')).not.toHaveValue('hello ')
+	})
+
+	test('media upload shows preview and publishes image post', async ({ page, publishPost }) => {
+		await page.locator('#mediaInput').setInputFiles({
+			name: 'pw-test.png',
+			mimeType: 'image/png',
+			buffer: TINY_PNG_BUFFER,
+		})
+		await expect(page.locator('#mediaPreview:not(.hidden) .media-chip img'))
+			.toBeVisible({ timeout: 30_000 })
+		const text = `media-post ${Date.now()}`
+		const { postId } = await publishPost(text)
+		const card = await findPostCard(page, postId)
+		await expect(card.locator('.post-media img.post-media-item')).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('group ref picker links chat group in post', async ({ page, baseUrl, apiKey }) => {
+		const { groupId, channelId } = await createTestGroup(baseUrl, apiKey)
+		await openHome(page, baseUrl)
+		await page.locator('#composerAdvancedToggle').click()
+		const groupSelect = page.locator('#linkGroupSelect')
+		await expect(groupSelect).toBeVisible({ timeout: 30_000 })
+		const optionValue = `${groupId}\t${channelId}`
+		await expect(groupSelect.locator(`option[value="${optionValue}"]`)).toHaveCount(1, { timeout: 30_000 })
+		await groupSelect.selectOption(optionValue)
+		await groupSelect.dispatchEvent('change')
+		await expect(page.locator('#groupRefPreview')).toBeVisible({ timeout: 20_000 })
+		const text = `group-ref ${Date.now()}`
+		await page.locator('#postText').fill(text)
+		await page.locator('#postButton').click()
+		await expect(page.locator('#postText')).toHaveValue('')
+		await expect(page.locator('#feedList .group-ref-block').first()).toBeVisible({ timeout: 30_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/deepLink.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/deepLink.spec.mjs
@@ -1,0 +1,62 @@
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import {
+	test,
+	expect,
+	openHome,
+	fetchViewerEntityHash,
+} from './fixtures.mjs'
+
+test.describe('Social deep links', () => {
+	test('hash search opens search view', async ({ page, baseUrl, publishPost }) => {
+		await openHome(page, baseUrl)
+		const tag = `hashsearch${Date.now()}`
+		const { postId } = await publishPost(`hash link #${tag}`)
+		await page.goto(`${baseUrl}/parts/shells:social/#search;${encodeURIComponent(tag)}`)
+		await waitForSocialReady(page)
+		await expect(page.locator('#searchView')).toBeVisible({ timeout: 30_000 })
+		await expect(page.locator('#feedSearchClearButton')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#searchViewResults [data-post-id="${postId}"]`).first()).toBeVisible({
+			timeout: 30_000,
+		})
+	})
+
+	test('query param q opens search with target post', async ({ page, baseUrl, publishPost }) => {
+		await openHome(page, baseUrl)
+		const tag = `qparam${Date.now()}`
+		const { postId } = await publishPost(`query search #${tag}`)
+		await page.goto(`${baseUrl}/parts/shells:social/?q=${encodeURIComponent(`#${tag}`)}`)
+		await waitForSocialReady(page)
+		await expect(page.locator('#searchView')).toBeVisible({ timeout: 30_000 })
+		await expect(page.locator('#feedSearchClearButton')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#searchViewResults [data-post-id="${postId}"]`).first()).toBeVisible({
+			timeout: 30_000,
+		})
+	})
+
+	test('profile hash without post id', async ({ page, baseUrl, apiKey }) => {
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const [, profileResponse] = await Promise.all([
+			page.goto(`${baseUrl}/parts/shells:social/#profile;${entityHash}`),
+			page.waitForResponse(res =>
+				res.url().includes(`/api/parts/shells:social/profile/${entityHash}`)
+				&& res.request().method() === 'GET'
+				&& res.status() === 200,
+			),
+		])
+		expect(profileResponse.ok()).toBe(true)
+		await waitForSocialReady(page)
+		await expect(page.locator('#profileView .profile-header')).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('hashchange navigates to search', async ({ page, baseUrl, publishPost }) => {
+		await openHome(page, baseUrl)
+		const tag = `hashchg${Date.now()}`
+		await publishPost(`hash change #${tag}`)
+		await page.evaluate(query => {
+			location.hash = `search;${encodeURIComponent(query)}`
+		}, tag)
+		await expect(page.locator('#searchView')).toBeVisible({ timeout: 30_000 })
+		await expect(page.locator('#feedSearchClearButton')).toBeVisible({ timeout: 30_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/drafts.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/drafts.spec.mjs
@@ -1,0 +1,35 @@
+import { test, expect, openHome } from './fixtures.mjs'
+
+test.describe('Social composer drafts', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('save draft from composer and open from drafts view', async ({ page }) => {
+		const text = `draft-ui ${Date.now()}`
+		await page.locator('#postText').fill(text)
+		const [saveRes] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/drafts')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			{ timeout: 60_000 },
+			),
+			page.locator('#saveDraftButton').click(),
+		])
+		const saved = await saveRes.json()
+		expect(saved.draftId).toBeTruthy()
+
+		await page.locator('.side-nav .nav-btn[data-view="drafts"]').click()
+		await expect(page.locator('#draftsView')).toBeVisible()
+		await expect(page.locator(`#draftsPanel [data-draft-id="${saved.draftId}"]`)).toBeVisible({ timeout: 20_000 })
+
+		await page.locator(`#draftsPanel [data-open-draft="${saved.draftId}"]`).click()
+		await expect(page.locator('#feedView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#postText')).toHaveValue(text)
+
+		await page.locator('.side-nav .nav-btn[data-view="drafts"]').click()
+		await page.locator(`#draftsPanel [data-delete-draft="${saved.draftId}"]`).click()
+		await expect(page.locator(`#draftsPanel [data-draft-id="${saved.draftId}"]`)).toHaveCount(0, { timeout: 20_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/explore_notifications.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/explore_notifications.spec.mjs
@@ -1,0 +1,245 @@
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import {
+	test,
+	expect,
+	openHome,
+	fetchViewerEntityHash,
+	injectForeignLike,
+	seedInboxLikes,
+	seedInboxMentions,
+} from './fixtures.mjs'
+
+test.describe('Social secondary views', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('explore view loads accounts and posts sections', async ({ page }) => {
+		const [accountsResponse, postsResponse] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/explore?')
+				&& res.status() === 200,
+			),
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/explore/posts')
+				&& res.status() === 200,
+			),
+			page.locator('.side-nav .nav-btn[data-view="explore"]').click(),
+		])
+		expect(await accountsResponse.json()).toHaveProperty('accounts')
+		expect(await postsResponse.json()).toHaveProperty('posts')
+		await expect(page.locator('#exploreView')).toBeVisible()
+		await expect(page.locator('#exploreView .section-title').first()).toBeVisible()
+		await expect(page.locator('#exploreMediaOnly')).toBeVisible()
+	})
+
+	test('explore media-only query returns posts payload', async ({ page, baseUrl, apiKey }) => {
+		await page.locator('.side-nav .nav-btn[data-view="explore"]').click()
+		await expect(page.locator('#exploreView')).toBeVisible({ timeout: 20_000 })
+		const res = await page.request.get(
+			`${baseUrl}/api/parts/shells:social/explore/posts?limit=5&mediaOnly=true&fount-apikey=${encodeURIComponent(apiKey)}`,
+		)
+		expect(res.ok()).toBe(true)
+		expect(await res.json()).toHaveProperty('posts')
+	})
+
+	test('explore media-only checkbox reloads filtered posts', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="explore"]').click()
+		await expect(page.locator('#exploreMediaOnly')).toBeVisible({ timeout: 20_000 })
+		const [postsResponse] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/explore/posts')
+				&& res.url().includes('mediaOnly=true')
+				&& res.status() === 200,
+			),
+			page.locator('#exploreMediaOnly').check(),
+		])
+		expect(await postsResponse.json()).toHaveProperty('posts')
+	})
+
+	test('notifications view loads', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsView')).toBeVisible()
+		await expect(page.locator('#notificationsView .empty, #notificationsView .notification-card').first())
+			.toBeVisible({ timeout: 20_000 })
+	})
+
+	test('notifications view loads inbox tabs', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsView')).toBeVisible()
+		await expect(page.locator('.inbox-filter-tabs [data-notif-filter="all"]')).toBeVisible()
+		await expect(page.locator('.inbox-filter-tabs [data-notif-filter="like"]')).toBeVisible()
+	})
+
+	test('like generates notification', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`notif-parent ${Date.now()}`)
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsView .notification-card').first())
+			.toBeVisible({ timeout: 20_000 })
+	})
+
+	test('notification view link opens post detail', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`notif-link ${Date.now()}`)
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await page.locator('.side-nav .nav-btn[data-view="feed"]').click()
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		const notifCard = page.locator('#notificationsView .notification-card').first()
+		await expect(notifCard).toBeVisible({ timeout: 30_000 })
+		await notifCard.locator('a.notification-view-link').click()
+		await expect(page.locator('#postDetailView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#postDetailView [data-post-id="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('notifications mark all read clears badge', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`markall-parent ${Date.now()}`)
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsMarkAllButton')).toBeVisible({ timeout: 20_000 })
+		await page.locator('#notificationsMarkAllButton').click()
+		await expect(page.locator('#notificationsBadge')).toHaveClass(/hidden/, { timeout: 20_000 })
+	})
+
+	test('notification badge shows unread count before opening view', async ({ page, baseUrl, publishPost, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`badge-parent ${Date.now()}`)
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await page.goto(`${baseUrl}/parts/shells:social/`, { waitUntil: 'domcontentloaded' })
+		await waitForSocialReady(page)
+		await expect(page.locator('#notificationsBadge:not(.hidden)')).toBeVisible({ timeout: 10_000 })
+	})
+
+	test('inbox like tab filters notifications', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`tab-like ${Date.now()}`)
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await seedInboxMentions(baseUrl, apiKey, 1)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsView .notification-card').first()).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#notificationsView .notification-card .icon-notification-mention').first()).toBeVisible()
+		await Promise.all([
+			page.waitForResponse(res => {
+				const url = new URL(res.url())
+				return url.pathname === '/api/parts/shells:social/notifications'
+					&& url.searchParams.get('types') === 'like'
+					&& res.status() === 200
+			}),
+			page.locator('.inbox-filter-tabs [data-notif-filter="like"]').click(),
+		])
+		await expect(page.locator('#notificationsView .notification-card .icon-notification-mention')).toHaveCount(0)
+		await expect(page.locator('#notificationsView .notification-card .icon-notification-like').first()).toBeVisible()
+		await expect(page.locator('#notificationsView .notification-card', {
+			has: page.locator(`a.notification-view-link[href*="${postId}"]`),
+		}).first()).toBeVisible()
+	})
+
+	test('aggregated like copy shows actor count', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`agg-like ${Date.now()}`)
+		await seedInboxLikes(baseUrl, apiKey, viewerEntityHash, postId, 2)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		const card = page.locator('#notificationsView .notification-card', {
+			has: page.locator(`a.notification-view-link[href*="${postId}"]`),
+		}).first()
+		await expect(card).toBeVisible({ timeout: 20_000 })
+		await expect(card).toHaveAttribute('data-actor-count', '2')
+		await expect(card.locator('.notification-type')).toContainText('和')
+	})
+
+	test('notification snippet is visible on inbox card', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`snippet-parent ${Date.now()}`)
+		await seedInboxLikes(baseUrl, apiKey, viewerEntityHash, postId, 1)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		const card = page.locator('#notificationsView .notification-card', {
+			has: page.locator(`a.notification-view-link[href*="${postId}"]`),
+		}).first()
+		await expect(card).toBeVisible({ timeout: 20_000 })
+		await expect(card.locator('.notification-snippet')).toContainText('aggregated like target')
+	})
+
+	test('WS notification merges into existing aggregated card', async ({ page, publishPost, baseUrl, apiKey }) => {
+		const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const { postId } = await publishPost(`ws-merge ${Date.now()}`)
+		await seedInboxLikes(baseUrl, apiKey, viewerEntityHash, postId, 1)
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		const cardForPost = page.locator('#notificationsView .notification-card', {
+			has: page.locator(`a.notification-view-link[href*="${postId}"]`),
+		})
+		await expect(cardForPost.first()).toBeVisible({ timeout: 20_000 })
+		await expect(cardForPost.first()).toHaveAttribute('data-actor-count', '1')
+		await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		await expect(cardForPost.first()).toHaveAttribute('data-actor-count', '2', { timeout: 20_000 })
+		await expect(cardForPost).toHaveCount(1)
+	})
+
+	test('notifications infinite scroll loads next page', async ({ page, baseUrl, apiKey }) => {
+		await seedInboxMentions(baseUrl, apiKey, 41)
+		// rootMargin 可能在首屏 bind 后立刻拉下一页；也覆盖需滚动才触发的情况
+		const cursorWait = page.waitForResponse(res => {
+			if (res.request().method() !== 'GET' || res.status() !== 200) return false
+			const url = new URL(res.url())
+			return url.pathname === '/api/parts/shells:social/notifications' && url.searchParams.has('cursor')
+		}, { timeout: 60_000 })
+		await page.locator('.side-nav .nav-btn[data-view="notifications"]').click()
+		await expect(page.locator('#notificationsView .notification-card').first())
+			.toBeVisible({ timeout: 30_000 })
+		await page.locator('#notificationsScrollSentinel').scrollIntoViewIfNeeded()
+		expect(await (await cursorWait).json()).toHaveProperty('notifications')
+		// 首页 limit=40；第二页到达后总数应超过首页
+		await expect.poll(
+			() => page.locator('#notificationsView .notification-card').count(),
+			{ timeout: 15_000 },
+		).toBeGreaterThan(40)
+	})
+
+	test('explore post link opens profile', async ({ page, publishPost }) => {
+		const snippet = `explore-link ${Date.now()}`
+		await publishPost(snippet)
+		await page.locator('.side-nav .nav-btn[data-view="explore"]').click()
+		await expect(page.locator('#exploreView .explore-post-card').first()).toBeVisible({ timeout: 30_000 })
+		const postCard = page.locator('#exploreView .explore-post-card', { hasText: snippet }).first()
+		await expect(postCard).toBeVisible({ timeout: 30_000 })
+		await postCard.locator('a.author-name').click()
+		await expect(page.locator('#profileView')).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('explore post author opens profile after ensure discoverable', async ({ page, publishPost }) => {
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await expect(page.locator('[data-profile-settings]')).toBeVisible({ timeout: 20_000 })
+		await page.locator('[data-profile-settings]').click()
+		await expect(page.locator('#settingsView')).toBeVisible({ timeout: 20_000 })
+		const protectedInput = page.locator('#exploreProtectedInput')
+		await expect(protectedInput).toBeVisible({ timeout: 10_000 })
+		// 先前用例可能把 hideFromDiscovery 拨成 true；保存 meta 会原样写回，导致探索页看不到新帖
+		if (await protectedInput.isChecked())
+			await Promise.all([
+				page.waitForResponse(res =>
+					res.url().includes('/api/parts/shells:social/profile/meta')
+					&& res.request().method() === 'POST'
+					&& res.status() === 200,
+				),
+				protectedInput.setChecked(false),
+			])
+		await page.locator('#settingsView [data-view="profile"]').click()
+		const snippet = `explore-visible-post ${Date.now()}`
+		await page.locator('.side-nav .nav-btn[data-view="feed"]').click()
+		await publishPost(snippet)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/explore/posts')
+				&& res.status() === 200,
+			),
+			page.locator('.side-nav .nav-btn[data-view="explore"]').click(),
+		])
+		const postCard = page.locator('#exploreView .explore-post-card', { hasText: snippet }).first()
+		await expect(postCard).toBeVisible({ timeout: 30_000 })
+		await postCard.locator('a.author-name').click()
+		await expect(page.locator('#profileView .profile-header')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#profileEntityCardHost .profile-popup')).toBeVisible()
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/feed.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/feed.spec.mjs
@@ -1,0 +1,174 @@
+import {
+	test,
+	expect,
+	openHome,
+	expectPostInFeed,
+	searchAndExpectPost,
+	waitForFeedLoad,
+	findPostCard,
+	seedPostsViaApi,
+} from './fixtures.mjs'
+
+test.describe('Social feed', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('feed refresh reloads posts', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`refresh-test ${Date.now()}`)
+		await expectPostInFeed(page, postId)
+		const [feedResponse] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/feed')
+				&& res.request().method() === 'GET'
+				&& res.status() === 200,
+			),
+			page.locator('#feedRefreshButton').click(),
+		])
+		expect(await feedResponse.json()).toHaveProperty('items')
+		await expectPostInFeed(page, postId)
+	})
+
+	test('hashtag search finds published post', async ({ page, publishPost }) => {
+		const tag = `pw${Date.now()}`
+		const { postId } = await publishPost(`search-me #${tag}`)
+		await searchAndExpectPost(page, `#${tag}`, postId)
+		await expect(page.locator('#feedSearchClearButton')).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('short search shows too-short hint', async ({ page }) => {
+		await page.locator('#feedSearchInput').fill('a')
+		await page.locator('#feedSearchInput').press('Enter')
+		await expect(page.locator('#searchViewResults [data-i18n="social.search.tooShort"]')).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('trending hashtag link opens topic view', async ({ page, publishPost }) => {
+		const tag = `trend${Date.now()}`
+		const { postId } = await publishPost(`trending-a #${tag}`)
+		await publishPost(`trending-b #${tag}`)
+		await Promise.all([
+			waitForFeedLoad(page),
+			page.locator('#feedRefreshButton').click(),
+		])
+		const trending = page.locator('#feedTrending')
+		await expect(trending).toBeVisible({ timeout: 30_000 })
+		const tagLink = trending.locator('a.trending-tag', { hasText: `#${tag}` })
+		await expect(tagLink).toBeVisible({ timeout: 30_000 })
+		await tagLink.click()
+		await expect(page.locator('#topicView:not(.hidden)')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#topicView .topic-view-title')).toHaveText(`#${tag}`)
+		await expect(page.locator(`#topicPostList [data-post-id="${postId}"]`)).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('search clear restores default feed', async ({ page, publishPost }) => {
+		const tag = `clear${Date.now()}`
+		const { postId } = await publishPost(`clear-feed #${tag}`)
+		await searchAndExpectPost(page, `#${tag}`, postId)
+		await page.locator('#feedSearchClearButton').click()
+		await expect(page.locator('#feedSearchInput')).toHaveValue('')
+		await expectPostInFeed(page, postId)
+	})
+
+	test('navigating to feed clears active search', async ({ page, publishPost }) => {
+		const tag = `refreshclr${Date.now()}`
+		const { postId } = await publishPost(`refresh-clear #${tag}`)
+		await searchAndExpectPost(page, `#${tag}`, postId)
+		await Promise.all([
+			waitForFeedLoad(page),
+			page.locator('.side-nav .nav-btn[data-view="feed"]').click(),
+		])
+		await expect(page.locator('#feedSearchInput')).toHaveValue('')
+		await expect(page.locator('#feedSearchClearButton')).toBeHidden()
+		await expectPostInFeed(page, postId)
+	})
+
+	test('hashtag link in post body opens topic view', async ({ page, publishPost }) => {
+		const tag = `bodytag${Date.now()}`
+		const { postId } = await publishPost(`see #${tag} here`)
+		const card = await findPostCard(page, postId)
+		await card.locator('a[href*="#topic:"]').filter({ hasText: `#${tag}` }).click()
+		await expect(page.locator('#topicView:not(.hidden)')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#topicView .topic-view-title')).toHaveText(`#${tag}`)
+		await expect(page.locator(`#topicPostList [data-post-id="${postId}"]`)).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('long code block stays collapsed and summary does not open detail', async ({ page, publishPost }) => {
+		const lines = Array.from({ length: 40 }, (_, i) => `const line${i} = ${i}`).join('\n')
+		const { postId } = await publishPost(`\`\`\`js\n${lines}\n\`\`\``)
+		const card = await findPostCard(page, postId)
+		const details = card.locator('details.markdown-code-block')
+		await expect(details).toBeVisible({ timeout: 20_000 })
+		await expect(details).not.toHaveAttribute('open')
+		const beforeHash = await page.evaluate(() => location.hash)
+		await details.locator('summary').click()
+		await expect(details).toHaveAttribute('open', '')
+		expect(await page.evaluate(() => location.hash)).toBe(beforeHash)
+		await expect(page.locator('#postDetailView:not(.hidden)')).toHaveCount(0)
+	})
+
+	test('long prose folds in feed and expands in place', async ({ page, publishPost }) => {
+		const text = Array.from({ length: 36 }, (_, i) => `fold-line-${i} ${'word '.repeat(12)}`).join('\n\n')
+		const { postId } = await publishPost(text)
+		const card = await findPostCard(page, postId)
+		const body = card.locator('.body.markdown-body').first()
+		await expect(body).toHaveClass(/body-foldable/, { timeout: 10_000 })
+		await expect(body).not.toHaveClass(/body-expanded/)
+		const expand = card.locator('.body-expand')
+		await expect(expand).toBeVisible()
+		const beforeHash = await page.evaluate(() => location.hash)
+		const collapsedHeight = await body.evaluate(el => el.getBoundingClientRect().height)
+		await expand.click()
+		await expect(body).toHaveClass(/body-expanded/)
+		expect(await page.evaluate(() => location.hash)).toBe(beforeHash)
+		const expandedHeight = await body.evaluate(el => el.getBoundingClientRect().height)
+		expect(expandedHeight).toBeGreaterThan(collapsedHeight)
+		await expand.click()
+		await expect(body).not.toHaveClass(/body-expanded/)
+	})
+
+	test('infinite scroll fetches next feed page', async ({ page, baseUrl, apiKey }) => {
+		await seedPostsViaApi(baseUrl, apiKey, 31, 'loadmore')
+		// 首屏后会后台预取带 cursor 的下一页；滚动时消费缓存而不再发请求
+		const cursorWait = page.waitForResponse(res => {
+			if (res.request().method() !== 'GET' || res.status() !== 200) return false
+			const url = new URL(res.url())
+			return url.pathname === '/api/parts/shells:social/feed' && url.searchParams.has('cursor')
+		}, { timeout: 60_000 })
+		await openHome(page, baseUrl)
+		await expect(page.locator('#feedScrollSentinel')).toBeAttached({ timeout: 60_000 })
+		const initialCount = await page.locator('#feedList [data-post-id]').count()
+		const feedResponse = await cursorWait
+		expect(await feedResponse.json()).toHaveProperty('items')
+		await page.locator('#feedScrollSentinel').scrollIntoViewIfNeeded()
+		await expect(page.locator('#feedList [data-post-id]')).not.toHaveCount(initialCount, { timeout: 15_000 })
+		const newCount = await page.locator('#feedList [data-post-id]').count()
+		expect(newCount).toBeGreaterThan(initialCount)
+	})
+
+	test('feed loops replay when cursor exhausted', async ({ page, baseUrl, apiKey }) => {
+		await seedPostsViaApi(baseUrl, apiKey, 3, 'replay')
+		await openHome(page, baseUrl)
+		await expect(page.locator('#feedList [data-post-id]').first()).toBeVisible({ timeout: 60_000 })
+		const before = await page.locator('#feedList [data-post-id]').count()
+		expect(before).toBeGreaterThan(0)
+		await expect(page.locator('#feedScrollSentinel')).toBeAttached({ timeout: 30_000 })
+		// 残留帖子可能先分页；持续滚到哨兵直到出现重放分隔线
+		for (let i = 0; i < 20; i++) {
+			if (await page.locator('.feed-replay-divider').isVisible()) break
+			await page.locator('#feedScrollSentinel').scrollIntoViewIfNeeded()
+			await page.waitForTimeout(250)
+		}
+		await expect(page.locator('.feed-replay-divider')).toBeVisible({ timeout: 15_000 })
+		// 分隔线先于卡片追加出现；等本轮重放追加完成后再取稳定计数
+		await expect(async () => {
+			const n = await page.locator('#feedList [data-post-id]').count()
+			expect(n).toBeGreaterThan(before)
+			await page.waitForTimeout(400)
+			expect(await page.locator('#feedList [data-post-id]').count()).toBe(n)
+		}).toPass({ timeout: 15_000 })
+		const afterReplay = await page.locator('#feedList [data-post-id]').count()
+		// 重放完成后计数应稳定，不再因 observer 重绑而死循环膨胀
+		await page.waitForTimeout(1500)
+		expect(await page.locator('#feedList [data-post-id]').count()).toBe(afterReplay)
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/fixtures.mjs
+++ b/src/public/parts/shells/social/test/frontend/fixtures.mjs
@@ -1,0 +1,481 @@
+import { Buffer } from 'node:buffer'
+
+import { ms } from 'fount/scripts/ms.mjs'
+import {
+	withApiRequest,
+	createChatTestGroup,
+	fetchViewerEntityHash as fetchViewerEntityHashShared,
+} from 'fount/scripts/test/playwright/api.mjs'
+import { createFountFixtures } from 'fount/scripts/test/playwright/fixtures.mjs'
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import {
+	FOREIGN_FE_AUTHOR_HASH,
+	SEEDED_TEST_TARGET_HASH,
+} from './seedConstants.mjs'
+
+/** 隔离节点专用测试用户名（由 run.mjs 注入 FOUNT_TEST_USERNAME） */
+export const TEST_USERNAME = process.env.FOUNT_TEST_USERNAME
+
+/** 经 bootstrap 注册 network hint 的可发现测试目标（follow/block 烟测）。 */
+export const DUMMY_ENTITY_HASH = SEEDED_TEST_TARGET_HASH
+
+/** bootstrap 联邦 ingest 的远程作者（治理菜单烟测）。 */
+export { FOREIGN_FE_AUTHOR_HASH }
+
+/**
+ * 安装 clipboard stub（share/copy 烟测避免缺 API）。
+ * @param {object} args fixture 参数
+ * @param {import('npm:@playwright/test').Page} args.page Playwright 页面
+ * @returns {Promise<void>}
+ */
+async function installClipboardStub({ page }) {
+	await page.addInitScript(() => {
+		if (!navigator.clipboard)
+			Object.defineProperty(navigator, 'clipboard', {
+				value: {
+					/* eslint-disable-next-line jsdoc/require-jsdoc -- stub */
+					writeText: async () => { },
+				},
+				configurable: true,
+			})
+		else
+			/**
+			 *
+			 */
+			navigator.clipboard.writeText = async () => { }
+	})
+}
+
+/**
+ * Social 前端 E2E 测试套件（扩展 publishPost fixture）。
+ */
+export const { test: baseTest, expect } = createFountFixtures({
+	locale: 'zh-CN',
+	isolated: {
+		shellLabel: 'Social',
+		timeout: ms('3m'),
+		beforeEach: installClipboardStub,
+	},
+})
+
+/**
+ * 扩展 publishPost 的 Social 测试套件。
+ */
+export const test = baseTest.extend({
+	/**
+	 * 通过 composer 发帖的 fixture。
+	 * @param {(text: string) => Promise<{ postJson: object, postId: string, text: string }>} use - Playwright fixture use 回调。
+	 */
+	publishPost: async ({ page, baseUrl, apiKey }, use) => {
+		await use(async text => {
+			const postJson = await publishPostViaComposer(page, text, { baseUrl, apiKey })
+			const postId = postIdFromResponse(postJson)
+			await waitForPostMaterialized(baseUrl, apiKey, postId)
+			return { postJson, postId, text }
+		})
+	},
+})
+
+/**
+ * 打开 Social 首页并等待 i18n 与 feed 就绪。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} baseUrl - 测试根 URL。
+ * @returns {Promise<void>}
+ */
+export async function openHome(page, baseUrl) {
+	await page.goto(`${baseUrl}/parts/shells:social/`, { waitUntil: 'domcontentloaded' })
+	await waitForSocialReady(page)
+	await expect(page.locator('#feedView')).toBeVisible({ timeout: ms('30s') })
+	await expect(page.locator('#postButton[data-i18n="social.composer.publish"]')).toBeVisible()
+	await expect(page.locator('#postButton')).not.toHaveText('', { timeout: ms('30s') })
+}
+
+/**
+ * 打开帖子卡片溢出菜单。
+ * @param {import('npm:@playwright/test').Locator} card - 帖子卡片定位器。
+ * @returns {Promise<void>}
+ */
+export async function openPostMoreMenu(card) {
+	await card.locator('[data-more-toggle]').click()
+	await expect(card.locator('.post-more-menu')).not.toHaveClass(/hidden/)
+}
+
+/**
+ * 等待 feed GET 完成。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {number} [timeout=60000] 等待毫秒数。
+ * @returns {Promise<import('npm:@playwright/test').Response>} feed GET 响应。
+ */
+export async function waitForFeedLoad(page, timeout = ms('1m')) {
+	return page.waitForResponse(res => {
+		if (res.request().method() !== 'GET' || res.status() !== 200) return false
+		return new URL(res.url()).pathname === '/api/parts/shells:social/feed'
+	}, { timeout })
+}
+
+/**
+ * 轮询直到帖子出现在 profile posts API 中。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {string} postId - 帖子 id。
+ * @returns {Promise<string>} entityHash。
+ */
+export async function waitForPostMaterialized(baseUrl, apiKey, postId) {
+	const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+	const key = encodeURIComponent(apiKey)
+	return withApiRequest(async req => {
+		for (let attempt = 0; attempt < 15; attempt++) {
+			const profileRes = await req.get(
+				`${baseUrl}/api/parts/shells:social/profile/${entityHash}/posts?fount-apikey=${key}`,
+			)
+			const feedRes = await req.get(`${baseUrl}/api/parts/shells:social/feed?fount-apikey=${key}`)
+			const inProfile = profileRes.ok()
+				&& (await profileRes.json()).items?.some(item => item.postId === postId)
+			const inFeed = feedRes.ok()
+				&& (await feedRes.json()).items?.some(item => item.postId === postId)
+			if (inProfile && inFeed) return entityHash
+			await new Promise(resolve => setTimeout(resolve, 200))
+		}
+		throw new Error(`post not materialized in profile+feed: ${postId}`)
+	})
+}
+
+/**
+ * 通过 composer 发帖并等待 API 成功及 feed 刷新。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} text - 帖子正文。
+ * @param {{ baseUrl?: string, apiKey?: string }} [api] - 可选 API 上下文（当前未使用，预留扩展）。
+ * @returns {Promise<object>} 发帖 API 响应 JSON（含 event.id）。
+ */
+export async function publishPostViaComposer(page, text, api = {}) {
+	await page.locator('#postText').fill(text)
+	const postWait = page.waitForResponse(res => {
+		if (res.request().method() !== 'POST' || res.status() !== 200) return false
+		return new URL(res.url()).pathname === '/api/parts/shells:social/posts'
+	}, { timeout: ms('1m') })
+	const feedWait = waitForFeedLoad(page)
+	await page.locator('#postButton').click()
+	const postResponse = await postWait
+	const postJson = await postResponse.json()
+	await feedWait
+	await expect(page.locator('#postText')).toHaveValue('')
+	return postJson
+}
+
+/**
+ * 提交回复并等待 POST 完成（避免后续 page.goto 打断在途请求）。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {import('npm:@playwright/test').Locator} panel - 回复面板定位器。
+ * @returns {Promise<void>}
+ */
+export async function submitReplyViaPanel(page, panel) {
+	await Promise.all([
+		page.waitForResponse(res =>
+			res.url().includes('/api/parts/shells:social/posts')
+			&& res.request().method() === 'POST'
+			&& res.status() === 200,
+		{ timeout: ms('30s') }),
+		panel.locator('[data-submit-reply]').click(),
+	])
+}
+
+/**
+ * 从发帖 API 响应解析 postId。
+ * @param {object} postJson - 发帖响应。
+ * @returns {string} postId。
+ */
+export function postIdFromResponse(postJson) {
+	const id = postJson?.event?.id || postJson?.event?.postId
+	if (!id) throw new Error('post response missing event.id')
+	return String(id)
+}
+
+/**
+ * 刷新 feed 并等待 GET 完成。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @returns {Promise<void>}
+ */
+async function refreshFeed(page) {
+	await Promise.all([
+		waitForFeedLoad(page),
+		page.locator('#feedRefreshButton').click(),
+	])
+}
+
+/**
+ * 在 feed 或资料页中按 postId 定位帖子卡片。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} postId - 帖子 id。
+ * @param {{ preferFeed?: boolean }} [options] - 查找选项。
+ * @returns {Promise<import('npm:@playwright/test').Locator>} 帖子卡片定位器。
+ */
+export async function findPostCard(page, postId, options = {}) {
+	const allowProfileFallback = options.allowProfileFallback === true
+	const sel = `[data-post-id="${postId}"]`
+	const feedCard = page.locator(`#feedView ${sel}`)
+	for (let attempt = 0; attempt < 3; attempt++) {
+		try {
+			// feed GET 返回后 DOM 渲染是异步的；等可见而非查 count，避免竞态
+			await expect(feedCard.first()).toBeVisible({ timeout: ms('5s') })
+			return feedCard.first()
+		}
+		catch { /* 未渲染或不在本页，刷新重试 */ }
+		await refreshFeed(page)
+	}
+	if (allowProfileFallback) {
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		const profileCard = page.locator(`#profileView ${sel}`)
+		await expect(profileCard.first()).toBeVisible({ timeout: ms('15s') })
+		return profileCard.first()
+	}
+	throw new Error(`post ${postId} not found in feed (set allowProfileFallback to search profile)`)
+}
+
+/**
+ * 等待 feed 中出现指定 postId 的帖子卡片。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} postId - 帖子 id。
+ * @returns {Promise<import('npm:@playwright/test').Locator>} 帖子卡片定位器。
+ */
+export const expectPostInFeed = findPostCard
+
+/**
+ * 轮询 feed 搜索直到目标帖出现在 API 结果与 DOM 中。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} query - 搜索词。
+ * @param {string} postId - 期望帖子 id。
+ * @returns {Promise<void>}
+ */
+async function pollSearchForPost(page, query, postId) {
+	for (let attempt = 0; attempt < 2; attempt++) {
+		await page.locator('#feedSearchInput').fill(query)
+		const searchWait = page.waitForResponse(res => {
+			if (res.request().method() !== 'GET' || res.status() !== 200) return false
+			return new URL(res.url()).pathname === '/api/parts/shells:social/search'
+		}, { timeout: ms('1m') })
+		await page.locator('#feedSearchInput').press('Enter')
+		const searchRes = await searchWait
+		const data = await searchRes.json()
+		if ((data.items || []).some(item => item.postId === postId)) {
+			await expect(page.locator(`#searchViewResults [data-post-id="${postId}"]`).first()).toBeVisible({
+				timeout: ms('10s'),
+			})
+			return
+		}
+		if (attempt === 0)
+			await page.waitForTimeout(300)
+	}
+	throw new Error(`search did not return post ${postId} for query ${query}`)
+}
+
+/**
+ * 执行 feed 搜索并等待结果中出现指定 postId。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} query - 搜索词。
+ * @param {string} postId - 期望帖子 id。
+ * @returns {Promise<void>} 无返回值。
+ */
+export async function searchAndExpectPost(page, query, postId) {
+	await pollSearchForPost(page, query, postId)
+}
+
+/**
+ * 通过 API 批量发帖（用于分页等需大量帖子的场景）。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {number} count - 发帖数量。
+ * @param {string} [textPrefix] - 正文前缀。
+ * @returns {Promise<void>}
+ */
+export async function seedPostsViaApi(baseUrl, apiKey, count, textPrefix = 'seed') {
+	const key = encodeURIComponent(apiKey)
+	await withApiRequest(async req => {
+		for (let index = 0; index < count; index++) {
+			const res = await req.post(
+				`${baseUrl}/api/parts/shells:social/posts?fount-apikey=${key}`,
+				{ data: { text: `${textPrefix}-${index}-${Date.now()}`, visibility: 'public', locale: 'zh-CN' } },
+			)
+			if (!res.ok()) throw new Error(`seed post failed: ${res.status()}`)
+		}
+	})
+}
+
+/**
+ * Social 前端建群：包装 `createChatTestGroup`，默认 name/description 带 social 前缀。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {{ name?: string, description?: string }} [options] - 可选项。
+ * @returns {Promise<{ groupId: string, channelId: string, defaultChannelId: string }>} 群与默认频道 id。
+ */
+export function createTestGroup(baseUrl, apiKey, options = {}) {
+	return createChatTestGroup(baseUrl, apiKey, {
+		description: 'social frontend test',
+		...options,
+		name: options.name ?? `social-fe-group-${Date.now()}`,
+	})
+}
+
+/** 极短黑帧 mp4，供 videos 前端测；经 page.route 本地 fulfill，不打外网。 */
+export const VIDEO_FIXTURE_PATH = '/__fount_test__/tiny.mp4'
+
+/** @see VIDEO_FIXTURE_PATH */
+export const TINY_MP4_BUFFER = Buffer.from(
+	'AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAANcbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAHgAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAod0cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAHgAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAB4AAAEAAABAAAAAAH/bWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAAAyAAAACABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABqm1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAWpzdGJsAAAAvnN0c2QAAAAAAAAAAQAAAK5hdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAABAAEABIAAAASAAAAAAAAAABFUxhdmM2Mi4xNi4xMDAgbGlieDI2NAAAAAAAAAAAAAAAGP//AAAANGF2Y0MBZAAK/+EAF2dkAAqs2V7ARAAAAwAEAAADAMg8SJZYAQAGaOvjyyLA/fj4AAAAABBwYXNwAAAAAQAAAAEAAAAUYnRydAAAAAAAAL7iAAAAAAAAABhzdHRzAAAAAAAAAAEAAAADAAACAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAKGN0dHMAAAAAAAAAAwAAAAEAAAQAAAAAAQAABgAAAAABAAACAAAAABxzdHNjAAAAAAAAAAEAAAABAAAAAwAAAAEAAAAgc3RzegAAAAAAAAAAAAAAAwAAAsUAAAAMAAAADAAAABRzdGNvAAAAAAAAAAEAAAOMAAAAYXVkdGEAAABZbWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAbWRpcmFwcGwAAAAAAAAAAAAAAAAsaWxzdAAAACSpdG9vAAAAHGRhdGEAAAABAAAAAExhdmY2Mi42LjEwMQAAAAhmcmVlAAAC5W1kYXQAAAKuBgX//6rcRem95tlIt5Ys2CDZI+7veDI2NCAtIGNvcmUgMTY1IHIzMjIzIDA0ODBjYjAgLSBILjI2NC9NUEVHLTQgQVZDIGNvZGVjIC0gQ29weWxlZnQgMjAwMy0yMDI1IC0gaHR0cDovL3d3dy52aWRlb2xhbi5vcmcveDI2NC5odG1sIC0gb3B0aW9uczogY2FiYWM9MSByZWY9MyBkZWJsb2NrPTE6MDowIGFuYWx5c2U9MHgzOjB4MTEzIG1lPWhleCBzdWJtZT03IHBzeT0xIHBzeV9yZD0xLjAwOjAuMDAgbWl4ZWRfcmVmPTEgbWVfcmFuZ2U9MTYgY2hyb21hX21lPTEgdHJlbGxpcz0xIDh4OGRjdD0xIGNxbT0wIGRlYWR6b25lPTIxLDExIGZhc3RfcHNraXA9MSBjaHJvbWFfcXBfb2Zmc2V0PS0yIHRocmVhZHM9MSBsb29rYWhlYWRfdGhyZWFkcz0xIHNsaWNlZF90aHJlYWRzPTAgbnI9MCBkZWNpbWF0ZT0xIGludGVybGFjZWQ9MCBibHVyYXlfY29tcGF0PTAgY29uc3RyYWluZWRfaW50cmE9MCBiZnJhbWVzPTMgYl9weXJhbWlkPTIgYl9hZGFwdD0xIGJfYmlhcz0wIGRpcmVjdD0xIHdlaWdodGI9MSBvcGVuX2dvcD0wIHdlaWdodHA9MiBrZXlpbnQ9MjUwIGtleWludF9taW49MjUgc2NlbmVjdXQ9NDAgaW50cmFfcmVmcmVzaD0wIHJjX2xvb2thaGVhZD00MCByYz1jcmYgbWJ0cmVlPTEgY3JmPTIzLjAgcWNvbXA9MC42MCBxcG1pbj0wIHFwbWF4PTY5IHFwc3RlcD00IGlwX3JhdGlvPTEuNDAgYXE9MToxLjAwAIAAAAAPZYiEADP//vbsvgU2FMjBAAAACEGaImxCv/7AAAAACAGeQXkK/8SB',
+	'base64',
+)
+
+/**
+ * 拦截 VIDEO_FIXTURE_PATH，返回 TINY_MP4_BUFFER。
+ * @param {import('@playwright/test').Page} page 页面
+ * @returns {Promise<void>}
+ */
+export async function installVideoFixtureRoute(page) {
+	await page.route(`**${VIDEO_FIXTURE_PATH}`, route => route.fulfill({
+		status: 200,
+		headers: { 'Content-Type': 'video/mp4' },
+		body: TINY_MP4_BUFFER,
+	}))
+}
+
+/**
+ * 绝对 URL，写入 mediaRefs 后由浏览器加载（需先 installVideoFixtureRoute）。
+ * @param {string} baseUrl 测试根 URL
+ * @returns {string} 视频 fixture 的绝对 URL
+ */
+export function videoFixtureUrl(baseUrl) {
+	return new URL(VIDEO_FIXTURE_PATH, baseUrl).href
+}
+
+/** 1×1 PNG，供 composer 媒体上传烟测。 */
+export const TINY_PNG_BUFFER = Buffer.from(
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+	'base64',
+)
+
+/**
+ * 读取当前测试用户的 viewer entityHash（含 ECONNRESET 重试）。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @returns {Promise<string>} entityHash
+ */
+export function fetchViewerEntityHash(baseUrl, apiKey) {
+	return fetchViewerEntityHashShared(baseUrl, apiKey, { retries: 2 })
+}
+
+/**
+ * 通过 API 关注指定 entity。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {string} entityHash - 目标 entityHash。
+ * @returns {Promise<void>}
+ */
+export async function followEntityViaApi(baseUrl, apiKey, entityHash) {
+	await withApiRequest(async req => {
+		const res = await req.post(
+			`${baseUrl}/api/parts/shells:social/relationships/follow?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash, follow: true } },
+		)
+		if (!res.ok()) throw new Error(`follow failed: ${res.status()}`)
+	})
+}
+
+/**
+ * 关注 bootstrap 远程作者并刷新 feed，返回其帖子卡片定位器。
+ * @param {import('npm:@playwright/test').Page} page - Playwright 页面。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @returns {Promise<import('npm:@playwright/test').Locator>} 远程作者帖子卡片。
+ */
+export async function findForeignAuthorPostCard(page, baseUrl, apiKey) {
+	await followEntityViaApi(baseUrl, apiKey, FOREIGN_FE_AUTHOR_HASH)
+	const [feedResponse] = await Promise.all([
+		waitForFeedLoad(page),
+		page.locator('#feedRefreshButton').click(),
+	])
+	await feedResponse.json()
+	const card = page.locator(`#feedList .post-card[data-author-entity="${FOREIGN_FE_AUTHOR_HASH}"]`).first()
+	await expect(card).toBeVisible({ timeout: 30_000 })
+	return card
+}
+
+/**
+ * 注入远程作者点赞，生成 viewer 收件箱通知。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {string} targetEntityHash - 被赞帖作者。
+ * @param {string} targetPostId - 被赞帖 id。
+ * @returns {Promise<void>}
+ */
+export async function injectForeignLike(baseUrl, apiKey, targetEntityHash, targetPostId) {
+	const key = encodeURIComponent(apiKey)
+	await followEntityViaApi(baseUrl, apiKey, FOREIGN_FE_AUTHOR_HASH)
+	await withApiRequest(async req => {
+		const res = await req.post(
+			`${baseUrl}/api/parts/shells:social/test/foreign-like?fount-apikey=${key}`,
+			{ data: { targetEntityHash, targetPostId } },
+		)
+		if (!res.ok()) throw new Error(`foreign-like failed: ${res.status()}`)
+	})
+}
+
+/**
+ * 通过 API 批量远程点赞以生成通知（用于通知分页烟测）。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {number} [count=41] - 通知卡片数量。
+ * @returns {Promise<void>}
+ */
+export async function seedNotificationsViaReplies(baseUrl, apiKey, count = 41) {
+	const viewerEntityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+	const key = encodeURIComponent(apiKey)
+	await withApiRequest(async req => {
+		for (let index = 0; index < count; index++) {
+			const parentRes = await req.post(
+				`${baseUrl}/api/parts/shells:social/posts?fount-apikey=${key}`,
+				{ data: { text: `notif-seed-parent-${index}-${Date.now()}`, visibility: 'public', locale: 'zh-CN' } },
+			)
+			if (!parentRes.ok()) throw new Error(`parent post failed: ${parentRes.status()}`)
+			const postId = postIdFromResponse(await parentRes.json())
+			await injectForeignLike(baseUrl, apiKey, viewerEntityHash, postId)
+		}
+	})
+}
+
+/**
+ * 直接写入 like 收件箱行（聚合烟测加速路径）。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {string} targetEntityHash - 被赞帖作者。
+ * @param {string} targetPostId - 被赞帖 id。
+ * @param {number} [count=2] - like 行数。
+ * @returns {Promise<void>}
+ */
+export async function seedInboxLikes(baseUrl, apiKey, targetEntityHash, targetPostId, count = 2) {
+	const key = encodeURIComponent(apiKey)
+	await withApiRequest(async req => {
+		const res = await req.post(
+			`${baseUrl}/api/parts/shells:social/test/inbox-likes?fount-apikey=${key}`,
+			{ data: { targetEntityHash, targetPostId, count } },
+		)
+		if (!res.ok()) throw new Error(`inbox-likes failed: ${res.status()}`)
+	})
+}
+
+/**
+ * 直接写入 mention 收件箱行（分页烟测加速路径）。
+ * @param {string} baseUrl - 测试根 URL。
+ * @param {string} apiKey - API 密钥。
+ * @param {number} [count=41] - 行数。
+ * @returns {Promise<void>}
+ */
+export async function seedInboxMentions(baseUrl, apiKey, count = 41) {
+	const key = encodeURIComponent(apiKey)
+	await withApiRequest(async req => {
+		const res = await req.post(
+			`${baseUrl}/api/parts/shells:social/test/inbox-mentions?fount-apikey=${key}`,
+			{ data: { count } },
+		)
+		if (!res.ok()) throw new Error(`inbox-mentions failed: ${res.status()}`)
+	})
+}

--- a/src/public/parts/shells/social/test/frontend/navigation.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/navigation.spec.mjs
@@ -1,0 +1,79 @@
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import { test, expect, openHome, expectPostInFeed } from './fixtures.mjs'
+
+test.describe('Social navigation', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('switches between main views', async ({ page }) => {
+		const views = [
+			{ name: 'explore', selector: '#exploreView' },
+			{ name: 'notifications', selector: '#notificationsView' },
+			{ name: 'saved', selector: '#savedView' },
+			{ name: 'drafts', selector: '#draftsView' },
+			{ name: 'profile', selector: '#profileView' },
+			{ name: 'feed', selector: '#feedView' },
+		]
+
+		for (const { name, selector } of views) {
+			await page.locator(`.side-nav .nav-btn[data-view="${name}"]`).click()
+			await expect(page.locator(selector)).toBeVisible()
+			await expect(page).toHaveURL(new RegExp(`#${name}$`))
+			if (name === 'feed')
+				await expect(page.locator('#composer')).toBeVisible()
+			else
+				await expect(page.locator('#composer')).toBeHidden()
+		}
+	})
+
+	test('refresh restores active nav tab from hash', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="explore"]').click()
+		await expect(page.locator('#exploreView')).toBeVisible()
+		await expect(page).toHaveURL(/#explore$/)
+		await page.reload()
+		await waitForSocialReady(page)
+		await expect(page.locator('#exploreView')).toBeVisible({ timeout: 60_000 })
+		await expect(page).toHaveURL(/#explore$/)
+	})
+
+	test('videos view opens fullscreen and shows empty state', async ({ page }) => {
+		const feedPromise = page.waitForResponse(res => {
+			if (res.request().method() !== 'GET' || res.status() !== 200) return false
+			return new URL(res.url()).pathname === '/api/parts/shells:social/videos/feed'
+		}, { timeout: 60_000 })
+		await page.locator('.side-nav .nav-btn[data-view="videos"]').click()
+		await feedPromise
+		await expect(page.locator('#videosView')).toBeVisible()
+		await expect(page.locator('#composer')).toBeHidden()
+		await expect(page.locator('#videosView .empty-state--video')).toBeVisible()
+		await expect(page.locator('#videosView .empty-state-title')).toHaveText('暂无短视频')
+		await page.locator('#videosView [data-video-compose]').click()
+		await expect(page.locator('#feedView')).toBeVisible()
+		await expect(page.locator('#composer')).toBeVisible()
+	})
+
+	test('feed search filters posts and clear restores feed', async ({ page, publishPost }) => {
+		const tag = `navsrch${Date.now()}`
+		const { postId } = await publishPost(`nav-filter #${tag}`)
+		await expect(page.locator(`#feedView [data-post-id="${postId}"]`).first()).toBeVisible({ timeout: 60_000 })
+
+		const input = page.locator('#feedSearchInput')
+		await input.fill(`#${tag}`)
+		await input.press('Enter')
+		await expect(page.locator('#searchView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#feedSearchClearButton')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#searchViewResults [data-post-id="${postId}"]`).first()).toBeVisible({ timeout: 30_000 })
+
+		await input.fill(`__no-match-${Date.now()}__`)
+		await input.press('Enter')
+		await expect(page.locator(`#searchViewResults [data-post-id="${postId}"]`)).toHaveCount(0, { timeout: 30_000 })
+
+		await page.locator('#feedSearchClearButton').click()
+		await expect(input).toHaveValue('')
+		await expect(page.locator('#feedView')).toBeVisible({ timeout: 20_000 })
+		await expectPostInFeed(page, postId)
+	})
+}
+)

--- a/src/public/parts/shells/social/test/frontend/phases.mjs
+++ b/src/public/parts/shells/social/test/frontend/phases.mjs
@@ -1,0 +1,28 @@
+/**
+ * Social 前端测试阶段定义（供 Deno 测试框架和 Playwright Node 配置双重读取）。
+ * 此文件不得引用任何 npm 包，以保持 Deno / Node 双重可导入性。
+ */
+
+/**
+ * @type {Array<{ name: string, testMatch: string[] }>}
+ */
+export const phases = [
+	{ name: 'smoke', testMatch: ['smoke.spec.mjs'] },
+	{
+		name: 'actions',
+		testMatch: ['postActions.spec.mjs', 'replies.spec.mjs', 'postDetail.spec.mjs'],
+	},
+	{
+		// composer 含 Chat 群关联，单独阶段避免拖垮后续 deepLink/feed 节点
+		name: 'composer',
+		testMatch: ['composer.spec.mjs'],
+	},
+	{
+		name: 'core',
+		testMatch: ['deepLink.spec.mjs', 'feed.spec.mjs', 'navigation.spec.mjs', 'profile.spec.mjs', 'saved.spec.mjs', 'drafts.spec.mjs', 'videos.spec.mjs'],
+	},
+	{
+		name: 'tail',
+		testMatch: ['explore_notifications.spec.mjs'],
+	},
+]

--- a/src/public/parts/shells/social/test/frontend/playwright.config.mjs
+++ b/src/public/parts/shells/social/test/frontend/playwright.config.mjs
@@ -1,0 +1,8 @@
+import { createPhasedPlaywrightConfig } from 'fount/scripts/test/playwright/config.mjs'
+
+import { phases } from './phases.mjs'
+
+/**
+ * Social 前端 Playwright 多阶段配置。
+ */
+export default await createPhasedPlaywrightConfig(import.meta.url, phases)

--- a/src/public/parts/shells/social/test/frontend/postActions.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/postActions.spec.mjs
@@ -1,0 +1,109 @@
+import { test, expect, openHome, findPostCard, openPostMoreMenu, findForeignAuthorPostCard, FOREIGN_FE_AUTHOR_HASH } from './fixtures.mjs'
+
+test.describe('Social post actions', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('dm from post card navigates to chat', async ({ page, baseUrl, apiKey }) => {
+		const card = await findForeignAuthorPostCard(page, baseUrl, apiKey)
+		await openPostMoreMenu(card)
+		await card.locator(`[data-dm="${FOREIGN_FE_AUTHOR_HASH}"]`).click()
+		await expect(page).toHaveURL(
+			new RegExp(`/parts/shells:chat/hub/\\?contact=${FOREIGN_FE_AUTHOR_HASH}`),
+			{ timeout: 20_000 },
+		)
+	})
+
+	test('like and unlike toggle', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`like-toggle ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		const likeButton = card.locator('.like-btn')
+		await likeButton.click()
+		await expect(likeButton).toHaveAttribute('data-liked', '1', { timeout: 20_000 })
+		await likeButton.click()
+		await expect(likeButton).toHaveAttribute('data-liked', '0', { timeout: 20_000 })
+	})
+
+	test('submit repost appears in feed', async ({ page, publishPost }) => {
+		const { postId: originalId } = await publishPost(`repost-src ${Date.now()}`)
+		const card = await findPostCard(page, originalId, { allowProfileFallback: true })
+		const repostKey = await card.locator('[data-repost]').getAttribute('data-repost')
+		const panel = card.locator(`[data-repost-for="${repostKey}"]`)
+		await card.locator('[data-repost]').click()
+		const comment = `repost-comment ${Date.now()}`
+		await panel.locator('textarea').fill(comment)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/posts/')
+				&& res.url().includes('/repost')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			panel.locator('[data-submit-repost]').click(),
+		])
+		await expect(panel).toHaveClass(/hidden/)
+		await page.locator('#feedRefreshButton').click()
+		await expect(page.locator('#feedList .repost-comment', { hasText: comment })).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('translate appends translated text block', async ({ page, publishPost }) => {
+		const source = `translate-me-${Date.now()}`
+		const { postId } = await publishPost(source)
+		const card = await findPostCard(page, postId)
+		await openPostMoreMenu(card)
+		const translateRes = page.waitForResponse(res =>
+			res.url().includes('/api/parts/shells:social/translate')
+			&& res.request().method() === 'POST'
+			&& res.status() === 200,
+		)
+		await card.locator('[data-translate]').click()
+		const res = await translateRes
+		const body = await res.json()
+		if (body.translated && body.translated !== source)
+			await expect(card.locator('.translation-block')).toContainText(body.translated, { timeout: 20_000 })
+		else
+			await expect(card.locator('.translation-block')).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('save modal confirm bookmarks post', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`modal-save ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await card.locator('[data-save]').click()
+		await expect(page.locator('#saveModal')).toBeVisible({ timeout: 20_000 })
+		await page.locator('#saveConfirmButton').click()
+		await expect(page.locator('#saveModal')).toBeHidden({ timeout: 10_000 })
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		await expect(page.locator(`#savedView a[href*="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('hide removes foreign author posts optimistically', async ({ page, baseUrl, apiKey }) => {
+		const card = await findForeignAuthorPostCard(page, baseUrl, apiKey)
+		await openPostMoreMenu(card)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/relationships/hide')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			card.locator('[data-hide]').click(),
+		])
+		await expect(page.locator(`#feedList .post-card[data-author-entity="${FOREIGN_FE_AUTHOR_HASH}"]`))
+			.toHaveCount(0, { timeout: 10_000 })
+	})
+
+	test('delete removes own post optimistically', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`delete-opt ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await openPostMoreMenu(card)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/posts')
+				&& res.request().method() === 'DELETE'
+				&& res.status() === 200,
+			),
+			card.locator('[data-delete]').click(),
+		])
+		await expect(page.locator(`#feedList [data-post-id="${postId}"]`)).toHaveCount(0, { timeout: 10_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/postDetail.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/postDetail.spec.mjs
@@ -1,0 +1,25 @@
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import { test, expect, openHome, findPostCard, fetchViewerEntityHash } from './fixtures.mjs'
+
+test.describe('Social post detail', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('opens post detail from time link and deep hash', async ({ page, baseUrl, publishPost, apiKey }) => {
+		const { postId } = await publishPost(`detail-target ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		await card.locator('.post-time-link').click()
+		await expect(page.locator('#postDetailView')).toBeVisible({ timeout: 30_000 })
+		await expect(page.locator(`#postDetailView [data-post-id="${postId}"]`)).toBeVisible()
+		await expect(page).toHaveURL(/#post;/)
+
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		await page.goto(`${baseUrl}/parts/shells:social/#post;${entityHash};${postId}`)
+		await waitForSocialReady(page)
+		await expect(page.locator('#postDetailView')).toBeVisible({ timeout: 30_000 })
+		await expect(page.locator(`#postDetailView [data-post-id="${postId}"]`)).toBeVisible()
+		await expect(page.locator('#postDetailView .post-detail-replies .reply-composer')).toBeVisible()
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/profile.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/profile.spec.mjs
@@ -1,0 +1,154 @@
+import { waitForSocialReady } from 'fount/scripts/test/playwright/ready.mjs'
+
+import {
+	test,
+	expect,
+	openHome,
+	postIdFromResponse,
+	fetchViewerEntityHash,
+	waitForPostMaterialized,
+	DUMMY_ENTITY_HASH,
+} from './fixtures.mjs'
+
+test.describe('Social profile', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('profile view shows own posts', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`profile-post ${Date.now()}`)
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await expect(page.locator('#profileView')).toBeVisible()
+		await expect(page.locator('#profileView .profile-header')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('#profileView #profileEntityCardHost .profile-popup')).toBeVisible()
+		await expect(page.locator('#profileView .profile-popup-banner.entity-profile-banner')).toBeVisible()
+		await expect(page.locator(`#profilePostsPanel [data-post-id="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('[data-profile-stat="following"]')).toBeVisible()
+		await expect(page.locator('[data-profile-stat="followers"]')).toBeVisible()
+		await expect(page.locator('[data-profile-tab="following"]')).toHaveCount(0)
+	})
+
+	test('profile likes tab shows liked posts', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`like-tab-src ${Date.now()}`)
+		const card = page.locator(`#feedList [data-post-id="${postId}"]`)
+		await expect(card).toBeVisible({ timeout: 30_000 })
+		await card.locator('[data-like]').click()
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await page.locator('[data-profile-tab="likes"]').click()
+		await expect(page.locator('#profileLikesPanel')).toBeVisible()
+		await expect(page.locator(`#profileLikesPanel [data-post-id="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('profile settings view saves hideFromDiscovery', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await expect(page.locator('[data-profile-settings]')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('[data-profile-edit]')).toBeVisible()
+		await page.locator('[data-profile-settings]').click()
+		await expect(page.locator('#settingsView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator('.side-nav .nav-btn[data-view="taste"]')).toHaveCount(0)
+		const protectedInput = page.locator('#exploreProtectedInput')
+		await expect(protectedInput).toBeVisible({ timeout: 10_000 })
+		const wasProtected = await protectedInput.isChecked()
+		const [metaResponse] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/profile/meta')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			protectedInput.setChecked(!wasProtected),
+		])
+		const metaJson = await metaResponse.json()
+		expect(metaJson).toHaveProperty('socialMeta')
+		expect(metaJson.socialMeta?.hideFromDiscovery).toBe(!wasProtected)
+	})
+
+	test('deep link opens profile with highlighted post', async ({ page, baseUrl, apiKey, publishPost }) => {
+		const { postJson, postId } = await publishPost(`deeplink ${Date.now()}`)
+		expect(postIdFromResponse(postJson)).toBe(postId)
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+		await Promise.all([
+			page.goto(`${baseUrl}/parts/shells:social/#profile;${entityHash};${postId}`),
+			page.waitForResponse(res =>
+				res.url().includes(`/api/parts/shells:social/profile/${entityHash}/posts`)
+				&& res.request().method() === 'GET'
+				&& res.status() === 200,
+			),
+		])
+		await waitForSocialReady(page)
+		await expect(page.locator('#profileView')).toBeVisible({ timeout: 30_000 })
+		const highlighted = page.locator(`#profileView [data-post-id="${postId}"].highlight-post`)
+		await expect(highlighted).toBeVisible({ timeout: 30_000 })
+		await expect(highlighted).toHaveClass(/highlight-post/)
+	})
+
+	test('follow and unfollow seeded target smoke', async ({ page, baseUrl }) => {
+		const dummy = DUMMY_ENTITY_HASH
+		await page.goto(`${baseUrl}/parts/shells:social/#profile;${dummy}`)
+		await waitForSocialReady(page)
+		const followButton = page.locator(`[data-follow="${dummy}"]`)
+		await expect(followButton).toBeVisible({ timeout: 20_000 })
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/relationships/follow')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			followButton.click(),
+		])
+		await expect(followButton).toHaveAttribute('data-is-following', '1', { timeout: 20_000 })
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await expect(page.locator('[data-profile-settings]')).toBeVisible({ timeout: 20_000 })
+		await page.locator('[data-profile-stat="following"]').click()
+		await expect(page.locator('#profileRelationshipList .following-link')).toContainText(dummy.slice(0, 8), { timeout: 20_000 })
+		await page.goto(`${baseUrl}/parts/shells:social/`)
+		await waitForSocialReady(page)
+		await page.evaluate(eh => { window.location.hash = `profile;${eh}` }, dummy)
+		const unfollowButton = page.locator(`[data-follow="${dummy}"]`)
+		await expect(unfollowButton).toBeVisible({ timeout: 30_000 })
+		await expect(unfollowButton).toHaveAttribute('data-is-following', '1', { timeout: 10_000 })
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/relationships/follow')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			{ timeout: 60_000 }),
+			unfollowButton.click(),
+		])
+		await expect(unfollowButton).toHaveAttribute('data-is-following', '0', { timeout: 20_000 })
+	})
+
+	test('dm button navigates to chat contact link smoke', async ({ page, baseUrl }) => {
+		const dummy = DUMMY_ENTITY_HASH
+		await page.goto(`${baseUrl}/parts/shells:social/#profile;${dummy}`)
+		await waitForSocialReady(page)
+		await page.locator(`[data-dm="${dummy}"]`).click()
+		await expect(page).toHaveURL(
+			new RegExp(`/parts/shells:chat/hub/\\?contact=${dummy}`),
+			{ timeout: 20_000 },
+		)
+	})
+
+	test('blocklist shows blocked entity and unblocks smoke', async ({ page, baseUrl, apiKey }) => {
+		const dummy = DUMMY_ENTITY_HASH
+		const blockRes = await page.request.post(
+			`${baseUrl}/api/parts/shells:social/relationships/block?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash: dummy, block: true } },
+		)
+		expect(blockRes.ok()).toBe(true)
+		await page.locator('.side-nav .nav-btn[data-view="profile"]').click()
+		await expect(page.locator('[data-profile-settings]')).toBeVisible({ timeout: 20_000 })
+		await page.locator('[data-profile-settings]').click()
+		await expect(page.locator('#settingsView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#blocklistSection [data-unblock="${dummy}"]`)).toBeVisible({ timeout: 20_000 })
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/relationships/block')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			page.locator(`[data-unblock="${dummy}"]`).click(),
+		])
+		await expect(page.locator(`[data-unblock="${dummy}"]`)).toHaveCount(0, { timeout: 20_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/replies.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/replies.spec.mjs
@@ -1,0 +1,43 @@
+import { test, expect, openHome, findPostCard, submitReplyViaPanel } from './fixtures.mjs'
+
+test.describe('Social replies', () => {
+
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('replies panel loads and accepts a reply', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`reply-target ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		const repliesButton = card.locator('[data-replies]')
+		const actionKey = await repliesButton.getAttribute('data-replies')
+		await repliesButton.click()
+		// 同一 postId 可能在 feed 出现多张卡片；面板须限定在当前卡片内
+		const panel = card.locator(`[data-replies-for="${actionKey}"]`)
+		await expect(panel).not.toHaveClass(/hidden/)
+		const replyText = `reply-body ${Date.now()}`
+		await panel.locator('textarea').fill(replyText)
+		await submitReplyViaPanel(page, panel)
+		await expect(card.locator(':scope > .post-actions > [data-replies] .action-count')).toHaveText('1', { timeout: 30_000 })
+		const replyRow = panel.locator('.reply').first()
+		await expect(replyRow.locator('.author-avatar, .reply-avatar, .hash-avatar')).toBeVisible()
+		await expect(replyRow.locator('[data-like]')).toBeVisible()
+		await expect(replyRow.locator('[data-dislike]')).toBeVisible()
+		await expect(replyRow.locator('[data-repost]')).toBeVisible()
+		await expect(replyRow.locator('[data-save]')).toBeVisible()
+		await expect(replyRow.locator('[data-share]')).toBeVisible()
+	})
+
+	test('replies panel toggles closed', async ({ page, publishPost }) => {
+		const { postId } = await publishPost(`reply-toggle ${Date.now()}`)
+		const card = await findPostCard(page, postId)
+		const repliesButton = card.locator('[data-replies]')
+		const actionKey = await repliesButton.getAttribute('data-replies')
+		// 同一 postId 可能在 feed 出现多张卡片；面板须限定在当前卡片内
+		const panel = card.locator(`[data-replies-for="${actionKey}"]`)
+		await repliesButton.click()
+		await expect(panel).not.toHaveClass(/hidden/)
+		await repliesButton.click()
+		await expect(panel).toHaveClass(/hidden/)
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/run.mjs
+++ b/src/public/parts/shells/social/test/frontend/run.mjs
@@ -1,0 +1,18 @@
+/**
+ * Social 前端 Playwright 测试 driver。
+ */
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { runShellFrontendTests } from 'fount/scripts/test/playwright/shell_frontend.mjs'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+
+process.exit(await runShellFrontendTests({
+	configPath: join(testDir, 'playwright.config.mjs'),
+	testUsername: 'social-fe-user',
+	apiKeyPrefix: 'fount-social-fe-key',
+	loadParts: ['shells/social', 'shells/chat'],
+	bootstrapPath: join(testDir, '../node_bootstrap.mjs'),
+}))

--- a/src/public/parts/shells/social/test/frontend/saved.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/saved.spec.mjs
@@ -1,0 +1,134 @@
+import { test, expect, openHome, expectPostInFeed, fetchViewerEntityHash } from './fixtures.mjs'
+
+/**
+ * 通过顶栏按钮 + prompt 对话框新建收藏文件夹。
+ * @param {import('@playwright/test').Page} page 页面
+ * @param {string} folderName 文件夹名
+ * @returns {Promise<string>} folderId
+ */
+async function createSavedFolder(page, folderName) {
+	await page.locator('#createFolderButton').click()
+	const promptDialog = page.locator('dialog.modal').last()
+	await expect(promptDialog).toBeVisible({ timeout: 20_000 })
+	await promptDialog.locator('#promptInput').fill(folderName)
+	const [folderResponse] = await Promise.all([
+		page.waitForResponse(res =>
+			res.url().includes('/api/parts/shells:social/saved-posts/folders')
+			&& res.request().method() === 'POST',
+		{ timeout: 60_000 },
+		),
+		promptDialog.locator('[data-dialog-resolve]').click(),
+	])
+	expect(folderResponse.ok()).toBe(true)
+	const folderJson = await folderResponse.json()
+	const folderId = Object.keys(folderJson.folders || {}).find(
+		id => folderJson.folders[id]?.name === folderName,
+	)
+	expect(folderId).toBeTruthy()
+	return /** @type {string} */ folderId
+}
+
+test.describe('Social saved posts', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+	})
+
+	test('saved view lists bookmarked post', async ({ page, baseUrl, apiKey, publishPost }) => {
+		const { postId } = await publishPost(`saved-item ${Date.now()}`)
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const saveRes = await page.request.post(
+			`${baseUrl}/api/parts/shells:social/saved-posts/add?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash, postId } },
+		)
+		expect(saveRes.ok()).toBe(true)
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		await expect(page.locator('#savedView')).toBeVisible()
+		await expect(page.locator(`#savedPanel a[href*="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('create folder and save into it', async ({ page, baseUrl, apiKey, publishPost }) => {
+		const { postId } = await publishPost(`folder-save ${Date.now()}`)
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		await expectPostInFeed(page, postId)
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		const folderName = `folder-${Date.now()}`
+		const folderId = await createSavedFolder(page, folderName)
+		await expect(page.locator('#savedPanel').filter({ hasText: folderName })).toBeVisible()
+		const saveRes = await page.request.post(
+			`${baseUrl}/api/parts/shells:social/saved-posts/add?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash, postId, folderId } },
+		)
+		expect(saveRes.ok()).toBe(true)
+		await page.locator('.side-nav .nav-btn[data-view="feed"]').click()
+		const [savedLoad] = await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/saved-posts')
+				&& res.request().method() === 'GET'
+				&& res.status() === 200,
+			),
+			page.locator('.side-nav .nav-btn[data-view="saved"]').click(),
+		])
+		expect(savedLoad.ok()).toBe(true)
+		await expect(page.locator(`#savedPanel a[href*="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('saved link opens profile with post', async ({ page, baseUrl, apiKey, publishPost }) => {
+		const { postId } = await publishPost(`saved-link ${Date.now()}`)
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const saveRes = await page.request.post(
+			`${baseUrl}/api/parts/shells:social/saved-posts/add?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash, postId } },
+		)
+		expect(saveRes.ok()).toBe(true)
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		await page.locator(`#savedPanel a[href*="${postId}"]`).click()
+		await expect(page.locator('#profileView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#profileView [data-post-id="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('remove saved post from unfiled list', async ({ page, baseUrl, apiKey, publishPost }) => {
+		const { postId } = await publishPost(`remove-saved ${Date.now()}`)
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const saveRes = await page.request.post(
+			`${baseUrl}/api/parts/shells:social/saved-posts/add?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: { entityHash, postId } },
+		)
+		expect(saveRes.ok()).toBe(true)
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		await expect(page.locator(`#savedPanel a[href*="${postId}"]`)).toBeVisible({ timeout: 20_000 })
+		await page.locator(`#savedPanel .saved-row:has(a[href*="${postId}"]) [data-remove-saved]`).click()
+		await expect(page.locator(`#savedPanel a[href*="${postId}"]`)).toHaveCount(0, { timeout: 20_000 })
+	})
+
+	test('rename and delete saved folder', async ({ page }) => {
+		await page.locator('.side-nav .nav-btn[data-view="saved"]').click()
+		const folderName = `rename-folder-${Date.now()}`
+		const folderId = await createSavedFolder(page, folderName)
+		const renamed = `renamed-${Date.now()}`
+		await page.locator(`[data-rename-folder="${folderId}"]`).click()
+		const promptDialog = page.locator('dialog.modal').last()
+		await expect(promptDialog).toBeVisible({ timeout: 20_000 })
+		await promptDialog.locator('#promptInput').fill(renamed)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/saved-posts/folders/rename')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			promptDialog.locator('[data-dialog-resolve]').click(),
+		])
+		await expect(page.locator('#savedPanel').filter({ hasText: renamed })).toBeVisible({ timeout: 20_000 })
+		await page.locator(`[data-delete-folder="${folderId}"]`).click()
+		const confirmDialog = page.locator('dialog.modal').last()
+		await expect(confirmDialog).toBeVisible({ timeout: 20_000 })
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes('/api/parts/shells:social/saved-posts/folders/delete')
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			confirmDialog.locator('[data-dialog-resolve]').click(),
+		])
+		await expect(page.locator('#savedPanel').filter({ hasText: renamed })).toHaveCount(0, { timeout: 20_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/seedConstants.mjs
+++ b/src/public/parts/shells/social/test/frontend/seedConstants.mjs
@@ -1,0 +1,12 @@
+/** Playwright 可读常量（无 npm: 导入，供 Node 加载 fixtures）。 */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+
+/** bootstrap / live 烟测共用的可发现占位 entityHash。 */
+export const SEEDED_TEST_TARGET_HASH = placeholderEntityHash('a')
+
+/** 联邦 ingest 的远程作者 entityHash（与 seedForeignFeedAuthor.mjs 一致）。 */
+export const FOREIGN_FE_AUTHOR_HASH =
+	'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbd4e02f43853c45ca08a9ca2cbe399445861f4927d10b0861cce33c6f2fd4645'
+
+/** bootstrap 写入的公开帖正文前缀（Playwright 定位用）。 */
+export const FOREIGN_FE_POST_MARKER = 'fe-foreign-governance-post'

--- a/src/public/parts/shells/social/test/frontend/smoke.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/smoke.spec.mjs
@@ -1,0 +1,8 @@
+import { test, expect, openHome } from './fixtures.mjs'
+
+test.describe('Social shell smoke', () => {
+	test('hub shell loads feed view', async ({ page, baseUrl }) => {
+		await openHome(page, baseUrl)
+		await expect(page.locator('#feedView')).toBeVisible()
+	})
+})

--- a/src/public/parts/shells/social/test/frontend/videos.spec.mjs
+++ b/src/public/parts/shells/social/test/frontend/videos.spec.mjs
@@ -1,0 +1,279 @@
+import { withApiRequest } from 'fount/scripts/test/playwright/api.mjs'
+
+import {
+	test,
+	expect,
+	openHome,
+	postIdFromResponse,
+	waitForPostMaterialized,
+	fetchViewerEntityHash,
+	submitReplyViaPanel,
+	installVideoFixtureRoute,
+	videoFixtureUrl,
+} from './fixtures.mjs'
+
+/**
+ * 经 Social HTTP API 发帖。
+ * @param {string} baseUrl 根 URL
+ * @param {string} apiKey API 密钥
+ * @param {object} body 发帖体
+ * @returns {Promise<string>} postId
+ */
+async function publishViaApi(baseUrl, apiKey, body) {
+	return withApiRequest(async req => {
+		const res = await req.post(
+			`${baseUrl}/api/parts/shells:social/posts?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ data: body },
+		)
+		expect(res.ok(), `publish failed: ${res.status()}`).toBeTruthy()
+		return postIdFromResponse(await res.json())
+	})
+}
+
+/**
+ * 短视频帖 body（本地 fixture mp4）。
+ * @param {string} baseUrl 根 URL
+ * @param {string} text 正文
+ * @returns {object} 发帖体
+ */
+function videoPostBody(baseUrl, text) {
+	return {
+		text,
+		visibility: 'public',
+		locale: 'zh-CN',
+		mediaRefs: [{
+			kind: 'video',
+			url: videoFixtureUrl(baseUrl),
+		}],
+	}
+}
+
+/**
+ * 打开短视频视图并定位指定 slide。
+ * @param {import('@playwright/test').Page} page 页面
+ * @param {string} postId 帖子 id
+ * @returns {Promise<import('@playwright/test').Locator>} slide 定位器
+ */
+async function openVideoSlide(page, postId) {
+	const feedPromise = page.waitForResponse(res => {
+		if (res.request().method() !== 'GET' || res.status() !== 200) return false
+		return new URL(res.url()).pathname === '/api/parts/shells:social/videos/feed'
+	}, { timeout: 60_000 })
+	await page.locator('.side-nav .nav-btn[data-view="videos"]').click()
+	await feedPromise
+	const slide = page.locator(`#videosView .video-slide[data-post-id="${postId}"]`).first()
+	await expect(slide).toBeVisible({ timeout: 30_000 })
+	return slide
+}
+
+test.describe('Social short videos', () => {
+	test.beforeEach(async ({ page, baseUrl }) => {
+		await installVideoFixtureRoute(page)
+		await openHome(page, baseUrl)
+		await page.evaluate(() => localStorage.removeItem('fount.social.video.muted'))
+	})
+
+	test('renders own video post in vertical snap feed', async ({ page, baseUrl, apiKey }) => {
+		const text = `short-video ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+
+		const slide = await openVideoSlide(page, postId)
+		await expect(page.locator(`#videosView .video-slide[data-post-id="${postId}"]`)).toHaveCount(1)
+		await expect(slide.locator('.video-caption')).toContainText(text)
+		await expect(slide.locator('video.video-player')).toHaveAttribute('src', /\/__fount_test__\/tiny\.mp4$/)
+		await expect(slide.locator('.video-author')).not.toHaveText('')
+		await expect(slide.locator('.video-actions')).toBeVisible()
+		await expect(slide.locator('.video-share-btn')).toBeVisible()
+	})
+
+	test('empty replies panel can be closed', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-replies-close ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+
+		const slide = await openVideoSlide(page, postId)
+		const panel = slide.locator('[data-replies-panel]')
+		await slide.locator('.video-comment-btn').click()
+		await expect(panel).not.toHaveClass(/hidden/)
+		await expect(panel.locator('[data-close-replies]')).toBeVisible()
+		await expect(panel.locator('.reply-composer')).toBeVisible()
+
+		await panel.locator('[data-close-replies]').click()
+		await expect(panel).toHaveClass(/hidden/)
+
+		await slide.locator('.video-comment-btn').click()
+		await expect(panel).not.toHaveClass(/hidden/)
+		// 点视频中部空白区关闭（避开左上角返回钮）
+		const video = slide.locator('video.video-player')
+		const box = await video.boundingBox()
+		await video.click({
+			position: {
+				x: Math.max(80, (box?.width || 200) * 0.5),
+				y: Math.max(120, (box?.height || 400) * 0.55),
+			},
+		})
+		await expect(panel).toHaveClass(/hidden/)
+	})
+
+	test('share button copies link fallback', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-share ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+
+		const slide = await openVideoSlide(page, postId)
+		await page.evaluate(() => {
+			Object.defineProperty(navigator, 'share', { value: undefined, configurable: true })
+		})
+		await slide.locator('.video-share-btn').click()
+		await expect(slide.locator('.video-share-btn .action-count')).toHaveText('已复制', { timeout: 5_000 })
+	})
+
+	test('comment ticker shows existing replies', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-ticker ${Date.now()}`
+		const replyText = `ticker-reply ${Date.now()}`
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+		const replyId = await publishViaApi(baseUrl, apiKey, {
+			text: replyText,
+			replyTo: { entityHash, postId },
+			visibility: 'public',
+			locale: 'zh-CN',
+		})
+		await waitForPostMaterialized(baseUrl, apiKey, replyId)
+
+		const slide = await openVideoSlide(page, postId)
+		const ticker = slide.locator('[data-comment-ticker]')
+		await expect(ticker).not.toHaveClass(/hidden/, { timeout: 30_000 })
+		await expect(ticker.locator('.video-comment-ticker-item').first()).toContainText(replyText)
+	})
+
+	test('video replies panel accepts a reply while feed card exists', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-reply-send ${Date.now()}`
+		const replyText = `from-video ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+
+		// feed 里需有同帖卡片（含 data-replies-for）；发评必须落到当前 slide 面板而非 feed 空面板
+		await Promise.all([
+			page.waitForResponse(res => {
+				if (res.request().method() !== 'GET' || res.status() !== 200) return false
+				return new URL(res.url()).pathname === '/api/parts/shells:social/feed'
+			}, { timeout: 60_000 }),
+			page.locator('#feedRefreshButton').click(),
+		])
+		await expect(page.locator(`#feedList .post-card[data-post-id="${postId}"]`).first()).toBeVisible({ timeout: 30_000 })
+
+		const slide = await openVideoSlide(page, postId)
+		const panel = slide.locator('[data-replies-panel]')
+		await slide.locator('.video-comment-btn').click()
+		await expect(panel).not.toHaveClass(/hidden/)
+		await panel.locator('textarea').fill(replyText)
+		await submitReplyViaPanel(page, panel)
+		await expect(panel.locator('.reply')).toContainText(replyText, { timeout: 30_000 })
+		await expect(slide.locator('.video-comment-btn .action-count')).toHaveText('1')
+	})
+
+	test('mute preference persists after leaving videos view', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-mute-pref ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+
+		const slide = await openVideoSlide(page, postId)
+		const video = slide.locator('video.video-player')
+		await expect(video).toHaveJSProperty('muted', false)
+		await slide.locator('.video-mute-btn').click()
+		await expect(video).toHaveJSProperty('muted', true)
+		await expect.poll(() => page.evaluate(() => localStorage.getItem('fount.social.video.muted')))
+			.toBe('1')
+
+		await page.locator('#videosViewBackButton').click()
+		await expect(page.locator('#videosView')).toHaveClass(/hidden/)
+		const slideAgain = await openVideoSlide(page, postId)
+		await expect(slideAgain.locator('video.video-player')).toHaveJSProperty('muted', true)
+		await expect(slideAgain.locator('.video-mute-btn .icon')).toHaveClass(/icon-mute/)
+	})
+
+	test('comment ticker opens replies panel at that reply', async ({ page, baseUrl, apiKey }) => {
+		const text = `video-ticker-jump ${Date.now()}`
+		const replyA = `ticker-a ${Date.now()}`
+		const replyB = `ticker-b ${Date.now()}`
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+		await publishViaApi(baseUrl, apiKey, {
+			text: replyA,
+			replyTo: { entityHash, postId },
+			visibility: 'public',
+			locale: 'zh-CN',
+		})
+		const replyIdB = await publishViaApi(baseUrl, apiKey, {
+			text: replyB,
+			replyTo: { entityHash, postId },
+			visibility: 'public',
+			locale: 'zh-CN',
+		})
+		await waitForPostMaterialized(baseUrl, apiKey, replyIdB)
+
+		const slide = await openVideoSlide(page, postId)
+		const ticker = slide.locator('[data-comment-ticker]')
+		await expect(ticker).not.toHaveClass(/hidden/, { timeout: 30_000 })
+		await ticker.evaluate(el => {
+			el.querySelector('.video-comment-ticker-track')?.classList.remove('is-scrolling')
+		})
+		const target = ticker.locator(`.video-comment-ticker-item[data-reply-id="${replyIdB}"]`).first()
+		await expect(target).toBeVisible()
+		await target.click({ force: true })
+
+		const panel = slide.locator('[data-replies-panel]')
+		await expect(panel).not.toHaveClass(/hidden/)
+		const focused = panel.locator(`.reply[data-reply-id="${replyIdB}"]`)
+		await expect(focused).toHaveClass(/is-focused/)
+		await expect(focused).toContainText(replyB)
+		await expect(focused.locator('.hash-avatar, .author-avatar, .reply-avatar')).toBeVisible()
+	})
+
+	test('feed video is muted loop without controls and click opens videos view', async ({ page, baseUrl, apiKey }) => {
+		const text = `feed-video-click ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+		await page.locator('.side-nav .nav-btn[data-view="feed"]').click()
+		const card = page.locator(`#feedList [data-post-id="${postId}"]`)
+		await expect(card).toBeVisible({ timeout: 30_000 })
+		const video = card.locator('video.post-media-video')
+		await expect(video).toBeVisible()
+		await expect(video).toHaveAttribute('muted', '')
+		await expect(video).toHaveAttribute('loop', '')
+		await expect(video).not.toHaveAttribute('controls', /.*/)
+		await video.click()
+		await expect(page).toHaveURL(new RegExp(`#videos;${entityHash};${postId}`), { timeout: 20_000 })
+		await expect(page.locator('#videosView')).toBeVisible({ timeout: 20_000 })
+		await expect(page.locator(`#videosView .video-slide[data-post-id="${postId}"]`).first()).toBeVisible({ timeout: 30_000 })
+	})
+
+	test('post detail double-tap media likes', async ({ page, baseUrl, apiKey }) => {
+		const text = `detail-dbl-like ${Date.now()}`
+		const postId = await publishViaApi(baseUrl, apiKey, videoPostBody(baseUrl, text))
+		const entityHash = await fetchViewerEntityHash(baseUrl, apiKey)
+		await waitForPostMaterialized(baseUrl, apiKey, postId)
+		await page.goto(`${baseUrl}/parts/shells:social/#post;${entityHash};${postId}`)
+		const card = page.locator('#postDetailView .post-detail-card')
+		await expect(card).toBeVisible({ timeout: 30_000 })
+		const likeBtn = card.locator('[data-like]')
+		await expect(likeBtn).toHaveAttribute('data-liked', '0')
+		const media = card.locator('.post-media')
+		await media.dispatchEvent('pointerup')
+		await page.waitForTimeout(50)
+		await Promise.all([
+			page.waitForResponse(res =>
+				res.url().includes(`/api/parts/shells:social/posts/${entityHash}/${postId}/like`)
+				&& res.request().method() === 'POST'
+				&& res.status() === 200,
+			),
+			media.dispatchEvent('pointerup'),
+		])
+		await expect(likeBtn).toHaveAttribute('data-liked', '1', { timeout: 10_000 })
+	})
+})

--- a/src/public/parts/shells/social/test/harness.mjs
+++ b/src/public/parts/shells/social/test/harness.mjs
@@ -1,0 +1,81 @@
+/**
+ * Social 后端集成测试 harness：同进程共享 dataDir，每测试独立 username。
+ *
+ * 用 createTestSession() 惰性启动 server，避免模块加载时即 boot 多个实例。
+ */
+import { cp, mkdir } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { createLazySession } from 'fount/scripts/test/fixtures.mjs'
+import { createTestServerBoot, ensureSharedTestDataDir } from 'fount/scripts/test/node/boot.mjs'
+
+import { ensureSocialTestReady } from './afterInit.mjs'
+
+const fixturesRoot = join(dirname(fileURLToPath(import.meta.url)), 'fixtures')
+
+/**
+ * 创建 Social 集成测试 boot 句柄。
+ * @param {object} [options] harness 选项
+ * @param {string} [options.username] 测试用户名
+ * @param {(username: string) => Promise<void>} [options.afterInit] init 后钩子
+ * @returns {{ ensureServer: () => Promise<{ dataDir: string, username: string }>, dataDir: string, username: string }} 集成 boot 句柄
+ */
+export function createIntegrationBoot(options = {}) {
+	const username = options.username ?? 'social-test-user'
+	const dataDir = ensureSharedTestDataDir()
+	const afterInit = options.afterInit ?? ensureSocialTestReady
+	const ensureServer = createTestServerBoot({
+		username,
+		dataDir,
+		minP2pNode: true,
+		loadParts: ['shells/social'],
+		afterInit,
+	})
+	return { ensureServer, dataDir, username }
+}
+
+/**
+ * 将 `test/fixtures/chars/<name>` 复制到用户 chars 目录并解析 agent entityHash。
+ * @param {string} username 用户
+ * @param {string} charName fixture 目录名
+ * @param {object} [options] 选项
+ * @param {boolean} [options.ensureSocialReady] 是否 `ensureEntitySocialReady`
+ * @returns {Promise<string>} agent entityHash
+ */
+export async function seedAgentChar(username, charName, options = {}) {
+	const { getUserDictionary } = await import('fount/server/auth/index.mjs')
+	const { ensureLocalAgentEntityHash } = await import('fount/public/parts/shells/chat/src/entity/member.mjs')
+	const to = join(getUserDictionary(username), 'chars', charName)
+	await mkdir(to, { recursive: true })
+	await cp(join(fixturesRoot, 'chars', charName), to, { recursive: true })
+	const hash = await ensureLocalAgentEntityHash(username, charName)
+	if (options.ensureSocialReady) {
+		const { ensureEntitySocialReady } = await import('../src/lib/bootstrap.mjs')
+		await ensureEntitySocialReady(username, hash)
+	}
+	return hash
+}
+
+/**
+ * 启动 server 并解析 operator 会话。
+ * @param {{ ensureServer: () => Promise<unknown>, username: string }} boot 集成 boot 对象
+ * @returns {Promise<{ username: string, operator: string }>} operator 会话
+ */
+export async function resolveTestOperator(boot) {
+	await boot.ensureServer()
+	const { resolveOperatorEntityHashForUser } = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+	const operator = await resolveOperatorEntityHashForUser(boot.username)
+	if (!operator) throw new Error('operator entityHash missing')
+	return { username: boot.username, operator }
+}
+
+/**
+ * 创建惰性 operator 会话启动器。
+ * @param {object} [options] createIntegrationBoot 选项
+ * @returns {() => Promise<{ username: string, operator: string }>} 惰性 operator 会话启动器
+ */
+export function createTestSession(options = {}) {
+	const boot = createIntegrationBoot(options)
+	return createLazySession(() => resolveTestOperator(boot))
+}

--- a/src/public/parts/shells/social/test/integration/drafts.test.mjs
+++ b/src/public/parts/shells/social/test/integration/drafts.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * 草稿箱 CRUD 集成测试。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+Deno.test('composer drafts upsert list get delete', async () => {
+	const { username } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+
+	const created = await client.drafts.upsert({ text: 'draft-hello', visibility: 'public' })
+	assert(created.draftId)
+	assertEquals(created.preview, 'draft-hello')
+	assertEquals(created.body.text, 'draft-hello')
+
+	const listed = await client.drafts.list()
+	assert(listed.drafts.some(row => row.draftId === created.draftId))
+
+	const updated = await client.drafts.upsert({
+		draftId: created.draftId,
+		text: 'draft-updated',
+		visibility: 'followers',
+	})
+	assertEquals(updated.draftId, created.draftId)
+	assertEquals(updated.body.text, 'draft-updated')
+	assertEquals(updated.body.visibility, 'followers')
+
+	const got = await client.drafts.get(created.draftId)
+	assertEquals(got.body.text, 'draft-updated')
+
+	const afterDelete = await client.drafts.delete(created.draftId)
+	assert(!afterDelete.drafts.some(row => row.draftId === created.draftId))
+})

--- a/src/public/parts/shells/social/test/integration/entity_parity.test.mjs
+++ b/src/public/parts/shells/social/test/integration/entity_parity.test.mjs
@@ -1,0 +1,225 @@
+/**
+ * 实体平权：agent 经 SocialClient 的 feed / notifications 与 operator HTTP 读模型隔离；follower 索引 / OnMessage。
+ */
+/* global Deno */
+import { Buffer } from 'node:buffer'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { socialOnMessageProbe } from '../fixtures/probes/socialOnMessageProbe.mjs'
+import { createTestSession, seedAgentChar } from '../harness.mjs'
+
+const PROBE_CHAR = 'social_on_message_probe'
+const AUTHOR_CHAR = 'mention_getreply_agent'
+
+const getSession = createTestSession()
+const append = await import('../../src/timeline/append.mjs')
+const following = await import('../../src/following.mjs')
+const followerIndex = await import('../../src/federation/follower/index.mjs')
+const dispatch = await import('../../src/dispatch.mjs')
+
+/**
+ * @param {string} username replica
+ * @param {string} charName fixture 目录名
+ * @returns {Promise<string>} agent entityHash
+ */
+const seedReadyAgent = (username, charName) => seedAgentChar(username, charName, { ensureSocialReady: true })
+
+Deno.test('agent following feeds home feed; operator feed excludes agent-only follow', async () => {
+	const { username } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const authorHash = await seedReadyAgent(username, AUTHOR_CHAR)
+	await following.setFollow(username, agentHash, authorHash, true)
+
+	const authorPost = await append.commitTimelineEvent(username, authorHash, {
+		type: 'post',
+		content: { text: 'agent feed parity post', visibility: 'public' },
+	}, { fanout: false })
+
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentClient = await getSocialClient(username, agentHash)
+	const operatorClient = await getSocialClient(username)
+	const agentFeed = await agentClient.feed({ limit: 50 })
+	const operatorFeed = await operatorClient.feed({ limit: 50 })
+
+	assert(agentFeed.items.some(item =>
+		item.entityHash === authorHash && item.postId === authorPost.id),
+	'agent feed should include followed author post')
+	assert(!operatorFeed.items.some(item =>
+		item.entityHash === authorHash && item.postId === authorPost.id),
+	'operator feed should not include post only followed by agent')
+})
+
+Deno.test('buildNotifications reads agent entity inbox via SocialClient', async () => {
+	const { username, operator } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: `mention agent @[entity:${agentHash}]`, visibility: 'public' },
+	}, { fanout: false })
+
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentPage = await (await getSocialClient(username, agentHash)).notifications({ limit: 50 })
+	const operatorPage = await (await getSocialClient(username)).notifications({ limit: 50 })
+
+	assertEquals(agentPage.viewerEntityHash, agentHash)
+	assert(agentPage.notifications.some(row => row.type === 'mention'), 'agent inbox has mention')
+	assertEquals(operatorPage.viewerEntityHash, operator)
+	assert(!operatorPage.notifications.some(row =>
+		row.type === 'mention' && row.postId && agentPage.notifications.some(a => a.postId === row.postId)),
+	'operator inbox should not include agent-only mention')
+})
+
+Deno.test('agent follow projects entity-granular follower index', async () => {
+	const { username, operator } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	await following.setFollow(username, agentHash, operator, true)
+
+	const followers = await followerIndex.listLocalFollowersOf(operator)
+	assert(followers.some(row =>
+		row.replicaUsername === username && row.entityHash === agentHash),
+	'follower index records agent entity not just replica username')
+
+	const known = await followerIndex.listKnownFollowersOf(operator)
+	assert(known.some(row => row.entityHash === agentHash), 'known followers include agent')
+
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+	const profile = await client.profile(operator)
+	assert(profile.followerCount >= 1, 'profile reports followerCount')
+	const list = await client.profileFollowers(operator)
+	assert(list.followers.some(row => row.entityHash === agentHash), 'followers API lists agent')
+})
+
+Deno.test('operator SocialClient may delete owned agent post', async () => {
+	const { username } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentClient = await getSocialClient(username, agentHash)
+	const post = await agentClient.post({ text: 'agent post owner may delete', visibility: 'public' })
+	const operatorClient = await getSocialClient(username)
+	const deleted = await (await operatorClient.post(agentHash, post.postId)).delete()
+	assertEquals(deleted.type, 'post_delete')
+	assertEquals(deleted.content.targetPostId, post.postId)
+	const view = await append.readTimelineEvents(username, agentHash)
+	assert(view.some(row => row.type === 'post_delete' && row.content?.targetPostId === post.postId))
+	const { getOperatorSecretKey } = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+	const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+	const ownerSender = pubKeyHash(publicKeyFromSeed(
+		new Uint8Array(Buffer.from(await getOperatorSecretKey(username), 'hex')),
+	))
+	const deleteRow = view.find(row => row.type === 'post_delete' && row.content?.targetPostId === post.postId)
+	assertEquals(deleteRow.sender, ownerSender)
+})
+
+Deno.test('operator SocialClient may edit owned agent post', async () => {
+	const { username } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentClient = await getSocialClient(username, agentHash)
+	const post = await agentClient.post({ text: 'agent post owner may edit', visibility: 'public' })
+	const operatorClient = await getSocialClient(username)
+	const edited = await (await operatorClient.post(agentHash, post.postId)).edit({ text: 'edited by owner' })
+	assertEquals(edited.type, 'post_edit')
+	assertEquals(edited.content.targetPostId, post.postId)
+	assertEquals(edited.content.text, 'edited by owner')
+	const view = await append.readTimelineEvents(username, agentHash)
+	assert(view.some(row => row.type === 'post_edit' && row.content?.targetPostId === post.postId))
+})
+
+Deno.test('setEntityOwner lets declared master manage human posts; operator lookup survives', async () => {
+	const { username, operator } = await getSession()
+	const masterHash = await seedReadyAgent(username, AUTHOR_CHAR)
+	const {
+		setEntityOwner,
+		resolveOperatorEntityHashForUser,
+		loadEntityIdentity,
+	} = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+	await setEntityOwner(username, operator, masterHash)
+	assertEquals(await resolveOperatorEntityHashForUser(username), operator)
+	assertEquals((await loadEntityIdentity(username, operator)).ownerEntityHash, masterHash)
+
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const humanClient = await getSocialClient(username)
+	const post = await humanClient.post({ text: 'human post owned by agent', visibility: 'public' })
+	const masterClient = await getSocialClient(username, masterHash)
+	const edited = await (await masterClient.post(operator, post.postId)).edit({ text: 'master edit' })
+	assertEquals(edited.type, 'post_edit')
+	const deleted = await (await masterClient.post(operator, post.postId)).delete()
+	assertEquals(deleted.type, 'post_delete')
+
+	await setEntityOwner(username, operator, null)
+	assertEquals(await resolveOperatorEntityHashForUser(username), operator)
+	assertEquals((await loadEntityIdentity(username, operator)).ownerEntityHash, null)
+})
+
+Deno.test('followed author post triggers agent OnMessage via timeline dispatch', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	socialOnMessageProbe.reset()
+	socialOnMessageProbe.returnValue = false
+	const { username } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const authorHash = await seedReadyAgent(username, AUTHOR_CHAR)
+	await following.setFollow(username, agentHash, authorHash, true)
+
+	await append.commitTimelineEvent(username, authorHash, {
+		type: 'post',
+		content: { text: 'followed author new post', visibility: 'public' },
+	}, { fanout: false })
+
+	const hit = socialOnMessageProbe.events.find(row => row.viewerEntityHash === agentHash)
+	assert(hit, 'agent OnMessage invoked for followed author post')
+	assertEquals(hit.authorEntityHash, authorHash)
+})
+
+Deno.test('rebuildFollowerIndex restores agent follows', async () => {
+	const { username, operator } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	await following.setFollow(username, agentHash, operator, true)
+
+	await followerIndex.rebuildFollowerIndex()
+	const followers = await followerIndex.listLocalFollowersOf(operator)
+	assert(followers.some(row =>
+		row.replicaUsername === username && row.entityHash === agentHash))
+})
+
+Deno.test('agent saved posts CRUD+search isolated from operator', async () => {
+	const { username, operator } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentClient = await getSocialClient(username, agentHash)
+	const operatorClient = await getSocialClient(username)
+
+	const post = await agentClient.post({ text: 'agent-saved-only-post', visibility: 'public' })
+	await agentClient.saved.add({ entityHash: post.entityHash, postId: post.postId })
+	const agentHit = await agentClient.saved.search('agent-saved-only')
+	assert(agentHit.posts.some(row => row.postId === post.postId), 'agent can search own saved posts')
+
+	const operatorList = await operatorClient.saved.list()
+	assert(!operatorList.unfiled.some(row => row.postId === post.postId), 'operator unfiled excludes agent saves')
+	for (const folder of Object.values(operatorList.folders))
+		assert(!folder.posts.some(row => row.postId === post.postId), 'operator folders exclude agent saves')
+	const operatorHit = await operatorClient.saved.search('agent-saved-only')
+	assertEquals(operatorHit.posts.length, 0)
+
+	await operatorClient.saved.add({ entityHash: operator, postId: post.postId })
+	assert((await operatorClient.saved.list()).unfiled.some(row => row.postId === post.postId))
+	assertEquals((await agentClient.saved.search('agent-saved-only')).posts.length, 1)
+})
+
+Deno.test('agent drafts isolated from operator', async () => {
+	const { username } = await getSession()
+	const agentHash = await seedReadyAgent(username, PROBE_CHAR)
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const agentClient = await getSocialClient(username, agentHash)
+	const operatorClient = await getSocialClient(username)
+
+	const agentDraft = await agentClient.drafts.upsert({ text: 'agent-only-draft', visibility: 'public' })
+	assert((await agentClient.drafts.list()).drafts.some(row => row.draftId === agentDraft.draftId))
+	assert(!(await operatorClient.drafts.list()).drafts.some(row => row.draftId === agentDraft.draftId))
+
+	const operatorDraft = await operatorClient.drafts.upsert({ text: 'operator-only-draft', visibility: 'public' })
+	assert((await operatorClient.drafts.list()).drafts.some(row => row.draftId === operatorDraft.draftId))
+	assert(!(await agentClient.drafts.list()).drafts.some(row => row.draftId === operatorDraft.draftId))
+})

--- a/src/public/parts/shells/social/test/integration/federation_rpc.test.mjs
+++ b/src/public/parts/shells/social/test/integration/federation_rpc.test.mjs
@@ -1,0 +1,237 @@
+/**
+ * social_rpc / 联邦导出过滤 / 探索 / feed 可见性。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+
+const append = await import('../../src/timeline/append.mjs')
+const sync = await import('../../src/timeline/sync.mjs')
+const fedExport = await import('../../src/timeline/federationExport.mjs')
+const discoverRpc = await import('../../src/discover/rpc.mjs')
+const discoverLocal = await import('../../src/discover/local.mjs')
+const feed = await import('../../src/feed/home.mjs')
+const following = await import('../../src/following.mjs')
+const socialMeta = await import('../../src/socialMeta.mjs')
+
+const TARGET = placeholderEntityHash('a')
+
+/**
+ * 发布一条 operator 帖子（不 fanout）。
+ * @param {string} username - 测试用户名
+ * @param {string} operator - operator 实体哈希
+ * @param {string} text - 帖子正文
+ * @param {string} [visibility='public'] - 可见性
+ * @returns {Promise<object>} 已提交事件
+ */
+async function postAs(username, operator, text, visibility = 'public') {
+	return append.commitTimelineEvent(username, operator, {
+		type: 'post', content: { text, visibility, locale: 'zh-CN' },
+	}, { fanout: false })
+}
+
+Deno.test('handleSocialRpc: unknown rpc type returns null', async () => {
+	const { username } = await getSession()
+	assertEquals(await discoverRpc.handleSocialRpc(username, { type: 'not_a_real_rpc' }), null)
+})
+
+Deno.test('handleSocialRpc: timeline_pull returns events for owner', async () => {
+	const { username, operator } = await getSession()
+	await postAs(username, operator, 'rpc pull post 1')
+	const resp = await discoverRpc.handleSocialRpc(username, {
+		type: 'social_timeline_pull_request', entityHash: operator, afterEventId: null,
+	}, { requesterNodeHash: null })
+	assertEquals(resp.type, 'social_timeline_pull_response')
+	assertEquals(resp.entityHash, operator.toLowerCase())
+	assert(resp.events.length >= 1)
+})
+
+Deno.test('federation export: private event types never leak', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'follow', content: { targetEntityHash: TARGET, rep_edge: 1 },
+	}, { fanout: false })
+	await append.commitTimelineEvent(username, operator, {
+		type: 'like', content: { targetEntityHash: TARGET, targetPostId: 'c'.repeat(64) },
+	}, { fanout: false })
+
+	const all = await append.readTimelineEvents(username, operator)
+	const exported = await fedExport.filterEventsForFederatedPull(username, operator, all, null)
+	const exportedTypes = new Set(exported.map(e => e.type))
+	for (const priv of ['follow', 'unfollow', 'follow_approve', 'file_share'])
+		assert(!exportedTypes.has(priv), `private type ${priv} must not be exported`)
+	// like 默认 publishReactions=true 时可导出；隐私关闭时不导出
+	assert(exportedTypes.has('like'), 'public reactions export when publishReactions defaults true')
+
+	const tasteStore = await import('../../src/taste/store.mjs')
+	await tasteStore.saveTaste(username, operator, {
+		...tasteStore.emptyTasteStore(),
+		privacy: { publishPreferences: true, publishReactions: false },
+	})
+	const exportedPrivate = await fedExport.filterEventsForFederatedPull(username, operator, all, null)
+	assert(!exportedPrivate.some(e => e.type === 'like'), 'like hidden when publishReactions=false')
+})
+
+Deno.test('federation export: followers-only post hidden from anonymous requester', async () => {
+	const { username, operator } = await getSession()
+	const pub = await postAs(username, operator, 'public visible', 'public')
+	const foll = await postAs(username, operator, 'followers only secret', 'followers')
+	const all = await append.readTimelineEvents(username, operator)
+	const exported = await fedExport.filterEventsForFederatedPull(username, operator, all, null)
+	const ids = new Set(exported.map(e => e.id))
+	assert(ids.has(pub.id), 'public post should be exported')
+	assert(!ids.has(foll.id), 'followers-only post should be hidden from anonymous')
+})
+
+Deno.test('federation export: social_meta hidden when timeline protected', async () => {
+	const { username, operator } = await getSession()
+	await socialMeta.updateSocialMeta(username, operator, { hideFromDiscovery: true })
+	const all = await append.readTimelineEvents(username, operator)
+	const exported = await fedExport.filterEventsForFederatedPull(username, operator, all, null)
+	assert(!exported.some(e => e.type === 'social_meta'), 'social_meta hidden for protected timeline to anon')
+	await socialMeta.updateSocialMeta(username, operator, { hideFromDiscovery: false })
+})
+
+Deno.test('buildFederatedTimelinePullResponse honors afterEventId cursor', async () => {
+	const { username, operator } = await getSession()
+	const all = await append.readTimelineEvents(username, operator)
+	const firstId = all[0].id
+	const fromStart = await sync.buildFederatedTimelinePullResponse(username, operator, null, null)
+	const afterFirst = await sync.buildFederatedTimelinePullResponse(username, operator, firstId, null)
+	assert(afterFirst.length < fromStart.length, 'cursor should reduce returned set')
+})
+
+Deno.test('discoverFollowGraph: protected foreign timeline hides following from non-owner', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const foreignOwner = encodeEntityHash('1'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, foreignOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: true, createdAt: 1 } },
+		{ type: 'follow', content: { targetEntityHash: TARGET, rep_edge: 1 } },
+	])
+
+	const hidden = await discoverLocal.discoverFollowGraph(username, foreignOwner, { requesterNodeHash: 'b'.repeat(64) })
+	assertEquals(hidden.length, 0, 'non-owner sees empty following for protected timeline')
+})
+
+Deno.test('discoverFollowGraph: public foreign timeline exposes following', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const foreignOwner = encodeEntityHash('2'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, foreignOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'follow', content: { targetEntityHash: TARGET, rep_edge: 1 } },
+	])
+
+	const visible = await discoverLocal.discoverFollowGraph(username, foreignOwner, { requesterNodeHash: 'b'.repeat(64) })
+	assert(visible.includes(TARGET.toLowerCase()), 'public timeline following visible to anyone')
+})
+
+Deno.test('discoverAccounts skips protected timelines', async () => {
+	const { username, operator } = await getSession()
+	const before = await discoverLocal.discoverAccounts(username, { n: 50 })
+	assert(before.accounts.some(a => a.entityHash === operator.toLowerCase()), 'operator listed when public')
+	await socialMeta.updateSocialMeta(username, operator, { hideFromDiscovery: true })
+	const after = await discoverLocal.discoverAccounts(username, { n: 50 })
+	assert(!after.accounts.some(a => a.entityHash === operator.toLowerCase()), 'protected operator hidden')
+	await socialMeta.updateSocialMeta(username, operator, { hideFromDiscovery: false })
+})
+
+Deno.test('buildProfileFeedItems returns own posts', async () => {
+	const { username, operator } = await getSession()
+	const { items } = await feed.buildProfileFeedItems(username, operator)
+	assert(items.length >= 1)
+	assert(items.every(item => item.entityHash === operator.toLowerCase()))
+})
+
+Deno.test('buildHomeFeed includes own public posts', async () => {
+	const { username } = await getSession()
+	const { items } = await feed.buildHomeFeed(username, { limit: 50 })
+	assert(items.length >= 1, 'home feed should include operator self posts')
+})
+
+Deno.test('follow then seeded remote post is pullable via federation RPC', async () => {
+	const { username, operator } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('f'.repeat(64), subject)
+	await following.setFollow(username, operator, remoteOwner, true)
+	const [post] = await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'post', content: { text: 'follow fanout replica', visibility: 'public' } },
+	])
+	const resp = await discoverRpc.handleSocialRpc(username, {
+		type: 'social_timeline_pull_request', entityHash: remoteOwner, afterEventId: null,
+	}, { requesterNodeHash: null })
+	assertEquals(resp.type, 'social_timeline_pull_response')
+	assert(resp.events.some(e => e.id === post.id), 'followed remote post reachable after replica ingest')
+	await following.setFollow(username, operator, remoteOwner, false)
+})
+
+Deno.test('remote author profile + posts do not break feed/discover', async () => {
+	const { username, operator } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('3'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'post', content: { text: 'remote authored post', visibility: 'public' } },
+	])
+
+	const entityProfile = await import('../../src/lib/entityProfile.mjs')
+	const profile = await entityProfile.getEntityProfile(username, remoteOwner)
+	assert(profile, 'remote profile should resolve to derived defaults')
+
+	await following.setFollow(username, operator, remoteOwner, true)
+	const { items } = await feed.buildHomeFeed(username, { limit: 50 })
+	assert(items.some(item => item.entityHash === remoteOwner.toLowerCase()), 'remote post visible in home feed')
+
+	const discovered = await discoverLocal.discoverAccounts(username, { n: 50 })
+	assert(discovered.accounts.some(a => a.entityHash === remoteOwner.toLowerCase()), 'remote public account discoverable')
+	await following.setFollow(username, operator, remoteOwner, false)
+})
+
+Deno.test('discoverAccounts: ingress RPC lists only self-hosted entities', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('4'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+	])
+
+	const localView = await discoverLocal.discoverAccounts(username, { n: 50 })
+	assert(localView.accounts.some(a => a.entityHash === remoteOwner.toLowerCase()), 'local explore sees synced remote owner')
+
+	const rpcResp = await discoverRpc.handleSocialRpc(username, {
+		type: 'social_discover_request', n: 50,
+	}, { requesterNodeHash: 'b'.repeat(64) })
+	assert(!rpcResp.accounts.some(a => a.entityHash === remoteOwner.toLowerCase()), 'ingress RPC hides foreign synced timeline')
+})
+
+Deno.test('remote entity profile uses subjectHash placeholder not local persona', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('5'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+	])
+
+	const { resolvePersonaPresentation } = await import('fount/public/parts/shells/chat/src/entity/presentation.mjs')
+	const personaName = (await resolvePersonaPresentation(username)).displayName
+	const entityProfile = await import('../../src/lib/entityProfile.mjs')
+	const profile = await entityProfile.getEntityProfile(username, remoteOwner)
+	const placeholder = `${subject.slice(0, 8)}…${subject.slice(-4)}`
+	assert(profile?.name === placeholder, 'remote profile falls back to subjectHash placeholder')
+	assert(profile?.name !== personaName, 'remote profile must not reuse local persona name')
+})

--- a/src/public/parts/shells/social/test/integration/feed_backfill.test.mjs
+++ b/src/public/parts/shells/social/test/integration/feed_backfill.test.mjs
@@ -1,0 +1,87 @@
+/**
+ * Feed 联邦补给：post_discover handler + backfill 短路 / 入库。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+Deno.test('localPostDiscoverHandler returns signed public post events', async () => {
+	const { username, operator } = await getSession()
+	const append = await import('../../src/timeline/append.mjs')
+	const { localPostDiscoverHandler } = await import('../../src/discover/postDiscover.mjs')
+
+	const event = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'backfill-discover-sample', visibility: 'public' },
+	}, { fanout: false })
+
+	const rows = await localPostDiscoverHandler({ replicaUsername: username }, { limit: 10 })
+	const hit = rows.find(row => row.postId === event.id)
+	assert(hit, 'discovered row missing')
+	assertEquals(hit.entityHash, operator)
+	assert(hit.event?.signature, 'event must carry signature')
+	assertEquals(hit.event?.content?.visibility, 'public')
+})
+
+Deno.test('backfillPosts short-circuits when enough already', async () => {
+	const { username } = await getSession()
+	const { backfillPosts } = await import('../../src/federation/backfill.mjs')
+	let checks = 0
+	const result = await backfillPosts(username, {
+		/**
+		 * @returns {boolean} 是否已足够
+		 */
+		enough: () => {
+			checks++
+			return true
+		},
+	})
+	assertEquals(result.phase, 'skip')
+	assertEquals(checks, 1)
+})
+
+Deno.test('backfillPosts in-flight dedupes concurrent calls', async () => {
+	const { username } = await getSession()
+	const { backfillPosts } = await import('../../src/federation/backfill.mjs')
+	let runs = 0
+	/**
+	 * @returns {Promise<boolean>} 是否已足够
+	 */
+	const enough = async () => {
+		runs++
+		await new Promise(resolve => setTimeout(resolve, 30))
+		return true
+	}
+	const [a, b] = await Promise.all([
+		backfillPosts(username, { enough }),
+		backfillPosts(username, { enough }),
+	])
+	assertEquals(a.phase, 'skip')
+	assertEquals(b.phase, 'skip')
+	assertEquals(runs, 1)
+})
+
+Deno.test('backfillPosts progresses past following when still empty', async () => {
+	const { username, operator } = await getSession()
+	const { backfillPosts } = await import('../../src/federation/backfill.mjs')
+	const phases = []
+	let call = 0
+	const result = await backfillPosts(username, {
+		viewerEntityHash: operator,
+		/**
+		 * @returns {boolean} 是否已足够
+		 */
+		enough: () => {
+			call++
+			// 第一次入口检查不够；following 后再够，避免打 discover/multihop 网络
+			const ok = call > 1
+			phases.push(call)
+			return ok
+		},
+	})
+	assertEquals(result.phase, 'following')
+	assert(phases.length >= 2)
+})

--- a/src/public/parts/shells/social/test/integration/feed_merge.test.mjs
+++ b/src/public/parts/shells/social/test/integration/feed_merge.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * feed 归并 / engagement / feedHub 推送。
+ * 复测：deno test --no-check --allow-scripts --allow-all src/public/parts/shells/social/test/integration/feed_merge.test.mjs
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const feedMerge = await import('../../src/feedMerge.mjs')
+const feedHelpers = await import('../../src/feed/home.mjs')
+const buildItem = await import('../../src/feed/buildItem.mjs')
+const feedHub = await import('../../src/ws/feedHub.mjs')
+
+Deno.test('compareFeedItems orders newer hlc first', () => {
+	const older = { hlc: { wall: 100 }, postId: 'a'.repeat(64), repPenalty: 0 }
+	const newer = { hlc: { wall: 200 }, postId: 'b'.repeat(64), repPenalty: 0 }
+	assert(feedMerge.compareFeedItems(newer, older) > 0)
+	assert(feedMerge.compareFeedItems(older, newer) < 0)
+})
+
+Deno.test('kWayMergeFeedStreams merges sorted streams', () => {
+	const streams = [
+		{ candidates: [{ hlc: { wall: 300 }, postId: 'c'.repeat(64) }], index: 0 },
+		{ candidates: [{ hlc: { wall: 200 }, postId: 'b'.repeat(64) }], index: 0 },
+	]
+	const merged = feedMerge.kWayMergeFeedStreams(streams, 2)
+	assertEquals(merged.length, 2)
+	assertEquals(merged[0].hlc.wall, 300)
+})
+
+Deno.test('buildEngagementIndex counts likes and reposts', async () => {
+	const { username, operator } = await getSession()
+	const post = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'engage me', visibility: 'public' },
+	}, { fanout: false })
+	await append.commitTimelineEvent(username, operator, {
+		type: 'like',
+		content: { targetEntityHash: operator, targetPostId: post.id },
+	}, { fanout: false })
+	await append.commitTimelineEvent(username, operator, {
+		type: 'repost',
+		content: { targetEntityHash: operator, targetPostId: post.id, comment: '' },
+	}, { fanout: false })
+
+	const engagement = await feedHelpers.buildEngagementIndex(username, [operator])
+	const viewerLiked = await feedHelpers.buildViewerLikedSet(username)
+	const forPost = buildItem.createEngagementForPost(engagement, viewerLiked)
+	const stats = forPost(operator, post.id)
+	assertEquals(stats.likeCount, 1)
+	assertEquals(stats.repostCount, 1)
+	assert(stats.viewerLiked)
+})
+
+Deno.test('pushFeedUpdate sends to registered mock socket', async () => {
+	const { username } = await getSession()
+	/** 已发送的 WebSocket 载荷记录。
+	 * @type {string[]} */
+	const sent = []
+	/** 事件名到回调集合的注册表。
+	 * @type {Map<string, Set<() => void>>} */
+	const handlers = new Map()
+	const mockSocket = {
+		readyState: 1,
+		/** 记录推送载荷。
+		 * @param {string} text JSON 字符串
+		 */
+		send(text) { sent.push(text) },
+		/**
+		 * 注册 mock socket 事件监听。
+		 * @param {string} event 事件名
+		 * @param {() => void} fn 回调
+		 */
+		on(event, fn) {
+			const set = handlers.get(event) ?? new Set()
+			set.add(fn)
+			handlers.set(event, set)
+		},
+		/** 触发 close 以走 feedHub 注销路径。 */
+		close() {
+			for (const fn of handlers.get('close') ?? [])
+				fn()
+		},
+	}
+	feedHub.registerFeedSocket(username, mockSocket)
+	try {
+		feedHub.pushFeedUpdate(username, { type: 'feed_refresh', at: 1 })
+		assertEquals(sent.length, 1)
+		const payload = JSON.parse(sent[0])
+		assertEquals(payload.type, 'feed_refresh')
+	}
+	finally {
+		mockSocket.close()
+	}
+})

--- a/src/public/parts/shells/social/test/integration/gap_batch_features.test.mjs
+++ b/src/public/parts/shells/social/test/integration/gap_batch_features.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * 定时发布 / 话题订阅 / 门控 / 直播会话集成测试。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+Deno.test('scheduled post enqueue and cancel', async () => {
+	const { username, operator } = await getSession()
+	const { enqueueScheduledPost, listScheduledPosts, cancelScheduledPost } = await import('../../src/lib/scheduledPosts.mjs')
+	const publishAt = Date.now() + 60_000
+	const row = enqueueScheduledPost(username, operator, { text: 'later post' }, publishAt)
+	assert(row.scheduledId)
+	assertEquals(listScheduledPosts(username, operator).some(r => r.scheduledId === row.scheduledId), true)
+	const removed = cancelScheduledPost(username, operator, row.scheduledId)
+	assertEquals(removed?.scheduledId, row.scheduledId)
+	assertEquals(listScheduledPosts(username, operator).some(r => r.scheduledId === row.scheduledId), false)
+})
+
+Deno.test('tag_follow materializes followedTags', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+	assertEquals(client.entityHash, operator)
+	const result = await client.followTopic('gaptest', true)
+	assertEquals(result.isFollowing, true)
+	assert(result.tags.includes('gaptest'))
+	const listed = await client.followedTopics()
+	assert(listed.tags.includes('gaptest'))
+	await client.followTopic('gaptest', false)
+	const after = await client.followedTopics()
+	assertEquals(after.tags.includes('gaptest'), false)
+})
+
+Deno.test('replyPolicy followers_7d rejects non-follower', async () => {
+	const { username, operator } = await getSession()
+	const { canReplyUnderPolicy } = await import('../../src/lib/replyPolicy.mjs')
+	const { getTimelineMaterialized } = await import('../../src/timeline/materialize.mjs')
+
+	assertEquals(await canReplyUnderPolicy({
+		username,
+		authorEntityHash: operator,
+		replierEntityHash: operator,
+		replyPolicy: 'followers_7d',
+	}), true)
+
+	assertEquals(await canReplyUnderPolicy({
+		username,
+		authorEntityHash: operator,
+		replierEntityHash: 'c'.repeat(128),
+		replyPolicy: 'followers_7d',
+		at: Date.now(),
+	}), false)
+
+	const view = await getTimelineMaterialized(username, operator)
+	assert(Array.isArray(view.followedTags))
+})
+
+Deno.test('live session start stop', async () => {
+	const { username } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+	const session = await client.startLive({ title: 'test live', bridgeOrigin: 'http://live-bridge.test' })
+	assertEquals(session.status, 'live')
+	assert(session.liveId)
+	assert(session.avRoomId)
+	assert(session.livePostId)
+	assert(session.publicWatchSecret)
+	const feed = await client.liveFeed({ limit: 10 })
+	assert(feed.items.some(row => row.liveId === session.liveId))
+
+	const { getTimelineMaterialized } = await import('../../src/timeline/materialize.mjs')
+	const view = await getTimelineMaterialized(username, client.entityHash)
+	const livePost = view.postById[session.livePostId]
+	assert(livePost)
+	assertEquals(livePost.content?.liveRef?.liveId, session.liveId)
+	assertEquals(livePost.content?.liveRef?.status, 'live')
+
+	const { patchLiveStats } = await import('../../src/live/session.mjs')
+	patchLiveStats(username, client.entityHash, session.liveId, {
+		viewerCount: 3,
+		viewerEntityHash: client.entityHash,
+		likeDelta: 2,
+	})
+
+	const ended = await client.stopLive(session.liveId)
+	assertEquals(ended.status, 'ended')
+	assertEquals(ended.liveStats?.totalLikes, 2)
+	assert(ended.liveStats?.totalViewers >= 1)
+
+	const after = await getTimelineMaterialized(username, client.entityHash)
+	const endedPost = after.postById[session.livePostId]
+	assertEquals(endedPost.content?.liveRef?.status, 'ended')
+	assertEquals(endedPost.content?.liveRef?.totalLikes, 2)
+})
+
+Deno.test('same-node live link bridges sessions', async () => {
+	const { username } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+	const a = await client.startLive({ title: 'host-a', bridgeOrigin: 'http://live-bridge.test' })
+	// second live same entity blocked — use invite against fictional peer that auto-rejects
+	const invite = await client.inviteLiveLink(a.liveId, {
+		peerEntityHash: 'a'.repeat(128),
+		peerLiveId: crypto.randomUUID(),
+		bridgeOrigin: 'http://live-bridge.test',
+	})
+	assertEquals(invite.status, 'invited')
+	await client.stopLive(a.liveId)
+})

--- a/src/public/parts/shells/social/test/integration/gap_features.test.mjs
+++ b/src/public/parts/shells/social/test/integration/gap_features.test.mjs
@@ -1,0 +1,94 @@
+/**
+ * 关键词屏蔽 / 社区笔记投影 / dwell 信号集成测试。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const noteIndex = await import('../../src/federation/note/index.mjs')
+const mutedKeywords = await import('../../src/mutedKeywords.mjs')
+const contentFilter = await import('../../src/lib/contentFilter.mjs')
+const feedVisibility = await import('../../src/feedVisibility.mjs')
+const dwell = await import('../../src/engagement/dwell.mjs')
+
+const TARGET = placeholderEntityHash('a')
+const POST_ID = 'd'.repeat(64)
+
+Deno.test('muted keywords filter canViewPost', async () => {
+	const { username, operator } = await getSession()
+	await mutedKeywords.replaceMutedKeywords(username, operator, [
+		{ pattern: 'bannedword', matchTags: true },
+	])
+	const muted = await mutedKeywords.loadMutedKeywords(username, operator)
+	assertEquals(muted.entries.length, 1)
+	assert(contentFilter.postMatchesMutedKeywords({ content: { text: 'has bannedword here' } }, muted))
+
+	const viewerContext = {
+		following: new Set(),
+		personalFilter: {
+			blockedEntityHashes: new Set(),
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		},
+		mutedKeywords: muted,
+	}
+	assertEquals(feedVisibility.canViewPost({
+		entityHash: TARGET,
+		content: { text: 'has bannedword here', visibility: 'public' },
+	}, viewerContext), false)
+	assertEquals(feedVisibility.canViewPost({
+		entityHash: TARGET,
+		content: { text: 'clean post', visibility: 'public' },
+	}, viewerContext), true)
+})
+
+Deno.test('post_note projects into note_index and tops with helpful votes', async () => {
+	const { username, operator } = await getSession()
+	const noteId = 'a'.repeat(64)
+	await noteIndex.projectNoteFromTimelineEvent(username, operator, {
+		id: noteId,
+		type: 'post_note',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID, text: 'context for readers' },
+		hlc: { wall: Date.now() },
+	})
+
+	let summary = await noteIndex.summarizeNotes(username, TARGET, POST_ID)
+	assertEquals(summary.notes.length, 1)
+	assertEquals(summary.topNote, null)
+
+	await noteIndex.projectNoteFromTimelineEvent(username, operator, {
+		id: 'b'.repeat(64),
+		type: 'note_vote',
+		content: {
+			targetEntityHash: TARGET,
+			targetPostId: POST_ID,
+			noteEventId: noteId,
+			helpful: true,
+		},
+	})
+
+	summary = await noteIndex.summarizeNotes(username, TARGET, POST_ID)
+	assert(summary.topNote)
+	assertEquals(summary.topNote.noteEventId, noteId)
+	assertEquals(summary.topNote.score, 1)
+})
+
+Deno.test('dwell signals accumulate author and tag boosts', async () => {
+	const { username, operator } = await getSession()
+	const author = placeholderEntityHash('d')
+	await dwell.appendDwellSignals(username, operator, [
+		{ author, postId: POST_ID, tags: ['cats'], dwellMs: 4500 },
+		{ author, postId: POST_ID, tags: ['cats'], dwellMs: 8000 },
+		{ author, postId: 'f'.repeat(64), tags: ['dogs'], dwellMs: 1000 },
+	])
+	const authors = await dwell.loadDwellAuthorBoosts(username, operator)
+	assertEquals(authors.get(author.toLowerCase()), dwell.AUTHOR_BOOST_PER_DWELL * 2)
+	const tags = await dwell.loadDwellTagBoosts(username, operator)
+	assertEquals(tags.get('cats'), dwell.TAG_WEIGHT_PER_DWELL * 2)
+	assertEquals(tags.has('dogs'), false)
+})

--- a/src/public/parts/shells/social/test/integration/governance.test.mjs
+++ b/src/public/parts/shells/social/test/integration/governance.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Social 治理最小集：mute / contentWarning。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import { setPersonalMuted, isMutedBy } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+const TARGET = placeholderEntityHash('b')
+
+Deno.test('mute filters feed via personal lists', async () => {
+	const { username, operator } = await getSession()
+	const { isAuthorFilteredByPersonalSets, loadPersonalFilterSets } = await import('npm:@steve02081504/fount-p2p/node/personal_block')
+	const { canViewPost } = await import('../../src/feedVisibility.mjs')
+	const { loadViewerContext } = await import('../../src/feed/home.mjs')
+
+	await setPersonalMuted(operator, TARGET, true)
+	const filterSets = await loadPersonalFilterSets(operator)
+	assert(isAuthorFilteredByPersonalSets(filterSets, TARGET))
+
+	const viewerContext = await loadViewerContext(username, operator)
+	assertEquals(canViewPost({ entityHash: TARGET, content: { text: 'x', visibility: 'public' } }, viewerContext), false)
+	await setPersonalMuted(operator, TARGET, false)
+})
+
+Deno.test('isMutedBy blocks inbox actor', async () => {
+	const { operator } = await getSession()
+	await setPersonalMuted(operator, TARGET, true)
+	assert(await isMutedBy(operator, { entityHash: TARGET }))
+	await setPersonalMuted(operator, TARGET, false)
+	assertEquals(await isMutedBy(operator, { entityHash: TARGET }), false)
+})
+
+Deno.test('contentWarning persists on post content', async () => {
+	const { username, operator } = await getSession()
+	const append = await import('../../src/timeline/append.mjs')
+	const { getTimelineMaterialized } = await import('../../src/timeline/materialize.mjs')
+
+	const row = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: {
+			text: 'hidden body',
+			contentWarning: 'sensitive',
+			visibility: 'public',
+		},
+	}, { fanout: false })
+
+	const view = await getTimelineMaterialized(username, operator)
+	const post = view.postById?.[row.id] || view.posts.find(p => p.id === row.id)
+	assertEquals(post?.content?.contentWarning, 'sensitive')
+})

--- a/src/public/parts/shells/social/test/integration/inbox_persistence.test.mjs
+++ b/src/public/parts/shells/social/test/integration/inbox_persistence.test.mjs
@@ -1,0 +1,238 @@
+/**
+ * inbox 持久化 + 已读水位 + buildNotifications unreadCount + 聚合读模型。
+ */
+/* global Deno */
+import fs from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const notifications = await import('../../src/notifications.mjs')
+const inbox = await import('../../src/inbox.mjs')
+const following = await import('../../src/following.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+const { appendJsonlSynced } = await import('npm:@steve02081504/fount-p2p/dag/storage')
+
+Deno.test('inbox written on ingest and seen watermark clears unreadCount', async () => {
+	const { username, operator } = await getSession()
+	const parent = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'inbox target', visibility: 'public' },
+	}, { fanout: false })
+
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('4'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'like', content: { targetEntityHash: operator, targetPostId: parent.id } },
+	])
+
+	await following.setFollow(username, operator, remoteOwner, true)
+
+	const before = await notifications.buildNotifications(username, { limit: 20 })
+	assert(before.notifications.some(row => row.type === 'like'), 'like in inbox')
+	assert((before.unreadCount ?? 0) >= 1, 'has unread')
+
+	const at = before.notifications[0]?.at || Date.now()
+	inbox.setNotificationsSeenAt(username, operator, at)
+
+	const after = await notifications.buildNotifications(username, { limit: 20 })
+	assertEquals(after.unreadCount, 0)
+})
+
+Deno.test('local commit writes inbox for remote reply recipient', async () => {
+	const { username, operator } = await getSession()
+	const target = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'parent', visibility: 'public' },
+	}, { fanout: false })
+
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('4'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{
+			type: 'post',
+			content: {
+				text: 'remote reply body',
+				visibility: 'public',
+				replyTo: { entityHash: operator, postId: target.id },
+			},
+		},
+	])
+	await following.setFollow(username, operator, remoteOwner, true)
+
+	const { notifications: rows } = await notifications.buildNotifications(username, { limit: 10 })
+	assert(rows.some(row => row.type === 'reply' && row.targetPostId === target.id))
+})
+
+Deno.test('self reply does not write inbox notification', async () => {
+	const { username, operator } = await getSession()
+	const target = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'parent', visibility: 'public' },
+	}, { fanout: false })
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: {
+			text: 'self reply',
+			visibility: 'public',
+			replyTo: { entityHash: operator, postId: target.id },
+		},
+	}, { fanout: false })
+
+	const { notifications: rows } = await notifications.buildNotifications(username, { limit: 10 })
+	assert(!rows.some(row => row.type === 'reply' && row.targetPostId === target.id))
+})
+
+Deno.test('aggregateNotificationRows merges 1000 likes on one target', () => {
+	const viewer = 'a'.repeat(128)
+	const rows = Array.from({ length: 1000 }, (_, index) => ({
+		type: 'like',
+		actorEntityHash: `b${String(index).padStart(127, '0')}`,
+		postId: null,
+		targetPostId: 'post-1',
+		targetEntityHash: viewer,
+		at: index,
+	}))
+	const aggregated = inbox.aggregateNotificationRows(rows, viewer)
+	assertEquals(aggregated.length, 1)
+	assertEquals(aggregated[0].actorCount, 1000)
+})
+
+Deno.test('inbox read aggregates seeded likes into one card', async () => {
+	const { username, operator } = await getSession()
+	const parent = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'aggregate target', visibility: 'public' },
+	}, { fanout: false })
+
+	fs.rmSync(inbox.inboxDir(username, operator), { recursive: true, force: true })
+	const eventsPath = inbox.inboxEventsPath(username, operator)
+	fs.mkdirSync(inbox.inboxDir(username, operator), { recursive: true })
+	const lines = []
+	for (let index = 0; index < 12; index++) 
+		lines.push(JSON.stringify({
+			type: 'like',
+			actorEntityHash: `c${String(index).padStart(127, '0')}`,
+			postId: null,
+			targetPostId: parent.id,
+			targetEntityHash: operator,
+			snippet: 'aggregate target',
+			at: index,
+		}))
+	
+	await writeFile(eventsPath, `${lines.join('\n')}\n`, 'utf8')
+
+	const page = await inbox.readInboxNotifications(username, operator, { limit: 10 })
+	assertEquals(page.notifications.length, 1)
+	assertEquals(page.notifications[0].actorCount, 12)
+	assertEquals(page.unreadCount, 1)
+})
+
+Deno.test('types filter limits aggregated inbox page', async () => {
+	const { username, operator } = await getSession()
+	const eventsPath = inbox.inboxEventsPath(username, operator)
+	const actorA = encodeEntityHash('4'.repeat(64), pubKeyHash(publicKeyFromSeed(randomSeed())))
+	const actorB = encodeEntityHash('4'.repeat(64), pubKeyHash(publicKeyFromSeed(randomSeed())))
+	await appendJsonlSynced(eventsPath, {
+		type: 'mention',
+		actorEntityHash: actorA,
+		postId: 'post-mention',
+		targetPostId: null,
+		at: Date.now(),
+	})
+	await appendJsonlSynced(eventsPath, {
+		type: 'like',
+		actorEntityHash: actorB,
+		postId: null,
+		targetPostId: 'post-like',
+		targetEntityHash: operator,
+		at: Date.now() - 1,
+	})
+
+	const mentions = await inbox.readInboxNotifications(username, operator, { limit: 10, types: ['mention'] })
+	assertEquals(mentions.notifications.length, 1)
+	assertEquals(mentions.notifications[0].type, 'mention')
+})
+
+Deno.test('appendInboxFromTimelineEvent pushes notification over feed WS', async () => {
+	const feedHub = await import('../../src/ws/feedHub.mjs')
+	const { username, operator } = await getSession()
+	/** 已发送的 WebSocket 载荷记录。
+	 * @type {string[]} */
+	const sent = []
+	/** 事件名到回调集合的注册表。
+	 * @type {Map<string, Set<() => void>>} */
+	const handlers = new Map()
+	const mockSocket = {
+		readyState: 1,
+		/** 记录推送载荷。
+		 * @param {string} text JSON 字符串
+		 */
+		send(text) { sent.push(text) },
+		/**
+		 * 注册 mock socket 事件监听。
+		 * @param {string} event 事件名
+		 * @param {() => void} fn 回调
+		 */
+		on(event, fn) {
+			const set = handlers.get(event) ?? new Set()
+			set.add(fn)
+			handlers.set(event, set)
+		},
+		/** 触发 close 以走 feedHub 注销路径。 */
+		close() {
+			for (const fn of handlers.get('close') ?? [])
+				fn()
+		},
+	}
+	feedHub.registerFeedSocket(username, mockSocket)
+	try {
+		const parent = await append.commitTimelineEvent(username, operator, {
+			type: 'post',
+			content: { text: 'ws parent', visibility: 'public' },
+		}, { fanout: false })
+
+		const seed = randomSeed()
+		const subject = pubKeyHash(publicKeyFromSeed(seed))
+		const remoteOwner = encodeEntityHash('4'.repeat(64), subject)
+		await seedRemoteTimeline(username, seed, remoteOwner, [
+			{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+			{ type: 'like', content: { targetEntityHash: operator, targetPostId: parent.id } },
+		])
+		await following.setFollow(username, operator, remoteOwner, true)
+
+		const notificationFrame = sent.map(text => JSON.parse(text)).find(frame => frame.type === 'notification')
+		assert(notificationFrame, 'notification WS frame')
+		assertEquals(notificationFrame.notification.type, 'like')
+		assert(notificationFrame.notification.aggregateKey, 'aggregateKey on WS payload')
+	}
+	finally {
+		mockSocket.close()
+	}
+})
+
+Deno.test('notificationSnippet strips markdown noise', () => {
+	assertEquals(inbox.notificationSnippet('# Title\n\n**bold** text'), 'Title bold text')
+})
+
+Deno.test('aggregateNotificationRows keeps reply rows separate', () => {
+	const viewer = 'a'.repeat(128)
+	const rows = [
+		{ type: 'reply', actorEntityHash: 'b'.repeat(128), postId: 'p1', targetPostId: 't1', at: 2 },
+		{ type: 'reply', actorEntityHash: 'c'.repeat(128), postId: 'p2', targetPostId: 't2', at: 1 },
+	]
+	const aggregated = inbox.aggregateNotificationRows(rows, viewer)
+	assertEquals(aggregated.length, 2)
+})

--- a/src/public/parts/shells/social/test/integration/manifest_write_auth.test.mjs
+++ b/src/public/parts/shells/social/test/integration/manifest_write_auth.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * 时间线 manifest 写入授权（isTimelineWriteAuthorized）边界测试。
+ */
+/* global Deno */
+import { Buffer } from 'node:buffer'
+import fs from 'node:fs'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const { isTimelineWriteAuthorized } = await import('../../src/federation/write_auth.mjs')
+const append = await import('../../src/timeline/append.mjs')
+const { pubKeyHash, publicKeyFromSeed, keyPairFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash, entityHashFromRecoveryPubKeyHex } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+const {
+	ensureAgentEntityIdentity,
+	getEntitySecretKey,
+	getOperatorSecretKey,
+	resolveOperatorEntityHashForUser,
+} = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+const { getUserDictionary } = await import('fount/server/auth/index.mjs')
+const { ensureEntitySocialReady } = await import('../../src/lib/bootstrap.mjs')
+
+Deno.test('operator may write own user timeline', async () => {
+	const { username } = await getSession()
+	const operator = await resolveOperatorEntityHashForUser(username)
+	assert(operator)
+	const priorEvents = await append.readTimelineEvents(username, operator)
+	const secret = new Uint8Array(Buffer.from(await getOperatorSecretKey(username), 'hex'))
+	const sender = pubKeyHash(publicKeyFromSeed(secret))
+	assertEquals(await isTimelineWriteAuthorized(operator, sender, { priorEvents }), true)
+})
+
+Deno.test('foreign sender cannot write operator timeline', async () => {
+	const { username } = await getSession()
+	const operator = await resolveOperatorEntityHashForUser(username)
+	const attacker = pubKeyHash(publicKeyFromSeed(randomSeed()))
+	assertEquals(await isTimelineWriteAuthorized(operator, attacker), false)
+})
+
+Deno.test('local agent active key may write own timeline with key history', async () => {
+	const { username } = await getSession()
+	const charPartName = 'manifest-write-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const priorEvents = await append.readTimelineEvents(username, row.entityHash)
+	const secret = new Uint8Array(Buffer.from(await getEntitySecretKey(username, row.entityHash), 'hex'))
+	const sender = pubKeyHash(publicKeyFromSeed(secret))
+	assertEquals(await isTimelineWriteAuthorized(row.entityHash, sender, { priorEvents }), true)
+})
+
+Deno.test('remote agent timeline rejects unknown sender', async () => {
+	await getSession()
+	const { publicKey } = keyPairFromSeed(randomSeed())
+	const remoteOwner = entityHashFromRecoveryPubKeyHex('9'.repeat(64), Buffer.from(publicKey).toString('hex'))
+	const stranger = pubKeyHash(publicKeyFromSeed(randomSeed()))
+	assertEquals(await isTimelineWriteAuthorized(remoteOwner, stranger), false)
+})
+
+Deno.test('user-style owner accepts subjectHash sender only', async () => {
+	await getSession()
+	const seed = randomSeed()
+	const sender = pubKeyHash(publicKeyFromSeed(seed))
+	const owner = encodeEntityHash('d'.repeat(64), sender)
+	assertEquals(await isTimelineWriteAuthorized(owner, sender), true)
+	assertEquals(await isTimelineWriteAuthorized(owner, pubKeyHash(publicKeyFromSeed(randomSeed()))), false)
+})
+
+Deno.test('owner active key may post_delete on owned agent timeline', async () => {
+	const { username } = await getSession()
+	const charPartName = 'manifest-owner-delete-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	const operator = await resolveOperatorEntityHashForUser(username)
+	assert(operator)
+	await ensureEntitySocialReady(username, operator)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const ownerSecret = new Uint8Array(Buffer.from(await getOperatorSecretKey(username), 'hex'))
+	const ownerSender = pubKeyHash(publicKeyFromSeed(ownerSecret))
+	assertEquals(await isTimelineWriteAuthorized(row.entityHash, ownerSender, {
+		eventType: 'post_delete',
+		eventContent: { targetPostId: 'a'.repeat(64) },
+		username,
+	}), true)
+})
+
+Deno.test('stranger key cannot post_delete on agent timeline via owner branch', async () => {
+	const { username } = await getSession()
+	const charPartName = 'manifest-owner-delete-deny'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	const operator = await resolveOperatorEntityHashForUser(username)
+	await ensureEntitySocialReady(username, operator)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const stranger = pubKeyHash(publicKeyFromSeed(randomSeed()))
+	assertEquals(await isTimelineWriteAuthorized(row.entityHash, stranger, {
+		eventType: 'post_delete',
+		username,
+	}), false)
+})
+
+Deno.test('owner active key may post_edit on owned agent timeline', async () => {
+	const { username } = await getSession()
+	const charPartName = 'manifest-owner-edit-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	const operator = await resolveOperatorEntityHashForUser(username)
+	assert(operator)
+	await ensureEntitySocialReady(username, operator)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const ownerSecret = new Uint8Array(Buffer.from(await getOperatorSecretKey(username), 'hex'))
+	const ownerSender = pubKeyHash(publicKeyFromSeed(ownerSecret))
+	assertEquals(await isTimelineWriteAuthorized(row.entityHash, ownerSender, {
+		eventType: 'post_edit',
+		eventContent: { targetPostId: 'a'.repeat(64), text: 'by owner' },
+		username,
+	}), true)
+})

--- a/src/public/parts/shells/social/test/integration/markdown_extensions.test.mjs
+++ b/src/public/parts/shells/social/test/integration/markdown_extensions.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * Social markdown 扩展注册结构测试。
+ */
+/* global Deno */
+import { assertMatch } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+const socialMarkdownExtensionPath = new URL('../../public/markdown_extensions/index.mjs', import.meta.url)
+
+Deno.test('social markdown extension exports remark plugins', async () => {
+	const source = await Deno.readTextFile(socialMarkdownExtensionPath)
+	assertMatch(source, /remarkPlugins:\s*\[/)
+	assertMatch(source, /remarkSocialDialect/)
+})

--- a/src/public/parts/shells/social/test/integration/module_graph_probe.test.mjs
+++ b/src/public/parts/shells/social/test/integration/module_graph_probe.test.mjs
@@ -1,0 +1,19 @@
+/**
+ * Social shell 前后端加载 smoke。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { defaultRepoRoot, probeShellPart } from '../../../../../../scripts/test/shellLoadProbe.mjs'
+
+const repoRoot = defaultRepoRoot()
+
+Deno.test('social shell module graph resolves without cross-boundary leaks', async () => {
+	const { backendMissing, publicMissing, crossBoundary } = await probeShellPart({
+		repoRoot,
+		partPath: 'shells/social',
+	})
+	assertEquals(backendMissing, [])
+	assertEquals(publicMissing, [])
+	assertEquals(crossBoundary, [])
+})

--- a/src/public/parts/shells/social/test/integration/notifications_dispatch.test.mjs
+++ b/src/public/parts/shells/social/test/integration/notifications_dispatch.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * 通知与 dispatch 主流程。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession, seedAgentChar } from '../harness.mjs'
+
+const GETREPLY_CHAR = 'mention_getreply_agent'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const notifications = await import('../../src/notifications.mjs')
+const dispatch = await import('../../src/dispatch.mjs')
+const following = await import('../../src/following.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+
+Deno.test('buildNotifications includes like repost follow reply mention', async () => {
+	const { username, operator } = await getSession()
+	const parent = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'notify me', visibility: 'public' },
+	}, { fanout: false })
+
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('4'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'follow', content: { targetEntityHash: operator, rep_edge: 1 } },
+		{ type: 'like', content: { targetEntityHash: operator, targetPostId: parent.id } },
+		{ type: 'repost', content: { targetEntityHash: operator, targetPostId: parent.id, comment: 'nice' } },
+		{ type: 'post', content: {
+			text: `reply @${operator}`,
+			visibility: 'public',
+			replyTo: { entityHash: operator, postId: parent.id },
+		} },
+		{ type: 'post', content: {
+			text: `hello @[entity:${operator}] there`,
+			visibility: 'public',
+		} },
+	])
+
+	await following.setFollow(username, operator, remoteOwner, true)
+
+	const { notifications: rows, viewerEntityHash } = await notifications.buildNotifications(username, { limit: 50 })
+	assertEquals(viewerEntityHash, operator)
+	const types = new Set(rows.map(r => r.type))
+	assert(types.has('like'))
+	assert(types.has('repost'))
+	assert(types.has('follow'))
+	assert(types.has('reply'))
+	assert(types.has('mention'))
+	assert(rows.every(row => 'actorEntityHash' in row && row.postId !== undefined && row.targetPostId !== undefined))
+})
+
+Deno.test('buildNotifications respects viewerEntityHash / SocialClient agent', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'viewer notify target', visibility: 'public' },
+	}, { fanout: false })
+
+	const agentHash = await seedAgentChar(username, GETREPLY_CHAR)
+	const { ensureEntitySocialReady } = await import('../../src/lib/bootstrap.mjs')
+	await ensureEntitySocialReady(username, agentHash)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: {
+			text: `agent only @[entity:${agentHash}]`,
+			visibility: 'public',
+		},
+	}, { fanout: false })
+
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const operatorPage = await (await getSocialClient(username)).notifications({ limit: 50 })
+	assertEquals(operatorPage.viewerEntityHash, operator)
+
+	const agentPage = await (await getSocialClient(username, agentHash)).notifications({ limit: 50 })
+	assertEquals(agentPage.viewerEntityHash, agentHash)
+	assert(agentPage.notifications.some(row => row.type === 'mention'))
+	const agentMentionPostId = agentPage.notifications.find(row => row.type === 'mention')?.postId
+	assert(agentMentionPostId)
+	assert(!operatorPage.notifications.some(row => row.postId === agentMentionPostId),
+		'operator inbox should not include agent-only mention')
+})
+
+Deno.test('dispatchSocialMessage does not publish agent reply without mention when no OnMessage', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	const { username, operator } = await getSession()
+	const agentHash = await seedAgentChar(username, GETREPLY_CHAR)
+	const beforeCount = (await append.readTimelineEvents(username, agentHash)).length
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'no mentions here', visibility: 'public' },
+	}, { fanout: false })
+	const after = await append.readTimelineEvents(username, agentHash)
+	assertEquals(after.length, beforeCount, 'agent without OnMessage must not reply when unmentioned')
+})
+
+Deno.test('processSocialPostNotifyRpc accepts signed post payload', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	const { username, operator } = await getSession()
+	const post = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'rpc notify', visibility: 'public' },
+	}, { fanout: false })
+	const result = await dispatch.processSocialPostNotifyRpc(username, {
+		authorEntityHash: operator,
+		posterUsername: username,
+		post,
+	})
+	assertEquals(result.ok, true)
+
+	const forged = await dispatch.processSocialPostNotifyRpc(username, {
+		authorEntityHash: operator,
+		posterUsername: username,
+		post: { ...post, signature: '00'.repeat(64), id: 'f'.repeat(64) },
+	})
+	assertEquals(forged.ok, false)
+})

--- a/src/public/parts/shells/social/test/integration/personal_lists.test.mjs
+++ b/src/public/parts/shells/social/test/integration/personal_lists.test.mjs
@@ -1,0 +1,69 @@
+/**
+ * 个人 block / hide 写路径。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import { setPersonalHidden } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const personalBlock = await import('../../src/personalBlock.mjs')
+const materialize = await import('../../src/timeline/materialize.mjs')
+const { loadViewerContext } = await import('../../src/feed/home.mjs')
+const { canViewPost } = await import('../../src/feedVisibility.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+
+const TARGET = placeholderEntityHash('b')
+
+Deno.test('setPersonalBlock block then unblock updates materialized blocked', async () => {
+	const { username, operator } = await getSession()
+	let blocked = await personalBlock.setPersonalBlock(username, operator, TARGET, true)
+	assert(blocked.includes(TARGET))
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assert(view.blocked?.includes(TARGET))
+
+	blocked = await personalBlock.setPersonalBlock(username, operator, TARGET, false)
+	assert(!blocked.includes(TARGET))
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assert(!view.blocked?.includes(TARGET))
+})
+
+Deno.test('handleInboundPersonalBlockEvent syncs followed owner block index', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const foreignOwner = encodeEntityHash('2'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, foreignOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'block', content: { targetEntityHash: TARGET } },
+	])
+
+	const append = await import('../../src/timeline/append.mjs')
+	const blockEv = (await append.readTimelineEvents(username, foreignOwner))
+		.find(e => e.type === 'block')
+	assert(blockEv)
+
+	const followed = new Set([foreignOwner])
+	await personalBlock.handleInboundPersonalBlockEvent(username, foreignOwner, blockEv, followed)
+	const view = await materialize.getTimelineMaterialized(username, foreignOwner)
+	assert(view.blocked?.includes(TARGET))
+})
+
+Deno.test('setPersonalHidden hides author from canViewPost', async () => {
+	const { username, operator } = await getSession()
+	await setPersonalHidden(operator, TARGET, true)
+	const viewerContext = await loadViewerContext(username)
+	const post = {
+		entityHash: TARGET,
+		content: { text: 'hidden author post', visibility: 'public' },
+	}
+	assert(!canViewPost(post, viewerContext))
+	await setPersonalHidden(operator, TARGET, false)
+	const restored = await loadViewerContext(username)
+	assert(canViewPost(post, restored))
+})

--- a/src/public/parts/shells/social/test/integration/poll_edit_feed.test.mjs
+++ b/src/public/parts/shells/social/test/integration/poll_edit_feed.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * poll / post_edit / for_you / search cursor 集成测试。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const session = createTestSession()
+
+Deno.test('poll vote updates tally projection', async () => {
+	const { username, operator } = await session()
+	const { commitTimelineEvent } = await import('../../src/timeline/append.mjs')
+	const { listPollTally } = await import('../../src/federation/poll/index.mjs')
+
+	const post = await commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: {
+			text: 'poll post',
+			visibility: 'public',
+			locale: 'zh-CN',
+			poll: { options: ['A', 'B'], multi: false, deadline: null },
+		},
+	})
+	await commitTimelineEvent(username, operator, {
+		type: 'poll_vote',
+		content: {
+			targetEntityHash: operator,
+			targetPostId: post.id,
+			choices: [0],
+		},
+	})
+	const tally = await listPollTally(username, operator, post.id)
+	assertEquals(tally['0'], 1)
+})
+
+Deno.test('post_edit materializes latest text', async () => {
+	const { username, operator } = await session()
+	const { commitTimelineEvent } = await import('../../src/timeline/append.mjs')
+	const { getTimelineMaterialized } = await import('../../src/timeline/materialize.mjs')
+
+	const post = await commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'before edit', visibility: 'public', locale: 'zh-CN' },
+	})
+	await commitTimelineEvent(username, operator, {
+		type: 'post_edit',
+		content: { targetPostId: post.id, text: 'after edit', locale: 'zh-CN' },
+	})
+	const view = await getTimelineMaterialized(username, operator)
+	assertEquals(view.postById[post.id].content.text, 'after edit')
+	assertEquals(view.postById[post.id].edited, true)
+})
+
+Deno.test('searchPosts returns nextCursor', async () => {
+	const { username, operator } = await session()
+	const { commitTimelineEvent } = await import('../../src/timeline/append.mjs')
+	const { searchPosts } = await import('../../src/search.mjs')
+
+	await commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'alpha unique poll-edit token', visibility: 'public', locale: 'zh-CN' },
+	})
+	await commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'beta unique poll-edit token', visibility: 'public', locale: 'zh-CN' },
+	})
+	const page1 = await searchPosts(username, { q: 'unique poll-edit', limit: 1 })
+	assertEquals(page1.items.length, 1)
+	assert(page1.nextCursor)
+	const page2 = await searchPosts(username, { q: 'unique poll-edit', limit: 1, cursor: page1.nextCursor })
+	assertEquals(page2.items.length, 1)
+	assert(page1.items[0].postId !== page2.items[0].postId)
+})
+
+Deno.test('buildForYouFeed returns scored items', async () => {
+	const { username, operator } = await session()
+	const { commitTimelineEvent } = await import('../../src/timeline/append.mjs')
+	const { buildForYouFeed } = await import('../../src/feed/ranking.mjs')
+
+	await commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'for you feed item', visibility: 'public', locale: 'zh-CN' },
+	})
+	const feed = await buildForYouFeed(username, { viewerEntityHash: operator, limit: 10 })
+	assert(feed.items.length >= 1)
+	assert(typeof feed.items[0].score === 'number')
+})

--- a/src/public/parts/shells/social/test/integration/post_interactions.test.mjs
+++ b/src/public/parts/shells/social/test/integration/post_interactions.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * repost / reply / followers-only 可见性。
+ */
+/* global Deno */
+import { randomUUID } from 'node:crypto'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const materialize = await import('../../src/timeline/materialize.mjs')
+const feed = await import('../../src/feed/home.mjs')
+const following = await import('../../src/following.mjs')
+const { loadViewerContext } = await import('../../src/feed/home.mjs')
+const { canViewPost } = await import('../../src/feedVisibility.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+
+Deno.test('repost materializes and appears in home feed', async () => {
+	const { username, operator } = await getSession()
+	const signed = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'original for repost', visibility: 'public', locale: 'zh-CN' },
+	}, { fanout: false })
+	await append.commitTimelineEvent(username, operator, {
+		type: 'repost',
+		content: {
+			targetEntityHash: operator,
+			targetPostId: signed.id,
+			comment: 'boosting',
+		},
+	}, { fanout: false })
+
+	const view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.reposts.length, 1)
+	assertEquals(view.reposts[0].content.comment, 'boosting')
+
+	const { items } = await feed.buildHomeFeed(username, { limit: 50 })
+	assert(items.some(row => row.kind === 'repost' && row.postId === view.reposts[0].id))
+})
+
+Deno.test('reply chain surfaces via listReplies', async () => {
+	const { username, operator } = await getSession()
+	const parent = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'parent thread', visibility: 'public' },
+	}, { fanout: false })
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: {
+			text: 'child reply',
+			visibility: 'public',
+			replyTo: { entityHash: operator, postId: parent.id },
+		},
+	}, { fanout: false })
+
+	const replies = await feed.listReplies(username, operator, parent.id)
+	assertEquals(replies.length, 1)
+	assertEquals(replies[0].post.content.text, 'child reply')
+})
+
+Deno.test('followers-only post hidden when viewer does not follow author', async () => {
+	const { username, operator } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const foreignOwner = encodeEntityHash('3'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, foreignOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'post', content: { text: 'secret followers', visibility: 'followers' } },
+	])
+
+	const viewerContext = await loadViewerContext(username)
+	viewerContext.following = new Set([operator])
+	const view = await materialize.getTimelineMaterialized(username, foreignOwner)
+	const secret = view.posts[0]
+	assert(!canViewPost({ ...secret, entityHash: foreignOwner }, viewerContext))
+
+	viewerContext.following = new Set([operator, foreignOwner])
+	assert(canViewPost({ ...secret, entityHash: foreignOwner }, viewerContext))
+})
+
+Deno.test('owner sees own followers-only post decrypted on profile feed', async () => {
+	const { username, operator } = await getSession()
+	const postKeyId = randomUUID()
+	const encrypted = await import('../../src/vault_crypto/vault.mjs')
+	const encContent = await encrypted.maybeEncryptPostContent(
+		username, operator, postKeyId,
+		{ text: 'followers encrypted', visibility: 'followers', locale: 'zh-CN' },
+		'followers',
+	)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: encContent,
+	}, { fanout: false })
+
+	const { items } = await feed.buildProfileFeedItems(username, operator)
+	const followersItem = items.find(row => row.post?.content?.text === 'followers encrypted')
+	assert(followersItem, 'owner must decrypt followers-only post to plaintext on profile feed')
+	assertEquals(followersItem.post.content.visibility, 'followers')
+})

--- a/src/public/parts/shells/social/test/integration/posts_http.test.mjs
+++ b/src/public/parts/shells/social/test/integration/posts_http.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * HTTP POST /posts 路由（integration 进程内 bypass 覆盖不到 spread 路径）。
+ */
+/* global Deno */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { launchNode, stopNode } from 'fount/scripts/test/node/launch.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+
+const bootstrapPath = join(dirname(fileURLToPath(import.meta.url)), '../node_bootstrap.mjs')
+
+Deno.test({
+	name: 'POST /posts accepts body without mediaRefs',
+	sanitizeOps: false,
+	sanitizeResources: false,
+}, async () => {
+	const apiKey = `fount-social-posts-http-${Date.now().toString(36)}`
+	const node = await launchNode({
+		username: 'social-posts-http-user',
+		apiKey,
+		loadParts: ['shells/social', 'shells/chat'],
+		bootstrap: bootstrapPath,
+		p2p: false,
+		minP2pNode: true,
+	})
+	const { baseUrl } = node
+	try {
+		const viewerRes = await fetch(`${baseUrl}/api/parts/shells:chat/viewer?fount-apikey=${encodeURIComponent(apiKey)}`)
+		assertEquals(viewerRes.status, 200)
+		const { viewerEntityHash } = await viewerRes.json()
+		assert(viewerEntityHash)
+
+		const postRes = await fetch(`${baseUrl}/api/parts/shells:social/posts?fount-apikey=${encodeURIComponent(apiKey)}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				entityHash: viewerEntityHash,
+				text: 'integration posts http',
+				visibility: 'public',
+				locale: 'zh-CN',
+			}),
+		})
+		const postRaw = await postRes.text()
+		assertEquals(postRes.status, 200, postRaw)
+		const body = JSON.parse(postRaw)
+		assert(body.event?.id)
+		assertEquals(body.event.content?.text, 'integration posts http')
+
+		const pollRes = await fetch(`${baseUrl}/api/parts/shells:social/posts?fount-apikey=${encodeURIComponent(apiKey)}`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				entityHash: viewerEntityHash,
+				text: 'poll via http',
+				visibility: 'public',
+				locale: 'zh-CN',
+				poll: { options: ['yes', 'no'], multi: false },
+			}),
+		})
+		const pollRaw = await pollRes.text()
+		assertEquals(pollRes.status, 200, pollRaw)
+		const pollBody = JSON.parse(pollRaw)
+		const pollPostId = pollBody.event?.id
+		assert(pollPostId)
+		assertEquals(pollBody.event.content?.poll?.options?.length, 2)
+
+		const voteRes = await fetch(
+			`${baseUrl}/api/parts/shells:social/posts/${viewerEntityHash}/${pollPostId}/poll-vote?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ choices: [1] }),
+			},
+		)
+		const voteRaw = await voteRes.text()
+		assertEquals(voteRes.status, 200, voteRaw)
+		assertEquals(JSON.parse(voteRaw).event?.type, 'poll_vote')
+
+		const editRes = await fetch(
+			`${baseUrl}/api/parts/shells:social/posts/${viewerEntityHash}/${body.event.id}/edit?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ text: 'edited via http' }),
+			},
+		)
+		const editRaw = await editRes.text()
+		assertEquals(editRes.status, 200, editRaw)
+		assertEquals(JSON.parse(editRaw).event?.type, 'post_edit')
+	}
+	finally {
+		await stopNode(node)
+	}
+})

--- a/src/public/parts/shells/social/test/integration/saved_posts_default.test.mjs
+++ b/src/public/parts/shells/social/test/integration/saved_posts_default.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * 收藏夹默认结构单元测试（Deno）。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { loadSavedPosts } from '../../src/savedPosts.mjs'
+
+Deno.test('loadSavedPosts returns empty structure when file missing', async () => {
+	const data = await loadSavedPosts('__social_saved_posts_missing_user__', 'a'.repeat(128))
+	assertEquals(data.folders, {})
+	assertEquals(data.unfiled, [])
+})

--- a/src/public/parts/shells/social/test/integration/saved_vault_translate.test.mjs
+++ b/src/public/parts/shells/social/test/integration/saved_vault_translate.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * 收藏 / vault 索引 / 翻译缓存。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const saved = await import('../../src/savedPosts.mjs')
+const vaultRoot = await import('../../src/socialVaultIndex.mjs')
+const translate = await import('../../src/translate.mjs')
+
+Deno.test('saved posts folder CRUD', async () => {
+	const { username, operator } = await getSession()
+	const signed = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'saved target', visibility: 'public' },
+	}, { fanout: false })
+	const postId = signed.id
+
+	const created = await saved.createSavedFolder(username, operator, 'Favorites')
+	const folderId = Object.keys(created.folders).find(id => created.folders[id].name === 'Favorites')
+	assert(folderId)
+
+	let data = await saved.addSavedPost(username, operator, { entityHash: operator, postId }, folderId)
+	assert(data.folders[folderId].posts.some(r => r.postId === postId))
+
+	await saved.renameSavedFolder(username, operator, folderId, 'Starred')
+	data = await saved.loadSavedPosts(username, operator)
+	assertEquals(data.folders[folderId].name, 'Starred')
+
+	data = await saved.removeSavedPost(username, operator, { entityHash: operator, postId }, folderId)
+	assertEquals(data.folders[folderId].posts.length, 0)
+
+	data = await saved.addSavedPost(username, operator, { entityHash: operator, postId }, null)
+	assert(data.unfiled.some(r => r.postId === postId))
+
+	data = await saved.deleteSavedFolder(username, operator, folderId)
+	assert(!data.folders[folderId])
+	assert(data.unfiled.some(r => r.postId === postId))
+
+	await saved.removeSavedPost(username, operator, { entityHash: operator, postId })
+})
+
+Deno.test('registerVaultFile and getVaultFileByShareId', async () => {
+	const { username, operator } = await getSession()
+	const shareId = 'share-test-001'
+	const entry = await vaultRoot.registerVaultFile(username, operator, {
+		fileId: 'file-test-001',
+		logicalPath: 'shells/social/vault/file-test-001',
+		name: 'note.txt',
+		mimeType: 'text/plain',
+		size: 12,
+		shareId,
+		visibility: 'followers',
+	})
+	assertEquals(entry.shareId, shareId)
+
+	const found = await vaultRoot.getVaultFileByShareId(username, operator, shareId)
+	assert(found)
+	assertEquals(found.name, 'note.txt')
+})
+
+Deno.test('translate cache hit and miss', async () => {
+	const { username } = await getSession()
+	const key = 'zh-CN:cache test phrase'
+	assertEquals(translate.getCachedTranslation(username, key), null)
+	translate.cacheTranslation(username, key, 'cached translation')
+	assertEquals(translate.getCachedTranslation(username, key), 'cached translation')
+})
+
+Deno.test('translatePostText returns original when no generator', async () => {
+	const out = await translate.translatePostText('plain text', 'en')
+	assertEquals(out, 'plain text')
+})

--- a/src/public/parts/shells/social/test/integration/search_discover.test.mjs
+++ b/src/public/parts/shells/social/test/integration/search_discover.test.mjs
@@ -1,0 +1,65 @@
+/**
+ * 搜索 / 探索 / 热门话题。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const search = await import('../../src/search.mjs')
+const discoverLocal = await import('../../src/discover/local.mjs')
+const trending = await import('../../src/trending/hashtags.mjs')
+
+Deno.test('searchPosts finds operator post by hashtag', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'hello #SearchTagBatch9', visibility: 'public' },
+	}, { fanout: false })
+
+	const { items, query } = await search.searchPosts(username, { q: '#SearchTagBatch9', limit: 10 })
+	assertEquals(query, '#SearchTagBatch9')
+	assert(items.length >= 1)
+})
+
+Deno.test('searchPosts returns empty for short query', async () => {
+	const { username } = await getSession()
+	const { items } = await search.searchPosts(username, { q: 'a', limit: 10 })
+	assertEquals(items.length, 0)
+})
+
+Deno.test('discoverPosts returns public posts newest-first', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'discover sample post', visibility: 'public' },
+	}, { fanout: false })
+
+	const { posts } = await discoverLocal.discoverPosts(username, { n: 20 })
+	assert(posts.some(p => p.entityHash === operator))
+})
+
+Deno.test('discoverPosts skips followers-only visibility', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'discoverSecretFollowersOnly', visibility: 'followers' },
+	}, { fanout: false })
+
+	const { posts } = await discoverLocal.discoverPosts(username, { n: 50 })
+	assert(!posts.some(p => p.textSnippet?.includes('discoverSecretFollowersOnly')))
+})
+
+Deno.test('buildTrendingHashtags counts visible hashtag posts', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'hello #TrendTagSearch', visibility: 'public' },
+	}, { fanout: false })
+
+	const { tags } = await trending.buildTrendingHashtags(username, { limit: 20 })
+	assert(tags.some(row => row.tag === 'trendtagsearch' && row.count >= 1))
+})

--- a/src/public/parts/shells/social/test/integration/social_client.test.mjs
+++ b/src/public/parts/shells/social/test/integration/social_client.test.mjs
@@ -1,0 +1,38 @@
+/**
+ * SocialClient：绑定实体发帖 / 互动 / 收藏搜索。
+ */
+/* global Deno */
+import { assert, assertEquals, assertRejects } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+Deno.test('getSocialClient defaults to operator and posts return Post', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username)
+	assertEquals(client.entityHash, operator)
+
+	const post = await client.post({ text: `social-client-post-${Date.now()}` })
+	assertEquals(post.entityHash, operator)
+	assert(post.postId)
+	assertEquals(typeof post.like, 'function')
+
+	const liked = await post.like()
+	assertEquals(liked.type, 'like')
+
+	await client.saved.add({ entityHash: post.entityHash, postId: post.postId })
+	const hit = await client.saved.search('social-client-post')
+	assert(hit.posts.some(row => row.postId === post.postId))
+})
+
+Deno.test('getSocialClient rejects foreign entityHash', async () => {
+	const { username } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	await assertRejects(
+		() => getSocialClient(username, 'a'.repeat(128)),
+		Error,
+		'invalid entityHash',
+	)
+})

--- a/src/public/parts/shells/social/test/integration/social_on_message.test.mjs
+++ b/src/public/parts/shells/social/test/integration/social_on_message.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * social OnMessage 分发：GetReply 回退、意愿裁决、去重、care 通知。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { getReplyIdentityProbe } from '../fixtures/probes/getReplyIdentityProbe.mjs'
+import { socialOnMessageProbe } from '../fixtures/probes/socialOnMessageProbe.mjs'
+import { createTestSession, seedAgentChar } from '../harness.mjs'
+
+const GETREPLY_CHAR = 'mention_getreply_agent'
+const PROBE_CHAR = 'social_on_message_probe'
+
+const getSession = createTestSession()
+const append = await import('../../src/timeline/append.mjs')
+const dispatch = await import('../../src/dispatch.mjs')
+const inbox = await import('../../src/inbox.mjs')
+const following = await import('../../src/following.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+const { setCared } = await import('fount/public/parts/shells/chat/src/chat/lib/care.mjs')
+const { readJsonl } = await import('npm:@steve02081504/fount-p2p/dag/storage')
+
+Deno.test('dispatchSocialMessage falls back to chat.GetReply when OnMessage missing and mentioned', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	getReplyIdentityProbe.reset()
+	const { username, operator } = await getSession()
+	const agentHash = await seedAgentChar(username, GETREPLY_CHAR)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: `ping @[entity:${agentHash}]`, visibility: 'public' },
+	}, { fanout: false })
+
+	const agentTimeline = await append.readTimelineEvents(username, agentHash)
+	const reply = agentTimeline.find(ev =>
+		ev.type === 'post' && String(ev.content?.text || '').includes('mention-getreply-fallback'))
+	assert(reply, 'agent should publish GetReply reply when mentioned without OnMessage')
+	assertEquals(reply.content.replyTo?.entityHash, operator)
+
+	const identity = getReplyIdentityProbe.last
+	assert(identity, 'GetReply should capture identity fields')
+	assertEquals(identity.UserUid, operator)
+	assertEquals(identity.CharUid, agentHash)
+	assertEquals(identity.ReplyToUid, operator)
+	assertEquals(identity.chatLogUids?.[0], operator)
+})
+
+Deno.test('GetReply identity: stranger author must not become User*', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	getReplyIdentityProbe.reset()
+	const { username, operator } = await getSession()
+	const agentHash = await seedAgentChar(username, GETREPLY_CHAR)
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const stranger = encodeEntityHash('5'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, stranger, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'post', content: { text: `hey @[entity:${agentHash}]`, visibility: 'public' } },
+	])
+
+	const identity = getReplyIdentityProbe.last
+	assert(identity, 'GetReply should run for stranger @mention')
+	assertEquals(identity.UserUid, operator, 'UserUid must stay local operator')
+	assertEquals(identity.CharUid, agentHash)
+	assertEquals(identity.ReplyToUid, stranger, 'ReplyToUid is the post author')
+	assertEquals(identity.chatLogUids?.[0], stranger)
+	assert(identity.UserUid !== stranger, 'never treat stranger as User*')
+})
+
+Deno.test('OnMessage returns false → no reply published', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	socialOnMessageProbe.reset()
+	socialOnMessageProbe.returnValue = false
+	const { username, operator } = await getSession()
+	const agentHash = await seedAgentChar(username, PROBE_CHAR)
+	const before = (await append.readTimelineEvents(username, agentHash)).length
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: `hey @[entity:${agentHash}]`, visibility: 'public' },
+	}, { fanout: false })
+	const after = await append.readTimelineEvents(username, agentHash)
+	assertEquals(after.length, before, 'OnMessage false must not publish reply')
+	assert(socialOnMessageProbe.events.length >= 1, 'OnMessage still invoked')
+})
+
+Deno.test('unmentioned post still invokes OnMessage with event shape', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	socialOnMessageProbe.reset()
+	socialOnMessageProbe.returnValue = false
+	const { username, operator } = await getSession()
+	const agentHash = await seedAgentChar(username, PROBE_CHAR)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'plain post without mentions', visibility: 'public' },
+	}, { fanout: false })
+	const events = socialOnMessageProbe.events
+	assert(events.length >= 1, 'OnMessage invoked for unmentioned visible post')
+	const hit = events.find(row => row.viewerEntityHash === agentHash)
+	assert(hit, 'probe agent received event')
+	assertEquals(hit.authorEntityHash, operator)
+	assertEquals(hit.mentions?.entityHashes?.length ?? 0, 0)
+	assert('postText' in hit && 'postId' in hit)
+})
+
+Deno.test('duplicate dispatchSocialMessage only invokes OnMessage once per agent', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	socialOnMessageProbe.reset()
+	socialOnMessageProbe.returnValue = false
+	const { username, operator } = await getSession()
+	await seedAgentChar(username, PROBE_CHAR)
+	const post = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'dedup probe', visibility: 'public' },
+	}, { fanout: false })
+	const countAfterCommit = socialOnMessageProbe.events.length
+	assert(countAfterCommit >= 1)
+	await dispatch.dispatchSocialMessage(username, operator, post)
+	assertEquals(socialOnMessageProbe.events.length, countAfterCommit)
+})
+
+Deno.test('operator care author → care_post inbox row on post ingest', async () => {
+	dispatch.resetSocialDispatchDedupForTests()
+	const { username, operator } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const author = encodeEntityHash('4'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, author, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+	])
+	await following.setFollow(username, operator, author, true)
+	await setCared(username, operator, author, true)
+	await seedRemoteTimeline(username, seed, author, [
+		{ type: 'post', content: { text: 'cared author post', visibility: 'public' } },
+	])
+	const rows = await readJsonl(inbox.inboxEventsPath(username, operator))
+	const careRow = rows.find(row => row.type === 'care_post' && row.actorEntityHash === author)
+	assert(careRow, 'care_post row written for cared author')
+	assertEquals(careRow.postId?.length > 0, true)
+})
+
+Deno.test('processSocialPostNotifyRpc rejects invalid post payload', async () => {
+	const { username } = await getSession()
+	const result = await dispatch.processSocialPostNotifyRpc(username, { post: { type: 'like' } })
+	assertEquals(result.ok, false)
+})

--- a/src/public/parts/shells/social/test/integration/sync_following.test.mjs
+++ b/src/public/parts/shells/social/test/integration/sync_following.test.mjs
@@ -1,0 +1,27 @@
+/**
+ * follower 索引层：薄封装在 p2p social。
+ * following 读写集成见 integration/timeline.test.mjs。
+ * 离线 harness 下 fanout 自然为 0（P2P 关闭）；setFollow 仍走 commitTimelineEvent。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+Deno.test('setFollow uses commitTimelineEvent (fanout offline returns 0 in harness)', async () => {
+	const { username, operator } = await getSession()
+	const following = await import('../../src/following.mjs')
+	const append = await import('../../src/timeline/append.mjs')
+	const TARGET = placeholderEntityHash('e')
+
+	const before = await append.readTimelineEvents(username, operator)
+	const list = await following.setFollow(username, operator, TARGET, true)
+	assert(list.includes(TARGET))
+	const after = await append.readTimelineEvents(username, operator)
+	assertEquals(after.length, before.length + 1)
+	assertEquals(after.at(-1)?.type, 'follow')
+	await following.setFollow(username, operator, TARGET, false)
+})

--- a/src/public/parts/shells/social/test/integration/taste_http.test.mjs
+++ b/src/public/parts/shells/social/test/integration/taste_http.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * HTTP /taste 路由（launchNode 覆盖 client.username 回归）。
+ */
+/* global Deno */
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { launchNode, stopNode } from 'fount/scripts/test/node/launch.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+const bootstrapPath = join(dirname(fileURLToPath(import.meta.url)), '../node_bootstrap.mjs')
+
+Deno.test({
+	name: 'GET/PUT /taste persist privacy and manual weights',
+	sanitizeOps: false,
+	sanitizeResources: false,
+}, async () => {
+	const apiKey = `fount-social-taste-http-${Date.now().toString(36)}`
+	const node = await launchNode({
+		username: 'social-taste-http-user',
+		apiKey,
+		loadParts: ['shells/social'],
+		bootstrap: bootstrapPath,
+		p2p: false,
+		minP2pNode: true,
+	})
+	const { baseUrl } = node
+	const tasteUrl = `${baseUrl}/api/parts/shells:social/taste?fount-apikey=${encodeURIComponent(apiKey)}`
+	try {
+		const getRes = await fetch(tasteUrl)
+		const getRaw = await getRes.text()
+		assertEquals(getRes.status, 200, getRaw)
+		const initial = JSON.parse(getRaw)
+		assertEquals(initial.privacy?.publishPreferences, true)
+		assertEquals(initial.privacy?.publishReactions, true)
+		assert(Array.isArray(initial.tags))
+		assertEquals(typeof initial.clusteredAt, 'number')
+
+		const putRes = await fetch(tasteUrl, {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({
+				privacy: { publishPreferences: true, publishReactions: false },
+				tags: { tag_cats: 2, tag_dogs: -1 },
+			}),
+		})
+		const putRaw = await putRes.text()
+		assertEquals(putRes.status, 200, putRaw)
+		const updated = JSON.parse(putRaw)
+		assertEquals(updated.privacy.publishReactions, false)
+		assertEquals(updated.manual.tag_cats, 2)
+		assertEquals(updated.manual.tag_dogs, -1)
+		assertEquals(updated.tagCount, 2)
+
+		const reloadRes = await fetch(tasteUrl)
+		const reloadRaw = await reloadRes.text()
+		assertEquals(reloadRes.status, 200, reloadRaw)
+		const reloaded = JSON.parse(reloadRaw)
+		assertEquals(reloaded.privacy.publishReactions, false)
+		assertEquals(reloaded.tags.length, 2)
+
+		const clearRes = await fetch(tasteUrl, {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ tags: { tag_dogs: 0 } }),
+		})
+		const clearRaw = await clearRes.text()
+		assertEquals(clearRes.status, 200, clearRaw)
+		const cleared = JSON.parse(clearRaw)
+		assertEquals(cleared.manual.tag_dogs, undefined)
+		assertEquals(cleared.tagCount, 1)
+
+		const rebuildRes = await fetch(
+			`${baseUrl}/api/parts/shells:social/taste/rebuild?fount-apikey=${encodeURIComponent(apiKey)}`,
+			{ method: 'POST' },
+		)
+		const rebuildRaw = await rebuildRes.text()
+		assertEquals(rebuildRes.status, 200, rebuildRaw)
+		const rebuilt = JSON.parse(rebuildRaw)
+		assertEquals(typeof rebuilt.clusteredAt, 'number')
+		assertEquals(typeof rebuilt.tagCount, 'number')
+	}
+	finally {
+		await stopNode(node)
+	}
+})

--- a/src/public/parts/shells/social/test/integration/taste_reactions.test.mjs
+++ b/src/public/parts/shells/social/test/integration/taste_reactions.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * dislike / reaction_index / listReactionEvents 集成测试。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const materialize = await import('../../src/timeline/materialize.mjs')
+const reactionIndex = await import('../../src/federation/reaction/index.mjs')
+
+const TARGET = placeholderEntityHash('a')
+const POST_ID = 'd'.repeat(64)
+const REACTOR_B = placeholderEntityHash('b')
+const REACTOR_C = placeholderEntityHash('c')
+
+Deno.test('dislike then undislike via reducer', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'dislike',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.dislikes.length, 1)
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'undislike',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.dislikes.length, 0)
+})
+
+Deno.test('like and dislike are mutually exclusive in materialized view', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'like',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.likes.length, 1)
+	assertEquals(view.dislikes.length, 0)
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'dislike',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.likes.length, 0)
+	assertEquals(view.dislikes.length, 1)
+})
+
+Deno.test('reaction_index projection after like', async () => {
+	const { username, operator } = await getSession()
+	const likeEvent = await append.commitTimelineEvent(username, operator, {
+		type: 'like',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+
+	const summary = await reactionIndex.summarizeReactions(username, TARGET, POST_ID)
+	assert(summary.likes.includes(operator.toLowerCase()))
+	assert(!summary.dislikes.includes(operator.toLowerCase()))
+
+	const events = await reactionIndex.listReactionEvents(username, TARGET, POST_ID)
+	assertEquals(events.length, 1)
+	assertEquals(events[0].id, likeEvent.id)
+})
+
+Deno.test('listReactionEvents paginates by afterReactor', async () => {
+	const { username, operator } = await getSession()
+	const reactors = [operator, REACTOR_B, REACTOR_C].map(h => h.toLowerCase()).sort()
+	for (const reactor of reactors) 
+		await reactionIndex.upsertReaction(username, TARGET, POST_ID, reactor, {
+			kind: 'like',
+			event: { id: `evt-${reactor}`, type: 'like', content: { targetEntityHash: TARGET, targetPostId: POST_ID } },
+		})
+	
+
+	const first = await reactionIndex.listReactionEvents(username, TARGET, POST_ID, null, 2)
+	assertEquals(first.length, 2)
+	assertEquals(first[0].id, `evt-${reactors[0]}`)
+
+	const second = await reactionIndex.listReactionEvents(username, TARGET, POST_ID, reactors[1], 2)
+	assertEquals(second.length, 1)
+	assertEquals(second[0].id, `evt-${reactors[2]}`)
+})
+
+Deno.test('private publishReactions skips reaction_index projection', async () => {
+	const { username, operator } = await getSession()
+	const tasteStore = await import('../../src/taste/store.mjs')
+	await tasteStore.saveTaste(username, operator, {
+		...tasteStore.emptyTasteStore(),
+		privacy: { publishPreferences: true, publishReactions: false },
+	})
+	await append.commitTimelineEvent(username, operator, {
+		type: 'like',
+		content: { targetEntityHash: TARGET, targetPostId: POST_ID },
+	}, { fanout: false })
+	const summary = await reactionIndex.summarizeReactions(username, TARGET, POST_ID)
+	assert(!summary.likes.includes(operator.toLowerCase()))
+})
+
+Deno.test('tag_name event materializes into view.tagNames', async () => {
+	const { username, operator } = await getSession()
+	const tagHash = placeholderEntityHash('t')
+	await append.commitTimelineEvent(username, operator, {
+		type: 'tag_name',
+		content: { tagHash, locale: 'zh-CN', label: '测试标签' },
+	}, { fanout: false })
+	const view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.tagNames?.[tagHash.toLowerCase()]?.['zh-CN'], '测试标签')
+})
+
+Deno.test('normalizeReactionTarget rejects path traversal postId', () => {
+	assertEquals(reactionIndex.normalizeReactionTarget(TARGET, '../etc/passwd'), null)
+	assertEquals(reactionIndex.normalizeReactionTarget(TARGET, POST_ID)?.postId, POST_ID)
+})

--- a/src/public/parts/shells/social/test/integration/timeline_ingress.test.mjs
+++ b/src/public/parts/shells/social/test/integration/timeline_ingress.test.mjs
@@ -1,0 +1,341 @@
+/**
+ * 联邦入站边界（untrusted ingress）。
+ * ingestRemoteTimelineEvent 的校验：类型白名单 / eventId 自洽 / 验签 / 去重 / blocklist；
+ * canonicalizeSignedTimelineEvent + validateRemoteEventShape 的形状校验；
+ * 以及 owner↔author 绑定边界探测。
+ */
+/* global Deno */
+import { Buffer } from 'node:buffer'
+import fs from 'node:fs'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { makeRemoteSignedEvent, randomSeed } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const sync = await import('../../src/timeline/sync.mjs')
+const append = await import('../../src/timeline/append.mjs')
+const canon = await import('../../src/timeline/canonicalizeEvent.mjs')
+const { addDenylistEntry, loadDenylist, saveDenylist } = await import('npm:@steve02081504/fount-p2p/node/denylist')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash, entityHashFromRecoveryPubKeyHex } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+const { getNodeHash } = await import('npm:@steve02081504/fount-p2p/node/identity')
+const {
+	ensureAgentEntityIdentity,
+	getEntitySecretKey,
+	getOperatorSecretKey,
+	resolveOperatorEntityHashForUser,
+} = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+const { getUserDictionary } = await import('fount/server/auth/index.mjs')
+const { ensureEntitySocialReady } = await import('../../src/lib/bootstrap.mjs')
+
+/**
+ * 为给定种子构造一个 user 风格的 owner entityHash（nodeHash 任意 + sender subjectHash）。
+ * @param {Uint8Array} seed 32 字节种子
+ * @param {string} [nodeHashHex] owner nodeHash（默认任意值）
+ * @returns {string} 128 位 owner entityHash
+ */
+function ownerForSeed(seed, nodeHashHex = 'd'.repeat(64)) {
+	const sender = pubKeyHash(publicKeyFromSeed(seed))
+	return encodeEntityHash(nodeHashHex, sender)
+}
+
+Deno.test('valid remote post is ingested and visible', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post',
+		content: { text: 'remote hello', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), true)
+	const events = await append.readTimelineEvents(username, owner)
+	assert(events.some(e => e.id === event.id))
+})
+
+Deno.test('dedup: re-ingest same event returns true (idempotent)', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post', content: { text: 'dup', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), true)
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), true)
+})
+
+Deno.test('non-whitelisted event type is rejected', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'channel_key_rotate', content: { x: 1 },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), false)
+})
+
+Deno.test('eventId tampering is rejected', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post', content: { text: 'tamper id', visibility: 'public' },
+	})
+	const tampered = { ...event, content: { text: 'mutated', visibility: 'public' } }
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, tampered), false)
+})
+
+Deno.test('signature tampering is rejected', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post', content: { text: 'bad sig', visibility: 'public' },
+	})
+	const flipped = event.signature.startsWith('0') ? `1${event.signature.slice(1)}` : `0${event.signature.slice(1)}`
+	const tampered = { ...event, signature: flipped }
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, tampered), false)
+})
+
+Deno.test('senderPubKey not matching sender hash is rejected', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post', content: { text: 'pk mismatch', visibility: 'public' },
+	})
+	const otherPub = Buffer.from(publicKeyFromSeed(randomSeed())).toString('hex')
+	const tampered = { ...event, senderPubKey: otherPub }
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, tampered), false)
+})
+
+Deno.test('blocked sender (pubKeyHash) is rejected', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed)
+	const sender = pubKeyHash(publicKeyFromSeed(seed))
+	const blocklistBefore = loadDenylist()
+	await addDenylistEntry({ scope: 'subject', value: sender })
+	try {
+		const event = await makeRemoteSignedEvent(seed, owner, {
+			type: 'post', content: { text: 'blocked', visibility: 'public' },
+		})
+		assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), false)
+	}
+	finally {
+		saveDenylist(blocklistBefore)
+	}
+})
+
+Deno.test('validateRemoteEventShape rejects malformed events', () => {
+	const base = {
+		type: 'post', id: 'a'.repeat(64), prev_event_ids: [], sender: 'b'.repeat(64),
+	}
+	// good shape passes
+	canon.canonicalizeSignedTimelineEvent({ ...base, content: {}, groupId: 'g', hlc: { wall: 1 } })
+
+	for (const bad of [
+		{ ...base, id: 'xyz' },
+		{ ...base, prev_event_ids: 'nope' },
+		{ ...base, sender: 'short' },
+		{ ...base, type: '' },
+	]) {
+		let threw = false
+		try { canon.canonicalizeSignedTimelineEvent(bad) }
+		catch { threw = true }
+		assert(threw, `expected throw for ${JSON.stringify(bad).slice(0, 40)}`)
+	}
+})
+
+// ---- 信任边界 ----
+
+// 回归：groupId 必须与归档的 owner 时间线一致（已修复）。
+Deno.test('groupId mismatching owner timeline is rejected (regression for fix)', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const realOwner = ownerForSeed(seed)
+	// 事件 groupId 绑定 realOwner，却塞进另一个 owner 的路径 → 应拒绝
+	const otherOwner = ownerForSeed(seed, getNodeHash())
+	const event = await makeRemoteSignedEvent(seed, realOwner, {
+		type: 'post', content: { text: 'group mismatch', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, otherOwner, event), false)
+})
+
+// ---- 写入授权（已修复：sender 必须有权写入目标时间线） ----
+
+// 回归（核心攻击面）：攻击者用自有 key 自洽签名、把 groupId 伪造成受害者 user 时间线，
+// 试图把“伪造帖”注入受害者时间线 → 必须被拒绝（sender !== 受害者 subjectHash）。
+Deno.test('foreign-key injection into a user-style owner timeline is rejected', async () => {
+	const { username } = await getSession()
+	const attackerSeed = randomSeed()
+	// 受害者：user 型 owner（subjectHash 即其本人 pubKeyHash，与攻击者无关）
+	const victimSubject = 'f'.repeat(64)
+	const victimOwner = encodeEntityHash('e'.repeat(64), victimSubject)
+	const attackerSender = pubKeyHash(publicKeyFromSeed(attackerSeed))
+	assert(attackerSender !== victimSubject, 'sanity: attacker sender differs from victim subjectHash')
+	// 攻击者把 groupId 设成受害者时间线（自洽签名可绕过 groupId 绑定），用自己的 key 签名
+	const event = await makeRemoteSignedEvent(attackerSeed, victimOwner, {
+		type: 'post', content: { text: 'INJECTED into victim timeline', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, victimOwner, event), false)
+	// 受害者时间线不得出现伪造帖
+	const events = await append.readTimelineEvents(username, victimOwner)
+	assert(!events.some(e => e.id === event.id), 'forged event must not be archived')
+})
+
+// user 型正例：sender === subjectHash 时合法写入被接受（与攻击例对照）。
+Deno.test('legit user-owned write (sender === subjectHash) is accepted', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const owner = ownerForSeed(seed) // subjectHash === pubKeyHash(seed) === sender
+	const event = await makeRemoteSignedEvent(seed, owner, {
+		type: 'post', content: { text: 'legit owner post', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, owner, event), true)
+})
+
+// agent 型正例：本机 agent 身份 + social_meta 创世后，用 agent 活跃钥签名写入。
+Deno.test('agent-key-signed write to a local agent timeline is accepted', async () => {
+	const { username } = await getSession()
+	const charPartName = 'social-test-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const agentSecret = new Uint8Array(Buffer.from(await getEntitySecretKey(username, row.entityHash), 'hex'))
+	const event = await makeRemoteSignedEvent(agentSecret, row.entityHash, {
+		type: 'post', charPartName, content: { text: 'agent post by agent key', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, row.entityHash, event), true)
+})
+
+// agent 型攻击例：陌生 key 代签本机 agent 实体 → 拒绝。
+Deno.test('foreign-key injection into a locally-hosted agent timeline is rejected', async () => {
+	const { username } = await getSession()
+	const charPartName = 'social-test-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const attackerSeed = randomSeed()
+	const event = await makeRemoteSignedEvent(attackerSeed, row.entityHash, {
+		type: 'post', charPartName, content: { text: 'INJECTED agent post', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, row.entityHash, event), false)
+})
+
+// 远端节点 agent：先 ingest recovery 签创世链，再以活跃钥发帖 → 引导成功。
+Deno.test('remote agent timeline bootstraps via recovery genesis then accepts active-key post', async () => {
+	const { username } = await getSession()
+	const remoteNodeHash = '7'.repeat(64)
+	const recoverySeed = randomSeed()
+	const activeSeed = randomSeed()
+	const recoveryPub = Buffer.from(publicKeyFromSeed(recoverySeed)).toString('hex')
+	const activePub = Buffer.from(publicKeyFromSeed(activeSeed)).toString('hex')
+	const remoteAgentOwner = entityHashFromRecoveryPubKeyHex(remoteNodeHash, recoveryPub)
+
+	const socialMeta = await makeRemoteSignedEvent(recoverySeed, remoteAgentOwner, {
+		type: 'social_meta',
+		content: {
+			hideFromDiscovery: false,
+			createdAt: Date.now(),
+			recoveryPubKeyHex: recoveryPub,
+		},
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, socialMeta), true)
+
+	const rotate = await makeRemoteSignedEvent(recoverySeed, remoteAgentOwner, {
+		type: 'entity_key_rotate',
+		prev_event_ids: [socialMeta.id],
+		content: {
+			generation: 0,
+			activePubKeyHex: activePub,
+			prevGeneration: null,
+		},
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, rotate), true)
+
+	const post = await makeRemoteSignedEvent(activeSeed, remoteAgentOwner, {
+		type: 'post',
+		prev_event_ids: [rotate.id],
+		content: { text: 'remote agent post', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, post), true)
+	const events = await append.readTimelineEvents(username, remoteAgentOwner)
+	assert(events.some(e => e.id === post.id))
+})
+
+// 远端 agent 已引导后，陌生钥注入仍拒绝。
+Deno.test('foreign-key injection into a bootstrapped remote agent timeline is rejected', async () => {
+	const { username } = await getSession()
+	const remoteNodeHash = '8'.repeat(64)
+	const recoverySeed = randomSeed()
+	const activeSeed = randomSeed()
+	const recoveryPub = Buffer.from(publicKeyFromSeed(recoverySeed)).toString('hex')
+	const activePub = Buffer.from(publicKeyFromSeed(activeSeed)).toString('hex')
+	const remoteAgentOwner = entityHashFromRecoveryPubKeyHex(remoteNodeHash, recoveryPub)
+
+	const socialMeta = await makeRemoteSignedEvent(recoverySeed, remoteAgentOwner, {
+		type: 'social_meta',
+		content: {
+			hideFromDiscovery: false,
+			createdAt: Date.now(),
+			recoveryPubKeyHex: recoveryPub,
+		},
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, socialMeta), true)
+	const rotate = await makeRemoteSignedEvent(recoverySeed, remoteAgentOwner, {
+		type: 'entity_key_rotate',
+		prev_event_ids: [socialMeta.id],
+		content: { generation: 0, activePubKeyHex: activePub, prevGeneration: null },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, rotate), true)
+
+	const forged = await makeRemoteSignedEvent(randomSeed(), remoteAgentOwner, {
+		type: 'post',
+		prev_event_ids: [rotate.id],
+		content: { text: 'INJECTED remote agent post', visibility: 'public' },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, remoteAgentOwner, forged), false)
+	const events = await append.readTimelineEvents(username, remoteAgentOwner)
+	assert(!events.some(e => e.id === forged.id), 'forged event must not be archived')
+})
+
+// owner 活跃钥签 post_delete 写入本机 agent 时间线 → 接受（联邦复核路径）。
+Deno.test('owner-signed post_delete on local agent timeline is accepted', async () => {
+	const { username } = await getSession()
+	const charPartName = 'social-owner-delete-agent'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	const operator = await resolveOperatorEntityHashForUser(username)
+	await ensureEntitySocialReady(username, operator)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const post = await append.appendTimelineEvent(username, row.entityHash, {
+		type: 'post',
+		charPartName,
+		content: { text: 'agent post to delete', visibility: 'public' },
+	})
+	const ownerSecret = new Uint8Array(Buffer.from(await getOperatorSecretKey(username), 'hex'))
+	const event = await makeRemoteSignedEvent(ownerSecret, row.entityHash, {
+		type: 'post_delete',
+		content: { targetPostId: post.id },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, row.entityHash, event), true)
+})
+
+// 陌生钥签 post_delete → 拒绝。
+Deno.test('stranger-signed post_delete on local agent timeline is rejected', async () => {
+	const { username } = await getSession()
+	const charPartName = 'social-owner-delete-deny'
+	fs.mkdirSync(`${getUserDictionary(username)}/chars/${charPartName}`, { recursive: true })
+	const row = await ensureAgentEntityIdentity(username, charPartName)
+	const operator = await resolveOperatorEntityHashForUser(username)
+	await ensureEntitySocialReady(username, operator)
+	await ensureEntitySocialReady(username, row.entityHash)
+	const event = await makeRemoteSignedEvent(randomSeed(), row.entityHash, {
+		type: 'post_delete',
+		content: { targetPostId: 'a'.repeat(64) },
+	})
+	assertEquals(await sync.ingestRemoteTimelineEvent(username, row.entityHash, event), false)
+})

--- a/src/public/parts/shells/social/test/integration/timeline_materialize.test.mjs
+++ b/src/public/parts/shells/social/test/integration/timeline_materialize.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * 时间线核心写盘链路。
+ * append / materialize / follow / unfollow / profile 读写 / post / like / repost / social_meta。
+ */
+/* global Deno */
+import { placeholderEntityHash } from 'fount/scripts/test/fixtures.mjs'
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const append = await import('../../src/timeline/append.mjs')
+const materialize = await import('../../src/timeline/materialize.mjs')
+const following = await import('../../src/following.mjs')
+const socialMeta = await import('../../src/socialMeta.mjs')
+const entityProfile = await import('../../src/lib/entityProfile.mjs')
+const { resolveOperatorEntityHashForUser } = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+
+const TARGET_A = placeholderEntityHash('a')
+const TARGET_B = placeholderEntityHash('b')
+const POST_ID_HEX = 'c'.repeat(64)
+
+Deno.test('bootstrap created operator timeline with social_meta genesis', async () => {
+	const { username, operator } = await getSession()
+	const view = await materialize.getTimelineMaterialized(username, operator)
+	assert(view.socialMeta && typeof view.socialMeta === 'object')
+	assertEquals(view.posts.length, 0)
+})
+
+Deno.test('canWriteTimeline true for operator, false for foreign entity', async () => {
+	const { username, operator } = await getSession()
+	assertEquals(await append.canWriteTimeline(username, operator), true)
+	assertEquals(await append.canWriteTimeline(username, TARGET_A), false)
+})
+
+Deno.test('post → materialize roundtrip', async () => {
+	const { username, operator } = await getSession()
+	const signed = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'hello world', visibility: 'public', locale: 'zh-CN' },
+	}, { fanout: false })
+	assert(signed.id && signed.signature && signed.senderPubKey)
+	const view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.posts.length, 1)
+	assertEquals(view.posts[0].content.text, 'hello world')
+	assertEquals(view.postById[signed.id].id, signed.id)
+})
+
+Deno.test('follow then unfollow reflected in materialized following', async () => {
+	const { username, operator } = await getSession()
+	const afterFollow = await following.setFollow(username, operator, TARGET_A, true)
+	assert(afterFollow.includes(TARGET_A))
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assert(view.following.includes(TARGET_A))
+
+	const reFollow = await following.setFollow(username, operator, TARGET_A, true)
+	assertEquals(reFollow.filter(h => h === TARGET_A).length, 1)
+
+	const afterUnfollow = await following.setFollow(username, operator, TARGET_A, false)
+	assert(!afterUnfollow.includes(TARGET_A))
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assert(!view.following.includes(TARGET_A))
+})
+
+Deno.test('loadFollowing reads from materialized timeline (no following.json)', async () => {
+	const { username, operator } = await getSession()
+	await following.setFollow(username, operator, TARGET_B, true)
+	const { following: list } = await following.loadFollowing(username)
+	assert(list.includes(TARGET_B))
+	await following.setFollow(username, operator, TARGET_B, false)
+})
+
+Deno.test('like then unlike via reducer', async () => {
+	const { username, operator } = await getSession()
+	await append.commitTimelineEvent(username, operator, {
+		type: 'like',
+		content: { targetEntityHash: TARGET_A, targetPostId: POST_ID_HEX },
+	}, { fanout: false })
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.likes.length, 1)
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'unlike',
+		content: { targetEntityHash: TARGET_A, targetPostId: POST_ID_HEX },
+	}, { fanout: false })
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assertEquals(view.likes.length, 0)
+})
+
+Deno.test('post_delete removes post from materialized view', async () => {
+	const { username, operator } = await getSession()
+	const signed = await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: { text: 'to be deleted', visibility: 'public' },
+	}, { fanout: false })
+	let view = await materialize.getTimelineMaterialized(username, operator)
+	assert(view.postById[signed.id])
+
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post_delete',
+		content: { targetPostId: signed.id },
+	}, { fanout: false })
+	view = await materialize.getTimelineMaterialized(username, operator)
+	assert(!view.postById[signed.id], 'deleted post should be gone')
+})
+
+Deno.test('updateSocialMeta patches hideFromDiscovery', async () => {
+	const { username, operator } = await getSession()
+	const meta = await socialMeta.updateSocialMeta(username, operator, {
+		hideFromDiscovery: true,
+	})
+	assertEquals(meta.hideFromDiscovery, true)
+	await socialMeta.updateSocialMeta(username, operator, { hideFromDiscovery: false })
+})
+
+Deno.test('getEntityProfile returns profile for operator', async () => {
+	const { username, operator } = await getSession()
+	const profile = await entityProfile.getEntityProfile(username, operator)
+	assert(profile, 'operator profile should auto-create')
+})
+
+Deno.test('assertWritableTimeline rejects foreign entity', async () => {
+	const { username } = await getSession()
+	let threw = false
+	try {
+		await append.appendTimelineEvent(username, TARGET_A, { type: 'post', content: { text: 'x' } })
+	}
+	catch { threw = true }
+	assert(threw, 'should reject write to foreign timeline')
+})
+
+Deno.test('operator entityHash stable across resolves', async () => {
+	const { username, operator } = await getSession()
+	assertEquals(await resolveOperatorEntityHashForUser(username), operator)
+})

--- a/src/public/parts/shells/social/test/integration/timeline_retention.test.mjs
+++ b/src/public/parts/shells/social/test/integration/timeline_retention.test.mjs
@@ -1,0 +1,30 @@
+/**
+ * retention 与连通分支不变量。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { randomSeed, seedRemoteTimeline } from '../federation/remote_timeline.mjs'
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+const materialize = await import('../../src/timeline/materialize.mjs')
+const { pubKeyHash, publicKeyFromSeed } = await import('npm:@steve02081504/fount-p2p/crypto')
+const { encodeEntityHash } = await import('npm:@steve02081504/fount-p2p/core/entity_id')
+
+Deno.test('chained ingest survives retention across repeated materialize', async () => {
+	const { username } = await getSession()
+	const seed = randomSeed()
+	const subject = pubKeyHash(publicKeyFromSeed(seed))
+	const remoteOwner = encodeEntityHash('9'.repeat(64), subject)
+	await seedRemoteTimeline(username, seed, remoteOwner, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{ type: 'post', content: { text: 'remote authored', visibility: 'public' } },
+		{ type: 'post', content: { text: 'second post', visibility: 'public' } },
+	])
+
+	const v1 = await materialize.getTimelineMaterialized(username, remoteOwner)
+	const v2 = await materialize.getTimelineMaterialized(username, remoteOwner)
+	assertEquals(v1.posts.length, 2, 'first materialize sees both posts')
+	assertEquals(v2.posts.length, 2, 'repeated materialize keeps connected branch (no retention loss)')
+})

--- a/src/public/parts/shells/social/test/integration/vault_follow_approve.test.mjs
+++ b/src/public/parts/shells/social/test/integration/vault_follow_approve.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * vault 加密帖与 follow_approve。
+ */
+/* global Deno */
+import { Buffer } from 'node:buffer'
+import { randomUUID } from 'node:crypto'
+
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession()
+
+const vault = await import('../../src/vault_crypto/vault.mjs')
+const followApprove = await import('../../src/vault_crypto/followApprove.mjs')
+const append = await import('../../src/timeline/append.mjs')
+const fedExport = await import('../../src/timeline/federationExport.mjs')
+const { publicKeyFromSeed, pubKeyHash } = await import('npm:@steve02081504/fount-p2p/crypto')
+
+Deno.test('maybeEncryptPostContent roundtrips via maybeDecryptPostContent', async () => {
+	const { username, operator } = await getSession()
+	const postKeyId = randomUUID()
+	const plain = { text: 'vault secret', visibility: 'followers', locale: 'zh-CN' }
+	const enc = await vault.maybeEncryptPostContent(username, operator, postKeyId, plain, 'followers')
+	assertEquals(enc.scheme, 'gsh')
+	const dec = await vault.maybeDecryptPostContent(username, operator, enc)
+	assertEquals(dec.text, 'vault secret')
+})
+
+Deno.test('maybeDecryptPostContent passes through public plaintext content', async () => {
+	const { username, operator } = await getSession()
+	const plain = { text: 'public hello', visibility: 'public', locale: 'zh-CN' }
+	const dec = await vault.maybeDecryptPostContent(username, operator, plain)
+	assertEquals(dec, plain)
+})
+
+Deno.test('buildFollowApprovePayload + autoApproveFollower emits follow_approve', async () => {
+	const { username, operator } = await getSession()
+	const seed = new Uint8Array(32).fill(7)
+	const followerPubKeyHex = Buffer.from(publicKeyFromSeed(seed)).toString('hex')
+	const payload = await vault.buildFollowApprovePayload(username, operator, followerPubKeyHex)
+	assert(payload.targetPubKeyHex)
+	assert(payload.encrypted_H)
+	assert(payload.vaultGroupId)
+
+	const ev = await followApprove.autoApproveFollower(username, operator, followerPubKeyHex)
+	assertEquals(ev.type, 'follow_approve')
+	assertEquals(ev.content.targetPubKeyHex, followerPubKeyHex)
+})
+
+Deno.test('encrypted followers post hidden from anonymous federation pull', async () => {
+	const { username, operator } = await getSession()
+	const postKeyId = randomUUID()
+	const enc = await vault.maybeEncryptPostContent(
+		username, operator, postKeyId,
+		{ text: 'cipher body', visibility: 'followers' },
+		'followers',
+	)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: enc,
+	}, { fanout: false })
+
+	const all = await append.readTimelineEvents(username, operator)
+	const exported = await fedExport.filterEventsForFederatedPull(username, operator, all, null)
+	const cipherPost = all.find(e => e.type === 'post' && e.content?.scheme === 'gsh')
+	assert(cipherPost)
+	assertEquals(cipherPost.content?.visibility, 'followers')
+	const exportedPost = exported.find(e => e.id === cipherPost.id)
+	assert(!exportedPost, 'followers-only encrypted post must not export to anonymous requester')
+})
+
+Deno.test('encrypted followers post exports ciphertext to owner pull', async () => {
+	const { username, operator } = await getSession()
+	const postKeyId = randomUUID()
+	const enc = await vault.maybeEncryptPostContent(
+		username, operator, postKeyId,
+		{ text: 'owner pull cipher', visibility: 'followers' },
+		'followers',
+	)
+	await append.commitTimelineEvent(username, operator, {
+		type: 'post',
+		content: enc,
+	}, { fanout: false })
+
+	const all = await append.readTimelineEvents(username, operator)
+	const { getNodeHash } = await import('npm:@steve02081504/fount-p2p/node/identity')
+	const exported = await fedExport.filterEventsForFederatedPull(username, operator, all, getNodeHash())
+	const cipherPost = all.find(e => e.type === 'post' && e.content?.postKeyId === postKeyId)
+	assert(cipherPost)
+	const exportedPost = exported.find(e => e.id === cipherPost.id)
+	assert(exportedPost, 'owner pull should receive followers ciphertext envelope')
+	assertEquals(exportedPost.content?.scheme, 'gsh')
+	assertEquals(exportedPost.content?.visibility, 'followers')
+	assert(!exportedPost.content?.text, 'export must not leak plaintext')
+})

--- a/src/public/parts/shells/social/test/integration/visibility_albums.test.mjs
+++ b/src/public/parts/shells/social/test/integration/visibility_albums.test.mjs
@@ -1,0 +1,126 @@
+/**
+ * 可见性扩展 + 相册链接合集集成测试。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { createTestSession } from '../harness.mjs'
+
+const getSession = createTestSession({ username: 'social-vis-album-user' })
+
+Deno.test('private post encrypts with pkw and owner can decrypt', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	const post = await client.post({ text: 'only me', visibility: 'private' })
+	const view = await import('../../src/timeline/materialize.mjs').then(m => m.getTimelineMaterialized(username, operator))
+	const row = view.postById[post.event.id]
+	assertEquals(row.content.scheme, 'pkw')
+	assertEquals(row.content.visibility, 'private')
+	const got = await client.getPost(operator, post.event.id)
+	assertEquals(got.content?.text || got.event?.content?.text, 'only me')
+})
+
+Deno.test('album create / addPost derives post visibility and feed albums field', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	const { albumId } = await client.albums.create({
+		name: 'Friends',
+		visibility: 'followers',
+	})
+	const post = await client.post({
+		text: 'in album',
+		visibility: 'public',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/a.jpg' }],
+		albumIds: [albumId],
+	})
+	const view = await import('../../src/timeline/materialize.mjs').then(m => m.getTimelineMaterialized(username, operator))
+	assertEquals(view.albums[albumId].postIds.includes(post.event.id), true)
+	const plain = await import('../../src/vault_crypto/vault.mjs')
+		.then(m => m.maybeDecryptPostContent(username, operator, view.postById[post.event.id].content, operator))
+	assertEquals(plain?.visibility, 'followers')
+
+	const { items } = await import('../../src/feed/home.mjs').then(m => m.buildProfileFeedItems(username, operator))
+	const item = items.find(row => row.postId === post.event.id)
+	assert(item)
+	assert(item.albums?.some(album => album.albumId === albumId))
+})
+
+Deno.test('album update tightens member post visibility via reconcile', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	const { albumId } = await client.albums.create({ name: 'Tight', visibility: 'public' })
+	const post = await client.post({
+		text: 'will tighten',
+		visibility: 'public',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/b.jpg' }],
+		albumIds: [albumId],
+	})
+	await client.albums.update(albumId, { visibility: 'private' })
+	const view = await import('../../src/timeline/materialize.mjs').then(m => m.getTimelineMaterialized(username, operator))
+	const row = view.postById[post.event.id]
+	assertEquals(row.content.visibility, 'private')
+	assertEquals(row.content.scheme, 'pkw')
+})
+
+Deno.test('album delete links keeps posts; deletePosts removes them', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	const a = await client.albums.create({ name: 'KeepPosts', visibility: 'public' })
+	const postA = await client.post({
+		text: 'keep me',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/c.jpg' }],
+		albumIds: [a.albumId],
+	})
+	await client.albums.delete(a.albumId, { deletePosts: false })
+	let view = await import('../../src/timeline/materialize.mjs').then(m => m.getTimelineMaterialized(username, operator))
+	assert(!view.albums[a.albumId] || view.albums[a.albumId]?.virtual)
+	assert(view.postById[postA.event.id])
+
+	const b = await client.albums.create({ name: 'Nuke', visibility: 'public' })
+	const postB = await client.post({
+		text: 'delete me',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/d.jpg' }],
+		albumIds: [b.albumId],
+	})
+	await client.albums.delete(b.albumId, { deletePosts: true })
+	view = await import('../../src/timeline/materialize.mjs').then(m => m.getTimelineMaterialized(username, operator))
+	assert(!view.postById[postB.event.id])
+})
+
+Deno.test('album list exposes coverMediaRef for non-spoiler image', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	const { albumId } = await client.albums.create({ name: 'CoverAlbum', visibility: 'public' })
+	await client.post({
+		text: 'spoiler first',
+		visibility: 'public',
+		contentWarning: 'spoiler',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/spoiler.jpg', mimeType: 'image/jpeg' }],
+		albumIds: [albumId],
+	})
+	await client.post({
+		text: 'clean cover',
+		visibility: 'public',
+		mediaRefs: [{ kind: 'image', url: 'https://example.com/cover.jpg', mimeType: 'image/jpeg' }],
+		albumIds: [albumId],
+	})
+	const albums = await client.albums.list(operator)
+	const album = albums.find(row => row.albumId === albumId)
+	assert(album, 'album listed')
+	assertEquals(album.coverMediaRef?.url, 'https://example.com/cover.jpg')
+})
+
+Deno.test('unlisted posts are not public-discoverable', async () => {
+	const { username, operator } = await getSession()
+	const { getSocialClient } = await import('../../src/api/client/index.mjs')
+	const client = await getSocialClient(username, operator)
+	await client.post({ text: 'unlisted secret discover', visibility: 'unlisted' })
+	const { discoverPosts } = await import('../../src/discover/local.mjs')
+	const { posts } = await discoverPosts(username, { n: 50 })
+	assert(!posts.some(row => String(row.textSnippet || row.text || '').includes('unlisted secret discover')))
+})

--- a/src/public/parts/shells/social/test/live/run.mjs
+++ b/src/public/parts/shells/social/test/live/run.mjs
@@ -1,0 +1,64 @@
+/**
+ * Social live 测试 driver：按 suite 自启 fount 节点并运行 scripts/ 下对应脚本。
+ */
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { REPO_ROOT } from 'fount/scripts/test/core/repo_root.mjs'
+import { denoLiveRun } from 'fount/scripts/test/live/deno_run.mjs'
+import { runLiveSuiteCli } from 'fount/scripts/test/live/runner.mjs'
+
+const liveDir = dirname(fileURLToPath(import.meta.url))
+const socialBootstrap = join(liveDir, '../node_bootstrap.mjs')
+const scriptsDir = join(liveDir, 'scripts')
+
+/** Social live 测试 suite 表。 */
+/** @type {Record<string, { fed?: boolean, run: string[], node?: object }>} */
+const suites = {
+	smoke_social: {
+		run: denoLiveRun(join(scriptsDir, 'smoke_social.mjs')),
+		node: { loadParts: ['shells/social', 'shells/chat'], p2p: false, minP2pNode: true },
+	},
+	e2e_single: {
+		run: denoLiveRun(join(scriptsDir, 'e2e_single.mjs')),
+		node: { loadParts: ['shells/social', 'shells/chat'] },
+	},
+	cross_shell_emoji: {
+		fed: true,
+		run: denoLiveRun(join(scriptsDir, 'cross_shell_emoji.mjs')),
+		node: { loadParts: ['shells/social', 'shells/chat'] },
+	},
+	ws: {
+		run: denoLiveRun(join(scriptsDir, 'ws.mjs')),
+		node: { loadParts: ['shells/social', 'shells/chat'] },
+	},
+}
+
+await runLiveSuiteCli({
+	suites,
+	repoRoot: REPO_ROOT,
+	defaultSuite: 'e2e_single',
+	/**
+	 * @param {number} index 0-based
+	 * @param {{ port: number, releasePort: () => Promise<void> }} context 已分配端口
+	 * @returns {object} launchNode 选项
+	 */
+	buildNode: (index, { port, releasePort }) => index === 0
+		? {
+			port,
+			username: 'CI-user',
+			apiKey: process.env.FOUNT_TEST_NODE_1_KEY || `fount-ci-social-key-${port}`,
+			p2p: true,
+			bootstrap: socialBootstrap,
+			releasePort,
+		}
+		: {
+			port,
+			username: 'nodeb',
+			apiKey: process.env.FOUNT_TEST_NODE_2_KEY || `nodeb-fed-test-key-${port}`,
+			p2p: true,
+			bootstrap: socialBootstrap,
+			releasePort,
+		},
+})

--- a/src/public/parts/shells/social/test/live/scripts/cross_shell_emoji.mjs
+++ b/src/public/parts/shells/social/test/live/scripts/cross_shell_emoji.mjs
@@ -1,0 +1,149 @@
+import { formatEmojiToken } from 'fount/public/parts/shells/chat/public/shared/inlineTokenSyntax.mjs'
+import { ms } from 'fount/scripts/ms.mjs'
+import {
+	Api,
+	ApiMultipart,
+	ClearFedGroup,
+	completeLiveScript,
+	FedA,
+	FedB,
+	FedPngBytes,
+	P2pApi,
+	pollUntil,
+	RootApi,
+	ShellApi,
+	testCase,
+	WarmupFedNodeLinks,
+	WriteFedSummary,
+} from 'fount/scripts/test/live/federation/common.mjs'
+import { sleep } from 'fount/scripts/test/live/http.mjs'
+
+const groupTitle = 'FedCrossShell'
+let gid = null
+let cid = null
+let emojiId = null
+let emojiContentHash = null
+let postId = null
+let emojiToken = null
+/** @type {unknown[]} */
+let postMediaRefs = []
+let postText = null
+
+console.log('=== cross_shell_emoji: registry smoke ===')
+await testCase('Chat emoji registry reachable', async () => {
+	const r = await RootApi(FedA, 'GET', '/api/registries/emoji')
+	return r.status === 200 && (r.json?.filter(row => String(row.path).includes('providers/emoji')).length ?? 0) >= 1
+})
+
+await testCase('markdown_extensions registry reachable', async () => {
+	const r = await RootApi(FedA, 'GET', '/api/registries/markdown_extensions')
+	return r.status === 200 && (r.json?.length ?? 0) >= 1
+})
+
+console.log('\n=== Setup: B follows A (TrustGraph CAS fanout for non-member emoji) ===')
+await testCase('B follows A operator entity', async () => {
+	const viewerA = (await ShellApi(FedA, 'chat', 'GET', '/viewer')).json.viewerEntityHash
+	if (!viewerA) throw new Error('no viewerEntityHash on A')
+	const r = await ShellApi(FedB, 'social', 'POST', '/relationships/follow', { entityHash: viewerA, follow: true })
+	return r.status === 200
+})
+
+console.log('\n=== P2P warmup ===')
+await testCase('federation identity ready on A/B', async () => {
+	const fa = await P2pApi(FedA, 'GET', '/federation')
+	const fb = await P2pApi(FedB, 'GET', '/federation')
+	return fa.status === 200 && fb.status === 200 && fa.json.activePubKeyHex && fb.json.activePubKeyHex
+})
+await WarmupFedNodeLinks([FedA, FedB])
+await sleep(ms('5s'))
+
+console.log('\n=== Setup: A private group + emoji (B stays non-member) ===')
+await testCase('A creates invite-only group', async () => {
+	const g = (await Api(FedA, 'POST', '/groups/', { name: groupTitle, description: 'L4 fed probe' })).json
+	gid = g.groupId
+	cid = g.defaultChannelId
+	await Api(FedA, 'PUT', `/groups/${gid}/settings`, { joinPolicy: 'invite-only', discoveryPublic: true })
+	return Boolean(gid)
+})
+
+await testCase('A uploads group emoji', async () => {
+	const r = await ApiMultipart(FedA, 'POST', `/groups/${gid}/emojis`, { name: 'cross-emoji' }, 'emoji', 'fed.png', FedPngBytes)
+	if (r.status !== 201) throw new Error(`upload ${r.status}: ${r.raw}`)
+	emojiId = r.json.entry?.emojiId
+	emojiContentHash = r.json.entry?.contentHash
+	return Boolean(emojiId)
+})
+
+await testCase('A seeds channel (federation metadata)', async () => {
+	await sleep(ms('2s'))
+	await Api(FedA, 'POST', `/groups/${gid}/federation/catchup`, { waitMs: ms('6s') })
+	emojiToken = formatEmojiToken(gid, emojiId)
+	const r = await Api(FedA, 'POST', `/groups/${gid}/channels/${cid}/messages`, {
+		content: { type: 'text', content: `seed ${emojiToken}` },
+	})
+	return r.status === 200 || r.status === 201
+})
+
+console.log('\n=== A posts Social feed with group emoji token ===')
+await testCase('A feed post embeds groupEmoji mediaRef and retains token', async () => {
+	const viewer = (await ShellApi(FedA, 'chat', 'GET', '/viewer')).json.viewerEntityHash
+	if (!viewer) throw new Error('no viewerEntityHash')
+	const text = `cross-shell feed ${emojiToken}`
+	const r = await ShellApi(FedA, 'social', 'POST', '/posts', {
+		entityHash: viewer,
+		text,
+		visibility: 'public',
+		locale: 'zh-CN',
+	})
+	if (r.status !== 200) throw new Error(`post ${r.status}: ${r.raw}`)
+	postId = r.json.event?.id
+	postMediaRefs = r.json.event?.content?.mediaRefs?.filter(ref => ref.kind === 'groupEmoji') ?? []
+	postText = r.json.event?.content?.text
+	return Boolean(postId)
+		&& postMediaRefs.length >= 1
+		&& Boolean(postMediaRefs[0]?.contentHash)
+		&& String(postText ?? '').includes(emojiToken)
+})
+
+console.log('\n=== B (non-member) emoji-content + private preview ===')
+await Api(FedA, 'POST', `/groups/${gid}/federation/catchup`, { waitMs: ms('8s') })
+
+await testCase('B GET /emoji-content without group membership', async () => {
+	let hash = postMediaRefs[0]?.contentHash
+	if (!hash) hash = emojiContentHash
+	if (!hash) throw new Error('post or upload must yield contentHash for non-member CAS path')
+	const hashQ = `?json=1&contentHash=${hash}`
+	const ok = await pollUntil(async () => {
+		await Api(FedB, 'GET', `/groups/${gid}/preview`)
+		await Api(FedB, 'POST', `/groups/${gid}/federation/catchup`, { waitMs: ms('3s') })
+		const r = await Api(FedB, 'GET', `/emoji-content/${gid}/${emojiId}${hashQ}`)
+		return r.status === 200 && Boolean(r.json.dataUrl)
+	}, 120, 5)
+	if (!ok) {
+		const hash = postMediaRefs[0]?.contentHash ?? emojiContentHash
+		const last = await Api(FedB, 'GET', `/emoji-content/${gid}/${emojiId}?json=1&contentHash=${hash}`)
+		throw new Error(`non-member B must resolve /emoji-content (not A-side fallback); last status=${last.status} raw=${last.raw}`)
+	}
+	return true
+})
+
+await testCase('B GET /groups/:id/preview as non-member', async () => {
+	const ok = await pollUntil(async () => {
+		await Api(FedA, 'POST', `/groups/${gid}/federation/catchup`, { waitMs: ms('3s') })
+		const r = await Api(FedB, 'GET', `/groups/${gid}/preview`)
+		return r.status === 200 && r.json.isMember === false
+	}, 120, 4)
+	return Boolean(ok)
+})
+
+await testCase('B preview hides join for invite-only private group', async () => {
+	const ok = await pollUntil(async () => {
+		const r = await Api(FedB, 'GET', `/groups/${gid}/preview`)
+		return r.status === 200 && r.json.canJoin === false
+	}, 30, 3)
+	return Boolean(ok)
+})
+
+await ClearFedGroup(gid)
+WriteFedSummary('CROSS-SHELL-EMOJI', gid)
+completeLiveScript()

--- a/src/public/parts/shells/social/test/live/scripts/e2e_single.mjs
+++ b/src/public/parts/shells/social/test/live/scripts/e2e_single.mjs
@@ -1,0 +1,258 @@
+import { createShellProbe } from 'fount/scripts/test/live/singleNode/helpers.mjs'
+
+const social = await createShellProbe('social')
+const chat = await createShellProbe('chat')
+const {
+	shellApi,
+	testCase,
+	writeLiveSection,
+	writeLiveSummary,
+	completeLiveScript,
+} = social
+
+let entityHash = null
+let postId = null
+let folderId = null
+let shareId = null
+const dummyTarget = 'a'.repeat(128)
+
+writeLiveSection('A. Viewer & discover')
+
+await testCase('GET chat /viewer', async () => {
+	const r = await chat.shellApi('GET', '/viewer')
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	entityHash = r.json.viewerEntityHash
+	return Boolean(entityHash)
+})
+
+await testCase('GET /profile/likes', async () => {
+	const r = await shellApi('GET', `/profile/${entityHash}/likes`)
+	return r.status === 200 && r.json.items != null
+})
+
+await testCase('GET /feed', async () => {
+	const r = await shellApi('GET', '/feed?limit=20')
+	return r.status === 200 && r.json.items != null
+})
+
+await testCase('POST /feed/sync', async () => {
+	const r = await shellApi('POST', '/feed/sync', null)
+	return r.status === 200 && r.json.synced === true
+})
+
+await testCase('GET /explore/posts', async () => {
+	const r = await shellApi('GET', '/explore/posts?limit=10')
+	return r.status === 200
+})
+
+await testCase('GET /explore', async () => {
+	const r = await shellApi('GET', '/explore?limit=10')
+	return r.status === 200
+})
+
+await testCase('GET /hashtags/trending', async () => {
+	const r = await shellApi('GET', '/hashtags/trending?limit=8')
+	return r.status === 200 && r.json.tags != null
+})
+
+await testCase('GET /notifications', async () => {
+	const r = await shellApi('GET', '/notifications?limit=10')
+	return r.status === 200 && r.json.notifications != null
+})
+
+await testCase('GET /mentions/suggest', async () => {
+	const r = await shellApi('GET', '/mentions/suggest?q=ab&limit=5')
+	return r.status === 200
+})
+
+await testCase('GET /search short query 400', async () => {
+	const r = await shellApi('GET', '/search?q=a')
+	return r.status === 400
+})
+
+writeLiveSection('B. Profile read & post')
+
+await testCase('POST /posts', async () => {
+	const r = await shellApi('POST', '/posts', {
+		entityHash,
+		text: 'social e2e post',
+		visibility: 'public',
+		locale: 'zh-CN',
+	})
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	postId = r.json.event?.id
+	return Boolean(postId)
+})
+
+await testCase('GET /profile/:hash', async () => {
+	const r = await shellApi('GET', `/profile/${entityHash}`)
+	return r.status === 200 && r.json.entityHash === entityHash
+})
+
+await testCase('GET /profile/:hash/posts', async () => {
+	const r = await shellApi('GET', `/profile/${entityHash}/posts`)
+	return r.status === 200 && (r.json.items?.length ?? 0) >= 1
+})
+
+await testCase('GET /profile/:hash/following', async () => {
+	const r = await shellApi('GET', `/profile/${entityHash}/following`)
+	return r.status === 200
+})
+
+await testCase('GET /profile/:hash/replies/:postId', async () => {
+	const r = await shellApi('GET', `/profile/${entityHash}/replies/${postId}`)
+	return r.status === 200
+})
+
+await testCase('GET /search hashtag', async () => {
+	const r = await shellApi('GET', '/search?q=%23social')
+	return r.status === 200
+})
+
+writeLiveSection('C. Interactions')
+
+await testCase('POST /posts/:hash/:id/like', async () => {
+	const r = await shellApi('POST', `/posts/${entityHash}/${postId}/like`, { like: true })
+	return r.status === 200 && r.json.event?.type === 'like'
+})
+
+await testCase('POST /posts/:hash/:id/repost', async () => {
+	const r = await shellApi('POST', `/posts/${entityHash}/${postId}/repost`, { comment: 'e2e repost' })
+	return r.status === 200 && r.json.event?.type === 'repost'
+})
+
+await testCase('POST /relationships/follow seeded test target', async () => {
+	const r = await shellApi('POST', '/relationships/follow', { entityHash: dummyTarget, follow: true })
+	return r.status === 200 && r.json.isFollowing === true
+})
+
+await testCase('POST /relationships/follow unfollow seeded test target', async () => {
+	const r = await shellApi('POST', '/relationships/follow', { entityHash: dummyTarget, follow: false })
+	return r.status === 200 && r.json.isFollowing === false
+})
+
+await testCase('POST /profile/meta', async () => {
+	const r = await shellApi('POST', '/profile/meta', { hideFromDiscovery: false })
+	return r.status === 200
+})
+
+await testCase('POST /relationships/block + unblock seeded test target', async () => {
+	const b = await shellApi('POST', '/relationships/block', { entityHash: dummyTarget, block: true })
+	if (b.status !== 200) throw new Error(`block ${b.status}`)
+	const u = await shellApi('POST', '/relationships/block', { entityHash: dummyTarget, block: false })
+	return u.status === 200
+})
+
+await testCase('POST /relationships/hide + unhide seeded test target', async () => {
+	const h = await shellApi('POST', '/relationships/hide', { entityHash: dummyTarget, hide: true })
+	if (h.status !== 200) throw new Error(`hide ${h.status}`)
+	const u = await shellApi('POST', '/relationships/hide', { entityHash: dummyTarget, hide: false })
+	return u.status === 200
+})
+
+await testCase('GET chat /personal-lists', async () => {
+	const r = await chat.shellApi('GET', '/personal-lists')
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	return r.json.entries != null
+})
+
+writeLiveSection('D. Saved posts')
+
+await testCase('POST /saved-posts/folders', async () => {
+	const r = await shellApi('POST', '/saved-posts/folders', { name: 'E2E Saved' })
+	if (r.status !== 200) throw new Error(`status ${r.status}`)
+	folderId = Object.keys(r.json.folders ?? {})[0]
+	return Boolean(folderId)
+})
+
+await testCase('POST /saved-posts/add', async () => {
+	const r = await shellApi('POST', '/saved-posts/add', { entityHash, postId, folderId })
+	return r.status === 200
+})
+
+await testCase('GET /saved-posts', async () => {
+	const r = await shellApi('GET', '/saved-posts')
+	return r.status === 200
+})
+
+await testCase('POST /saved-posts/folders/rename', async () => {
+	const r = await shellApi('POST', '/saved-posts/folders/rename', { folderId, name: 'E2E Starred' })
+	return r.status === 200
+})
+
+await testCase('POST /saved-posts/remove', async () => {
+	const r = await shellApi('POST', '/saved-posts/remove', { entityHash, postId, folderId })
+	return r.status === 200
+})
+
+await testCase('POST /saved-posts/folders/delete', async () => {
+	const r = await shellApi('POST', '/saved-posts/folders/delete', { folderId })
+	return r.status === 200
+})
+
+writeLiveSection('D2. Composer drafts')
+
+let draftId = ''
+await testCase('POST /drafts', async () => {
+	const r = await shellApi('POST', '/drafts', { text: 'E2E draft body', visibility: 'public' })
+	if (r.status !== 200) throw new Error(`status ${r.status}`)
+	draftId = r.json.draftId
+	return Boolean(draftId)
+})
+
+await testCase('GET /drafts', async () => {
+	const r = await shellApi('GET', '/drafts')
+	return r.status === 200 && (r.json.drafts || []).some(row => row.draftId === draftId)
+})
+
+await testCase('GET /drafts/:draftId', async () => {
+	const r = await shellApi('GET', `/drafts/${draftId}`)
+	return r.status === 200 && r.json.body?.text === 'E2E draft body'
+})
+
+await testCase('POST /drafts update', async () => {
+	const r = await shellApi('POST', '/drafts', { draftId, text: 'E2E draft edited', visibility: 'unlisted' })
+	return r.status === 200 && r.json.body?.text === 'E2E draft edited'
+})
+
+await testCase('DELETE /drafts/:draftId', async () => {
+	const r = await shellApi('DELETE', `/drafts/${draftId}`)
+	return r.status === 200 && !(r.json.drafts || []).some(row => row.draftId === draftId)
+})
+
+writeLiveSection('E. Vault & translate')
+
+await testCase('POST /translate', async () => {
+	const r = await shellApi('POST', '/translate', { text: 'hello world', targetLang: 'zh-CN' })
+	return r.status === 200 && r.json.translated != null
+})
+
+await testCase('POST /files register', async () => {
+	const r = await shellApi('POST', '/files', {
+		fileId: 'e2e-file-001',
+		logicalPath: 'shells/social/vault/e2e-file-001',
+		name: 'e2e.txt',
+		mimeType: 'text/plain',
+		size: 4,
+		visibility: 'public',
+		shareId: 'e2e-share-001',
+	})
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	shareId = r.json.entry?.shareId
+	return Boolean(shareId)
+})
+
+await testCase('GET /files/:shareId', async () => {
+	const r = await shellApi('GET', `/files/${shareId}`)
+	return r.status === 200 && r.json.entry?.shareId === shareId
+})
+
+writeLiveSection('F. Cleanup')
+
+await testCase('DELETE /posts', async () => {
+	const r = await shellApi('DELETE', '/posts', { postId })
+	return r.status === 200 && r.json.event?.type === 'post_delete'
+})
+
+writeLiveSummary('social e2e_single')
+completeLiveScript()

--- a/src/public/parts/shells/social/test/live/scripts/smoke_social.mjs
+++ b/src/public/parts/shells/social/test/live/scripts/smoke_social.mjs
@@ -1,0 +1,34 @@
+import { createShellProbe } from 'fount/scripts/test/live/singleNode/helpers.mjs'
+
+const social = await createShellProbe('social')
+const chat = await createShellProbe('chat')
+const { testCase, writeLiveSection, completeLiveScript } = social
+
+let entityHash = null
+
+writeLiveSection('Social smoke')
+
+await testCase('GET chat /viewer', async () => {
+	const r = await chat.shellApi('GET', '/viewer')
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	entityHash = r.json.viewerEntityHash
+	return Boolean(entityHash)
+})
+
+await testCase('POST /posts', async () => {
+	const r = await social.shellApi('POST', '/posts', {
+		entityHash,
+		text: 'social smoke post',
+		visibility: 'public',
+		locale: 'zh-CN',
+	})
+	if (r.status !== 200) throw new Error(`status ${r.status}: ${r.raw}`)
+	return Boolean(r.json.event?.id)
+})
+
+await testCase('GET /feed', async () => {
+	const r = await social.shellApi('GET', '/feed?limit=20')
+	return r.status === 200 && r.json.items != null
+})
+
+completeLiveScript('SMOKE_SOCIAL')

--- a/src/public/parts/shells/social/test/live/scripts/ws.mjs
+++ b/src/public/parts/shells/social/test/live/scripts/ws.mjs
@@ -1,0 +1,82 @@
+// Social feed WebSocket: hello + post push + notification + reconnect.
+import process from 'node:process'
+
+import { ms } from 'fount/scripts/ms.mjs'
+import { liveWsBaseUrl } from 'fount/scripts/test/live/env.mjs'
+import { createLiveShellHttp, waitForWsFrame } from 'fount/scripts/test/live/wsHarness.mjs'
+
+const { chatApi, key: apiKey } = createLiveShellHttp({ shell: 'chat' })
+const { shellApi: socialApi } = createLiveShellHttp({ shell: 'social' })
+
+const viewer = await chatApi('GET', '/viewer')
+if (viewer.status !== 200 || !viewer.json?.viewerEntityHash) {
+	console.error('FAIL: GET chat /viewer', viewer.status, viewer.json)
+	process.exit(1)
+}
+const entityHash = viewer.json.viewerEntityHash
+const wsUrl = `${liveWsBaseUrl()}/ws/parts/shells:social/feed?fount-apikey=${encodeURIComponent(apiKey)}`
+
+const postRun = await waitForWsFrame({
+	url: wsUrl,
+	types: ['post'],
+	timeoutMs: ms('20s'),
+	/** 发帖以触发 feed post 帧。 */
+	trigger: async () => {
+		const post = await socialApi('POST', '/posts', {
+			entityHash,
+			text: `ws-push ${Date.now()}`,
+			visibility: 'public',
+			locale: 'zh-CN',
+		})
+		if (post.status !== 200) throw new Error(`post failed ${post.status}`)
+	},
+})
+if (!postRun.ok) {
+	console.error('FAIL: post push', postRun.types)
+	process.exit(1)
+}
+console.log('PASS: post push', postRun.types)
+
+const seedPost = await socialApi('POST', '/posts', {
+	entityHash,
+	text: `ws-like-target ${Date.now()}`,
+	visibility: 'public',
+	locale: 'zh-CN',
+})
+const postId = seedPost.json?.event?.id
+if (seedPost.status !== 200 || !postId) {
+	console.error('FAIL: seed post for notification', seedPost.status)
+	process.exit(1)
+}
+
+const notificationRun = await waitForWsFrame({
+	url: wsUrl,
+	types: ['notification'],
+	timeoutMs: ms('20s'),
+	/** foreign-like 以触发 notification 帧。 */
+	trigger: async () => {
+		const foreignLike = await socialApi('POST', '/test/foreign-like', {
+			targetEntityHash: entityHash,
+			targetPostId: postId,
+		})
+		if (foreignLike.status !== 200) throw new Error(`foreign-like failed ${foreignLike.status}`)
+	},
+})
+if (!notificationRun.ok) {
+	console.error('FAIL: notification push', notificationRun.types)
+	process.exit(1)
+}
+console.log('PASS: notification push', notificationRun.types)
+
+const reconnectRun = await waitForWsFrame({
+	url: wsUrl,
+	types: ['hello'],
+	timeoutMs: ms('10s'),
+})
+if (!reconnectRun.ok) {
+	console.error('FAIL: reconnect hello', reconnectRun.types)
+	process.exit(1)
+}
+console.log('PASS: reconnect hello')
+
+process.exit(0)

--- a/src/public/parts/shells/social/test/manifest.json
+++ b/src/public/parts/shells/social/test/manifest.json
@@ -1,0 +1,240 @@
+{
+	"id": "shells/social",
+	"triggerSets": {
+		"testFramework": [
+			"src/scripts/test/deno/serial.mjs",
+			"src/scripts/test/node/boot.mjs"
+		],
+		"shellBackend": [
+			"src/public/parts/shells/social/src/**",
+			"src/public/parts/shells/social/main.mjs",
+			"src/public/parts/shells/social/fount.json",
+			"src/public/parts/shells/social/locales.json"
+		],
+		"shellPureExtra": [
+			"src/public/parts/shells/chat/public/markdown_extensions/**",
+			"deno.json",
+			"src/server/p2p_server/**",
+			"src/scripts/search/**",
+			"src/server/registries.mjs",
+			"src/public/pages/scripts/api/registries.mjs",
+			"src/public/pages/scripts/components/emojiPicker.mjs",
+			"src/public/pages/scripts/components/stickerPicker.mjs",
+			"src/public/pages/scripts/features/markdown/extensions.mjs"
+		],
+		"shellIntegrationExtra": [
+			"src/public/parts/shells/chat/public/markdown_extensions/**",
+			"src/public/parts/shells/chat/src/group/groupPreview.mjs",
+			"src/public/parts/shells/chat/src/group/emojiContentResolve.mjs",
+			"deno.json",
+			"src/server/p2p_server/**",
+			"src/scripts/search/**",
+			"src/server/registries.mjs",
+			"src/public/pages/scripts/api/registries.mjs",
+			"src/public/pages/scripts/components/emojiPicker.mjs",
+			"src/public/pages/scripts/components/stickerPicker.mjs",
+			"src/public/pages/scripts/features/markdown/extensions.mjs"
+		],
+		"shellPureTests": [
+			"src/public/parts/shells/social/test/pure/**"
+		],
+		"shellIntegrationTests": [
+			"src/public/parts/shells/social/test/integration/**"
+		],
+		"shellLiveInfra": [
+			"src/public/parts/shells/social/test/live/run.mjs",
+			"src/public/parts/shells/social/test/afterInit.mjs"
+		],
+		"liveSmokeSocial": [
+			"src/public/parts/shells/social/test/live/scripts/smoke_social.mjs"
+		],
+		"liveE2eSingle": [
+			"src/public/parts/shells/social/test/live/scripts/e2e_single.mjs"
+		],
+		"liveWs": [
+			"src/public/parts/shells/social/test/live/scripts/ws.mjs"
+		],
+		"crossShellEmojiExtra": [
+			"src/public/parts/shells/chat/public/markdown_extensions/**",
+			"src/public/parts/shells/chat/src/group/groupPreview.mjs",
+			"src/public/parts/shells/chat/src/group/emojiContentResolve.mjs",
+			"src/server/registries.mjs",
+			"src/public/pages/scripts/api/registries.mjs",
+			"src/public/pages/scripts/components/emojiPicker.mjs"
+		],
+		"liveCrossShellEmoji": [
+			"src/public/parts/shells/social/test/live/scripts/cross_shell_emoji.mjs"
+		],
+		"wsExtra": [
+			"src/server/registries.mjs",
+			"src/public/pages/scripts/api/registries.mjs"
+		],
+		"frontendShared": [
+			"src/public/parts/shells/social/test/frontend/fixtures.mjs",
+			"src/public/parts/shells/social/test/frontend/run.mjs",
+			"src/public/parts/shells/social/test/frontend/phases.mjs",
+			"src/public/parts/shells/social/test/frontend/playwright.config.mjs",
+			"src/public/parts/shells/social/test/node_bootstrap.mjs",
+			"src/public/parts/shells/social/public/index.html",
+			"src/public/parts/shells/social/public/styles.css",
+			"src/public/parts/shells/social/public/src/init.mjs",
+			"src/public/parts/shells/social/public/src/state.mjs",
+			"src/public/parts/shells/social/public/src/gate.mjs",
+			"src/public/parts/shells/social/public/src/lib/apiClient.mjs",
+			"src/public/parts/shells/social/public/src/lib/socialWrite.mjs",
+			"src/scripts/test/playwright/**",
+			"src/public/pages/scripts/test/ready_gate.mjs",
+			"src/server/auth/index.mjs",
+			"src/server/web_server/endpoints.mjs"
+		]
+	},
+	"suites": [
+		{
+			"name": "pure",
+			"trigger": ["shellBackend", "shellPureExtra", "shellPureTests", "testFramework"],
+			"run": [
+				"deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json",
+				"./src/scripts/test/deno/serial.mjs",
+				"./src/public/parts/shells/social/test/pure/"
+			]
+		},
+		{
+			"name": "integration",
+			"dependsOn": ["server:live"],
+			"trigger": ["shellBackend", "shellIntegrationExtra", "shellIntegrationTests", "testFramework"],
+			"run": [
+				"deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json",
+				"./src/scripts/test/deno/serial.mjs",
+				"./src/public/parts/shells/social/test/integration/"
+			]
+		},
+		{ "name": "smoke_social", "dependsOn": ["server:live"], "trigger": ["shellBackend", "shellLiveInfra", "liveSmokeSocial"], "run": ["deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json", "./src/public/parts/shells/social/test/live/run.mjs", "--suite", "smoke_social"] },
+		{ "name": "e2e_single", "dependsOn": ["server:live", "smoke_social"], "trigger": ["shellLiveInfra", "liveE2eSingle"], "run": ["deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json", "./src/public/parts/shells/social/test/live/run.mjs", "--suite", "e2e_single"] },
+		{ "name": "ws", "dependsOn": ["server:live", "smoke_social"], "trigger": ["wsExtra", "shellLiveInfra", "liveWs"], "run": ["deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json", "./src/public/parts/shells/social/test/live/run.mjs", "--suite", "ws"] },
+		{ "name": "cross_shell_emoji", "dependsOn": ["server:live", "smoke_social", "shells/chat:fed_core", "shells/chat:fed_emoji"], "trigger": ["crossShellEmojiExtra", "shellLiveInfra", "liveCrossShellEmoji"], "run": ["deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json", "./src/public/parts/shells/social/test/live/run.mjs", "--suite", "cross_shell_emoji"] },
+		{
+			"name": "frontend",
+			"dependsOn": ["server:live", "smoke_social", "e2e_single"],
+			"trigger": "frontendShared",
+			"subtests": [
+				{
+					"name": "smoke",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/smoke.spec.mjs"
+					]
+				},
+				{
+					"name": "postActions",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/postActions.spec.mjs",
+						"src/public/parts/shells/social/public/src/actions/**",
+						"src/public/parts/shells/social/public/src/postCard.mjs",
+						"src/public/parts/shells/social/public/src/actions.mjs"
+					]
+				},
+				{
+					"name": "replies",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/replies.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/replies.mjs"
+					]
+				},
+				{
+					"name": "postDetail",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/postDetail.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/postDetail.mjs",
+						"src/public/parts/shells/social/src/endpoints/posts.mjs"
+					]
+				},
+				{
+					"name": "composer",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/composer.spec.mjs",
+						"src/public/parts/shells/social/public/src/composer.mjs",
+						"src/public/parts/shells/social/public/src/visibilityPicker.mjs",
+						"src/public/parts/shells/social/public/src/actions/composerFeed.mjs"
+					]
+				},
+				{
+					"name": "deepLink",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/deepLink.spec.mjs",
+						"src/public/parts/shells/social/public/src/navigation.mjs"
+					]
+				},
+				{
+					"name": "feed",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/feed.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/feed.mjs",
+						"src/public/parts/shells/social/public/src/postCard.mjs",
+						"src/public/pages/scripts/infiniteScroll.mjs"
+					]
+				},
+				{
+					"name": "navigation",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/navigation.spec.mjs",
+						"src/public/parts/shells/social/public/src/navigation.mjs",
+						"src/public/parts/shells/social/public/src/viewChrome.mjs",
+						"src/public/parts/shells/social/public/src/views/video.mjs"
+					]
+				},
+				{
+					"name": "profile",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/profile.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/profile.mjs",
+						"src/public/parts/shells/social/public/src/views/albums.mjs",
+						"src/public/parts/shells/social/public/src/actions.mjs",
+						"src/public/parts/shells/social/public/src/lib/replies.mjs",
+						"src/public/parts/shells/social/public/src/lib/profileHover.mjs",
+						"src/public/parts/shells/social/public/src/actions/postProfileActions.mjs",
+						"src/public/parts/shells/social/public/src/actions/profileNavActions.mjs",
+						"src/public/parts/shells/chat/public/shared/entityProfileHoverCard.mjs",
+						"src/public/parts/shells/chat/public/shared/entityProfileCard.*"
+					]
+				},
+				{
+					"name": "saved",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/saved.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/saved.mjs",
+						"src/public/parts/shells/social/public/src/actions/saved.mjs"
+					]
+				},
+				{
+					"name": "drafts",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/drafts.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/drafts.mjs",
+						"src/public/parts/shells/social/public/src/actions/drafts.mjs",
+						"src/public/parts/shells/social/src/drafts.mjs",
+						"src/public/parts/shells/social/src/endpoints/drafts.mjs",
+						"src/public/parts/shells/social/src/api/client/drafts.mjs"
+					]
+				},
+				{
+					"name": "videos",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/videos.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/video.mjs",
+						"src/public/parts/shells/social/public/src/lib/verticalSnap.mjs",
+						"src/public/parts/shells/social/src/videosFeed.mjs",
+						"src/public/parts/shells/social/src/endpoints/videos.mjs"
+					]
+				},
+				{
+					"name": "explore_notifications",
+					"triggers": [
+						"src/public/parts/shells/social/test/frontend/explore_notifications.spec.mjs",
+						"src/public/parts/shells/social/public/src/views/explore.mjs",
+						"src/public/parts/shells/social/public/src/views/notifications.mjs"
+					]
+				}
+			],
+			"run": ["deno", "run", "--allow-scripts", "--allow-all", "-c", "./deno.json", "./src/public/parts/shells/social/test/frontend/run.mjs"]
+		}
+	]
+}

--- a/src/public/parts/shells/social/test/node_bootstrap.mjs
+++ b/src/public/parts/shells/social/test/node_bootstrap.mjs
@@ -1,0 +1,13 @@
+import { ensureSocialTestReady } from './afterInit.mjs'
+import { seedForeignFeedAuthorPost } from './seedForeignFeedAuthor.mjs'
+import { seedKnownTestEntityTarget } from './seedKnownEntity.mjs'
+
+/**
+ * Social live / 前端测试节点 bootstrap（由 test node worker 调用）。
+ * @param {string} username 测试用户名
+ */
+export default async function bootstrap(username) {
+	await ensureSocialTestReady(username)
+	await seedKnownTestEntityTarget()
+	await seedForeignFeedAuthorPost(username)
+}

--- a/src/public/parts/shells/social/test/pure/content_filter.test.mjs
+++ b/src/public/parts/shells/social/test/pure/content_filter.test.mjs
@@ -1,0 +1,34 @@
+/**
+ * 关键词/标签屏蔽匹配纯测。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { postMatchesMutedKeywords, pruneMutedKeywordEntries } from '../../src/lib/contentFilter.mjs'
+
+Deno.test('postMatchesMutedKeywords hits body and contentWarning', () => {
+	const muted = { entries: [{ pattern: 'spoiler', matchTags: true }] }
+	assertEquals(postMatchesMutedKeywords({ content: { text: 'big SPOILER ahead' } }, muted), true)
+	assertEquals(postMatchesMutedKeywords({ content: { text: 'ok', contentWarning: 'spoiler alert' } }, muted), true)
+	assertEquals(postMatchesMutedKeywords({ content: { text: 'fine' } }, muted), false)
+})
+
+Deno.test('postMatchesMutedKeywords matches tags when enabled', () => {
+	const muted = { entries: [{ pattern: '#nsfw', matchTags: true }] }
+	assertEquals(postMatchesMutedKeywords({ content: { text: 'pic', tags: ['nsfw'] } }, muted), true)
+	assertEquals(postMatchesMutedKeywords({ content: { text: '#nsfw' } }, muted), true)
+	assertEquals(postMatchesMutedKeywords(
+		{ content: { text: 'pic', tags: ['nsfw'] } },
+		{ entries: [{ pattern: 'nsfw', matchTags: false }] },
+	), false)
+})
+
+Deno.test('pruneMutedKeywordEntries drops expired and duplicates', () => {
+	const pruned = pruneMutedKeywordEntries([
+		{ pattern: 'a' },
+		{ pattern: 'A' },
+		{ pattern: 'b', expiresAt: Date.now() - 1000 },
+		{ pattern: 'c', expiresAt: Date.now() + 60_000 },
+	])
+	assertEquals(pruned.map(entry => entry.pattern), ['a', 'c'])
+})

--- a/src/public/parts/shells/social/test/pure/dispatch_mentions.test.mjs
+++ b/src/public/parts/shells/social/test/pure/dispatch_mentions.test.mjs
@@ -1,0 +1,27 @@
+/**
+ * Social dispatch：加密帖 @ 提及与通知正文分离。
+ */
+/* global Deno */
+import { extractMentionEntityHashes } from 'fount/public/parts/shells/chat/public/shared/mentions.mjs'
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { mentionSourceText, postTextForNotification } from '../../src/lib/postMentionText.mjs'
+
+const MENTION_HASH = 'a'.repeat(128)
+
+Deno.test('encrypted post: no mention scan on ciphertext body', () => {
+	const post = {
+		content: {
+			scheme: 'gsh',
+			postKeyId: 'key-1',
+		},
+	}
+	assertEquals(mentionSourceText(post), '')
+	assertEquals(postTextForNotification(post), null)
+	assertEquals(extractMentionEntityHashes(mentionSourceText(post)).length, 0)
+})
+
+Deno.test('public post: mention and notification text match', () => {
+	const post = { content: { text: `hi @${MENTION_HASH}` } }
+	assertEquals(mentionSourceText(post), postTextForNotification(post))
+})

--- a/src/public/parts/shells/social/test/pure/drafts.test.mjs
+++ b/src/public/parts/shells/social/test/pure/drafts.test.mjs
@@ -1,0 +1,25 @@
+/**
+ * 草稿箱默认结构单元测试（Deno）。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { loadDrafts, sanitizeDraftBody } from '../../src/drafts.mjs'
+
+Deno.test('loadDrafts returns empty structure when file missing', async () => {
+	const data = await loadDrafts('__social_drafts_missing_user__', 'a'.repeat(128))
+	assertEquals(data.drafts, [])
+})
+
+Deno.test('sanitizeDraftBody strips file blobs and empty fields', () => {
+	const body = sanitizeDraftBody({
+		text: '  hello  ',
+		mediaRefs: [{ path: 'x', file: {}, objectUrl: 'blob:1', pending: true, alt: 'a' }],
+		visibility: 'public',
+		sensitiveMedia: false,
+	})
+	assertEquals(body.text, 'hello')
+	assertEquals(body.mediaRefs, [{ path: 'x', alt: 'a' }])
+	assertEquals(body.visibility, 'public')
+	assertEquals(body.sensitiveMedia, undefined)
+})

--- a/src/public/parts/shells/social/test/pure/emoji_tokens.test.mjs
+++ b/src/public/parts/shells/social/test/pure/emoji_tokens.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * Social emoji token 扫描与展示结构测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { formatEmojiToken } from '../../../chat/public/shared/inlineTokenSyntax.mjs'
+import { buildEmojiMediaRefsForPost, scanEmojiTokens } from '../../src/lib/emojiPostEmbed.mjs'
+
+Deno.test('post with emoji token yields media ref candidates', () => {
+	const refs = scanEmojiTokens(`see ${formatEmojiToken('privateGroup', 'customEmoji')} here`)
+	assertEquals(refs[0]?.groupId, 'privateGroup')
+	assertEquals(refs[0]?.emojiId, 'customEmoji')
+})
+
+Deno.test('scanEmojiTokens deduplicates repeated tokens', () => {
+	const token = formatEmojiToken('a', 'b')
+	const refs = scanEmojiTokens(`${token} ${token}`)
+	assertEquals(refs.length, 1)
+})
+
+Deno.test('scanEmojiTokens requires typed emoji prefix and trailing colon', () => {
+	const refs = scanEmojiTokens(`seed ${formatEmojiToken('g1', 'e1')} tail`)
+	assertEquals(refs, [{ groupId: 'g1', emojiId: 'e1' }])
+	assertEquals(scanEmojiTokens('see :[g1/e1]: without emoji prefix'), [])
+	assertEquals(scanEmojiTokens('see :[emoji:g1/e1] without trailing colon'), [])
+})
+
+Deno.test('buildEmojiMediaRefsForPost empty when no emoji tokens', async () => {
+	const mediaRefs = await buildEmojiMediaRefsForPost('user', 'plain text without tokens')
+	assertEquals(mediaRefs, [])
+})
+
+Deno.test('feed mediaRef shape for groupEmoji embed', () => {
+	const contentHash = 'a'.repeat(64)
+	const refs = scanEmojiTokens(formatEmojiToken('g1', 'e1'))
+	const mediaRefs = refs.map(({ groupId, emojiId }) => ({
+		kind: 'groupEmoji',
+		groupId,
+		emojiId,
+		contentHash,
+	}))
+	assertEquals(mediaRefs[0].kind, 'groupEmoji')
+	assertEquals(mediaRefs[0].contentHash.length, 64)
+})

--- a/src/public/parts/shells/social/test/pure/feed_helpers.test.mjs
+++ b/src/public/parts/shells/social/test/pure/feed_helpers.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Social 纯函数单元测试（Deno，无 server 依赖）。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import { topologicalCanonicalOrder } from 'npm:@steve02081504/fount-p2p/dag/index'
+import { normalizeDenylist } from 'npm:@steve02081504/fount-p2p/node/denylist'
+import { isAuthorFilteredByPersonalSets } from 'npm:@steve02081504/fount-p2p/node/personal_block'
+
+import { canViewPost } from '../../src/feedVisibility.mjs'
+
+/**
+ * 按拓扑序物化 post 事件（过滤非 post 类型）。
+ * @param {object[]} events 原始事件
+ * @returns {object[]} 物化后的 post 事件列表
+ */
+function materializePostsOnly(events) {
+	const order = topologicalCanonicalOrder(events.map(event => ({
+		id: event.id,
+		prev_event_ids: event.prev_event_ids,
+		hlc: event.hlc,
+		node_id: event.node_id,
+	})))
+	const byId = new Map(events.map(event => [event.id, event]))
+	const posts = new Map()
+	for (const eventId of order) {
+		const event = byId.get(eventId)
+		if (event?.type === 'post') posts.set(event.id, event)
+	}
+	return [...posts.values()]
+}
+
+Deno.test('canViewPost respects visibility with implicit self-follow', () => {
+	const viewerContext = {
+		viewerEntityHash: 'viewer1',
+		following: new Set(['author1', 'viewer1']),
+		personalFilter: {
+			blockedEntityHashes: new Set(),
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		},
+	}
+	assertEquals(canViewPost({ entityHash: 'author1', content: { visibility: 'public' } }, viewerContext), true)
+	assertEquals(canViewPost({ entityHash: 'author2', content: { visibility: 'followers' } }, viewerContext), false)
+	assertEquals(canViewPost({ entityHash: 'viewer1', content: { visibility: 'followers' } }, viewerContext), true)
+})
+
+Deno.test('canViewPost hides personally blocked authors', () => {
+	const viewerContext = {
+		viewerEntityHash: 'viewer1',
+		following: new Set(['viewer1', 'bad']),
+		personalFilter: {
+			blockedEntityHashes: new Set(['bad']),
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		},
+	}
+	assertEquals(canViewPost({ entityHash: 'bad', content: { visibility: 'public' } }, viewerContext), false)
+})
+
+Deno.test('isAuthorFilteredByPersonalSets subject scope', () => {
+	const pk = 'a'.repeat(64)
+	const filterSets = {
+		blockedEntityHashes: new Set(),
+		blockedSubjects: new Set([pk]),
+		hiddenEntityHashes: new Set(),
+		hiddenSubjects: new Set(),
+	}
+	assertEquals(isAuthorFilteredByPersonalSets(filterSets, 'b'.repeat(64) + pk), true)
+})
+
+Deno.test('materialize keeps all posts regardless of visibility', () => {
+	const posts = materializePostsOnly([
+		{ id: 'a', type: 'post', prev_event_ids: [], hlc: { wall: 1 }, content: { visibility: 'followers' } },
+		{ id: 'b', type: 'post', prev_event_ids: ['a'], hlc: { wall: 2 }, content: { visibility: 'public' } },
+	])
+	assertEquals(posts.length, 2)
+})
+
+Deno.test('blocklist entity scope from p2p normalizeDenylist', () => {
+	const entity = `${'e'.repeat(128)}`
+	const list = normalizeDenylist({ blocked: [{ scope: 'entity', value: entity }] })
+	assertEquals(list.blocked[0].value, entity)
+})

--- a/src/public/parts/shells/social/test/pure/feed_threads.test.mjs
+++ b/src/public/parts/shells/social/test/pure/feed_threads.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * 同页自回复 thread 合并。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { groupSelfReplyThreads } from '../../public/src/lib/feedThreads.mjs'
+
+Deno.test('groupSelfReplyThreads merges self-reply chain in chronological order', () => {
+	const author = 'a'.repeat(128)
+	const root = {
+		kind: 'post',
+		entityHash: author,
+		postId: 'p1',
+		hlc: { wall: 1 },
+		post: { content: { text: 'root' } },
+	}
+	const reply = {
+		kind: 'post',
+		entityHash: author,
+		postId: 'p2',
+		hlc: { wall: 2 },
+		replyContext: { entityHash: author, postId: 'p1' },
+		post: { content: { text: 'reply', replyTo: { entityHash: author, postId: 'p1' } } },
+	}
+	// feed 新→旧
+	const groups = groupSelfReplyThreads([reply, root])
+	assertEquals(groups.length, 1)
+	assertEquals(groups[0].type, 'thread')
+	assertEquals(groups[0].items.map(i => i.postId), ['p1', 'p2'])
+})
+
+Deno.test('groupSelfReplyThreads keeps foreign replies separate', () => {
+	const a = 'a'.repeat(128)
+	const b = 'b'.repeat(128)
+	const root = {
+		kind: 'post',
+		entityHash: a,
+		postId: 'p1',
+		hlc: { wall: 1 },
+		post: { content: {} },
+	}
+	const foreign = {
+		kind: 'post',
+		entityHash: b,
+		postId: 'p2',
+		hlc: { wall: 2 },
+		replyContext: { entityHash: a, postId: 'p1' },
+		post: { content: { replyTo: { entityHash: a, postId: 'p1' } } },
+	}
+	const groups = groupSelfReplyThreads([foreign, root])
+	assertEquals(groups.length, 2)
+	assertEquals(groups.every(g => g.type === 'single'), true)
+})

--- a/src/public/parts/shells/social/test/pure/gap_batch_helpers.test.mjs
+++ b/src/public/parts/shells/social/test/pure/gap_batch_helpers.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * replyPolicy / searchFilters / topic normalize 纯函数测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import {
+	FOLLOWERS_7D_MS,
+	latestFollowWallForAuthor,
+	normalizeReplyDisplay,
+	normalizeReplyPolicy,
+} from '../../src/lib/replyPolicy.mjs'
+import {
+	hasSearchCriteria,
+	parseSearchFilters,
+	postMatchesFilters,
+} from '../../src/lib/searchFilters.mjs'
+import { normalizeTopicTag } from '../../src/topics.mjs'
+
+Deno.test('normalizeReplyPolicy defaults to everyone', () => {
+	assertEquals(normalizeReplyPolicy(undefined), 'everyone')
+	assertEquals(normalizeReplyPolicy('followers_7d'), 'followers_7d')
+	assertEquals(normalizeReplyPolicy('author_follows'), 'author_follows')
+	assertEquals(normalizeReplyPolicy('nope'), 'everyone')
+})
+
+Deno.test('normalizeReplyDisplay featured_only', () => {
+	assertEquals(normalizeReplyDisplay('featured_only'), 'featured_only')
+	assertEquals(normalizeReplyDisplay(''), 'all')
+})
+
+Deno.test('latestFollowWallForAuthor reads followEvents', () => {
+	const author = 'a'.repeat(128)
+	const view = {
+		following: [author],
+		followEvents: [
+			{ content: { targetEntityHash: author }, hlc: { wall: 1000 } },
+			{ content: { targetEntityHash: author }, hlc: { wall: 5000 } },
+		],
+	}
+	assertEquals(latestFollowWallForAuthor(view, author), 5000)
+	assertEquals(latestFollowWallForAuthor({ following: [], followEvents: [] }, author), null)
+	assertEquals(FOLLOWERS_7D_MS > 0, true)
+})
+
+Deno.test('parseSearchFilters extracts inline tokens', () => {
+	const filters = parseSearchFilters({ q: 'hello author:abcd media:video tag:fount' })
+	assertEquals(filters.q, 'hello')
+	assertEquals(filters.author, 'abcd')
+	assertEquals(filters.media, 'video')
+	assertEquals(filters.tag, 'fount')
+})
+
+Deno.test('postMatchesFilters media and tag', () => {
+	const post = {
+		entityHash: 'bbbbbbbb',
+		content: {
+			text: 'hello #fount',
+			mediaRefs: [{ kind: 'video' }],
+			tags: ['fount'],
+		},
+		hlc: { wall: 100 },
+	}
+	assertEquals(postMatchesFilters(post, parseSearchFilters({ media: 'video', tag: 'fount' })), true)
+	assertEquals(postMatchesFilters(post, parseSearchFilters({ media: 'image' })), false)
+	assertEquals(hasSearchCriteria(parseSearchFilters({ media: 'video' })), true)
+})
+
+Deno.test('normalizeTopicTag strips hash', () => {
+	assertEquals(normalizeTopicTag('#FoUnt'), 'fount')
+})

--- a/src/public/parts/shells/social/test/pure/gap_features.test.mjs
+++ b/src/public/parts/shells/social/test/pure/gap_features.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * mediaRefs 清扫 / 敏感媒体判定 / 分享 URL。
+ */
+/* global Deno */
+import { wrapProtocolHttpsUrl } from 'fount/public/parts/shells/chat/public/shared/runUri.mjs'
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { formatSocialPostRunUri } from '../../public/shared/runUri.mjs'
+import { normalizeDwellEntry, AUTHOR_BOOST_PER_DWELL } from '../../src/lib/dwellSignal.mjs'
+import { resolveSensitiveMedia, sanitizeMediaRefs } from '../../src/lib/mediaRefs.mjs'
+import { noteHelpfulScore } from '../../src/lib/noteScore.mjs'
+
+Deno.test('sanitizeMediaRefs truncates alt and drops junk', () => {
+	const refs = sanitizeMediaRefs([
+		{ kind: 'image', url: 'https://example.com/a.jpg', alt: 'x'.repeat(2000) },
+		null,
+		'bad',
+		{ kind: 'video', url: '/api/parts/shells:chat/entities/aa/files/b', alt: '  hello  ' },
+	])
+	assertEquals(refs.length, 2)
+	assertEquals(refs[0].alt.length, 1500)
+	assertEquals(refs[1].alt, 'hello')
+})
+
+Deno.test('sanitizeMediaRefs strips javascript: and other unsafe urls', () => {
+	const refs = sanitizeMediaRefs([
+		{ kind: 'file', url: 'javascript:alert(1)', name: 'x' },
+		{ kind: 'image', url: 'data:text/html,<script>1</script>' },
+		{ kind: 'image', url: 'https://example.com/ok.jpg' },
+		{ kind: 'image', url: 'javascript:void(0)', entityHash: 'ab'.repeat(64), path: 'profile/avatar' },
+	])
+	assertEquals(refs.length, 2)
+	assertEquals(refs[0].url, 'https://example.com/ok.jpg')
+	assertEquals(refs[1].url, undefined)
+	assertEquals(refs[1].entityHash, 'ab'.repeat(64))
+	assertEquals(refs[1].path, 'profile/avatar')
+})
+
+Deno.test('sanitizeMediaRefs keeps groupEmoji refs with contentHash', () => {
+	const refs = sanitizeMediaRefs([
+		{ kind: 'groupEmoji', groupId: 'g1', emojiId: 'e1', contentHash: 'a'.repeat(64) },
+		{ kind: 'groupEmoji', groupId: 'g1', emojiId: 'e2' },
+		{ kind: 'groupEmoji', emojiId: 'e3', contentHash: 'b'.repeat(64) },
+	])
+	assertEquals(refs.length, 1)
+	assertEquals(refs[0].kind, 'groupEmoji')
+	assertEquals(refs[0].emojiId, 'e1')
+})
+
+Deno.test('resolveSensitiveMedia defaults from contentWarning', () => {
+	assertEquals(resolveSensitiveMedia(undefined, 'cw'), true)
+	assertEquals(resolveSensitiveMedia(false, 'cw'), false)
+	assertEquals(resolveSensitiveMedia(true, ''), true)
+	assertEquals(resolveSensitiveMedia(undefined, ''), false)
+})
+
+Deno.test('noteHelpfulScore nets helpful votes', () => {
+	assertEquals(noteHelpfulScore({}, { a: true, b: true, c: false }), 1)
+	assertEquals(noteHelpfulScore({}, {}), 0)
+})
+
+Deno.test('normalizeDwellEntry rejects short dwells', () => {
+	assertEquals(normalizeDwellEntry({ author: 'aa', postId: 'bb', dwellMs: 1000 }), null)
+	const ok = normalizeDwellEntry({
+		author: 'Aa',
+		postId: 'Bb',
+		dwellMs: 5000,
+		tags: ['Foo', 'foo'],
+	})
+	assertEquals(ok?.author, 'aa')
+	assertEquals(ok?.tags, ['foo'])
+	assertEquals(AUTHOR_BOOST_PER_DWELL, 0.25)
+})
+
+Deno.test('formatSocialShareHttpsUrl wraps pages protocol', () => {
+	const url = wrapProtocolHttpsUrl(formatSocialPostRunUri('abc', 'def'))
+	assertEquals(url.startsWith('https://steve02081504.github.io/fount/protocol?url='), true)
+	assertEquals(decodeURIComponent(new URL(url).searchParams.get('url') || '').includes('shells:social/post'), true)
+})

--- a/src/public/parts/shells/social/test/pure/group_ref.test.mjs
+++ b/src/public/parts/shells/social/test/pure/group_ref.test.mjs
@@ -1,0 +1,81 @@
+/**
+ * groupRef 与 expandChannelLinks 单元测试（Deno）。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import {
+	expandChannelLinksInText,
+	formatChatGroupHref,
+	formatChatMessageHref,
+} from '../../../chat/public/shared/expandChannelLinks.mjs'
+import {
+	formatChannelToken,
+	formatGroupToken,
+	formatMessageToken,
+	stripChannelTokens,
+} from '../../../chat/public/shared/inlineTokenSyntax.mjs'
+import { groupRefLabel, renderGroupRefBlockHtml } from '../../public/shared/groupRef.mjs'
+
+Deno.test('formatChatGroupHref encodes group and channel', () => {
+	const href = formatChatGroupHref('my group', 'ch 1')
+	assertEquals(href.includes(encodeURIComponent('my group')), true)
+	assertEquals(href.includes(encodeURIComponent('ch 1')), true)
+})
+
+Deno.test('expandChannelLinksInText expands channel and group tokens', () => {
+	const channelHref = formatChatGroupHref('g1', 'c1')
+	const groupHref = formatChatGroupHref('g2')
+	assertEquals(
+		expandChannelLinksInText(`see ${formatChannelToken('g1', 'c1')}`),
+		`see [#g1/c1](${channelHref})`,
+	)
+	assertEquals(
+		expandChannelLinksInText(`join ${formatGroupToken('g2')}`),
+		`join [#g2](${groupHref})`,
+	)
+	assertEquals(
+		expandChannelLinksInText(`${formatChannelToken('g1', 'c1')} then ${formatGroupToken('g2')}`),
+		`[#g1/c1](${channelHref}) then [#g2](${groupHref})`,
+	)
+})
+
+Deno.test('expandChannelLinksInText expands message tokens', () => {
+	const messageHref = formatChatMessageHref('g1', 'c1', 'evt1234567890')
+	assertEquals(
+		expandChannelLinksInText(formatMessageToken('g1', 'c1', 'evt1234567890')),
+		`[#g1/c1/evt12345…](${messageHref})`,
+	)
+})
+
+Deno.test('expandChannelLinksInText leaves plain hashtags unchanged', () => {
+	assertEquals(expandChannelLinksInText('#hashtag plain'), '#hashtag plain')
+})
+
+Deno.test('expandChannelLinksInText href matches formatChatGroupHref', () => {
+	assertEquals(
+		expandChannelLinksInText(formatChannelToken('my-group', 'general')),
+		`[#my-group/general](${formatChatGroupHref('my-group', 'general')})`,
+	)
+})
+
+Deno.test('groupRefLabel prefers custom label', () => {
+	assertEquals(groupRefLabel({ groupId: 'g1', label: 'My server' }), 'My server')
+	assertEquals(groupRefLabel({ groupId: 'g1', channelId: 'general' }), '#g1/general')
+})
+
+Deno.test('renderGroupRefBlockHtml escapes hostile label', () => {
+	const html = renderGroupRefBlockHtml({
+		groupId: 'g1',
+		label: '<img src=x onerror=alert(1)>',
+	})
+	assertEquals(html.includes('<img'), false)
+	assertEquals(html.includes('&lt;img src=x onerror=alert(1)&gt;'), true)
+})
+
+Deno.test('formatChannelToken and stripChannelTokens', () => {
+	const token = formatChannelToken('my-group', 'general')
+	assertEquals(token, '#[channel:my-group/general]')
+	const stripped = stripChannelTokens(`hello\n\n${token}\n\ntail`)
+	assertEquals(stripped, 'hello\n\ntail')
+})

--- a/src/public/parts/shells/social/test/pure/hashtags.test.mjs
+++ b/src/public/parts/shells/social/test/pure/hashtags.test.mjs
@@ -1,0 +1,23 @@
+/**
+ * 话题提取与匹配测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { extractHashtagsFromText } from '../../src/lib/hashtags.mjs'
+import { postMatchesQuery } from '../../src/lib/postQuery.mjs'
+
+Deno.test('extractHashtagsFromText skips group refs', () => {
+	const tags = extractHashtagsFromText('see #[channel:mygroup/default] and #hello')
+	assertEquals(tags.includes('hello'), true)
+	assertEquals(tags.includes('mygroup'), false)
+})
+
+Deno.test('extractHashtagsFromText dedupes case', () => {
+	assertEquals(extractHashtagsFromText('#Foo #foo'), ['foo'])
+})
+
+Deno.test('postMatchesQuery uses hashtag tokens only', () => {
+	assertEquals(postMatchesQuery({ content: { text: 'say hello' } }, '#hello'), false)
+	assertEquals(postMatchesQuery({ content: { text: '#hello world' } }, '#hello'), true)
+})

--- a/src/public/parts/shells/social/test/pure/mentions.test.mjs
+++ b/src/public/parts/shells/social/test/pure/mentions.test.mjs
@@ -1,0 +1,27 @@
+/**
+ * Social @ 提及解析单元测试（Deno）。
+ */
+/* global Deno */
+import { extractMentionEntityHashes } from 'fount/public/parts/shells/chat/public/shared/mentions.mjs'
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+
+const SAMPLE_HASH = 'a'.repeat(128)
+
+Deno.test('extractMentionEntityHashes finds bracketed 128-hex mentions', () => {
+	const text = `hi @[entity:${SAMPLE_HASH}] and @[entity:${'b'.repeat(128)}]`
+	const found = extractMentionEntityHashes(text)
+	assertEquals(found.length, 2)
+	assertEquals(found[0], SAMPLE_HASH)
+})
+
+Deno.test('extractMentionEntityHashes ignores bare @128hex', () => {
+	assertEquals(extractMentionEntityHashes(`@${SAMPLE_HASH}`), [])
+	assertEquals(extractMentionEntityHashes('@abcdef'), [])
+	assertEquals(extractMentionEntityHashes(''), [])
+})
+
+Deno.test('extractMentionEntityHashes dedupes', () => {
+	const text = `@[entity:${SAMPLE_HASH}] @[entity:${SAMPLE_HASH.toUpperCase()}]`
+	assertEquals(extractMentionEntityHashes(text).length, 1)
+})

--- a/src/public/parts/shells/social/test/pure/post_query.test.mjs
+++ b/src/public/parts/shells/social/test/pure/post_query.test.mjs
@@ -1,0 +1,35 @@
+/**
+ * postQuery 纯函数测试（Deno）。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { normalizeSearchQuery, postMatchesQuery } from '../../src/lib/postQuery.mjs'
+
+Deno.test('postMatchesQuery requires min length and skips textless posts', () => {
+	assertEquals(postMatchesQuery({ content: { text: 'hello world' } }, 'h'), false)
+	assertEquals(postMatchesQuery({ content: { scheme: 'gsh' } }, 'hello'), false)
+	assertEquals(postMatchesQuery({ content: { text: 'hello world' } }, 'world'), true)
+})
+
+Deno.test('postMatchesQuery matches author entity prefix', () => {
+	const hash = 'a'.repeat(128)
+	assertEquals(postMatchesQuery({
+		entityHash: hash,
+		content: { text: 'x' },
+	}, hash.slice(0, 16)), true)
+})
+
+Deno.test('postMatchesQuery is case insensitive', () => {
+	assertEquals(postMatchesQuery({ content: { text: 'Foo Bar' } }, 'foo'), true)
+})
+
+Deno.test('normalizeSearchQuery detects hashtag', () => {
+	assertEquals(normalizeSearchQuery('#Fount').kind, 'hashtag')
+	assertEquals(normalizeSearchQuery('#Fount').value, 'fount')
+})
+
+Deno.test('postMatchesQuery hashtag does not match unrelated text', () => {
+	assertEquals(postMatchesQuery({ content: { text: 'hello #fount world' } }, '#fount'), true)
+	assertEquals(postMatchesQuery({ content: { text: 'hello fount' } }, '#fount'), false)
+})

--- a/src/public/parts/shells/social/test/pure/run_uri.test.mjs
+++ b/src/public/parts/shells/social/test/pure/run_uri.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * Social runUri 深链测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import {
+	formatSocialPostHref,
+	formatSocialPostPageUri,
+	formatSocialProfileHref,
+	formatSocialSearchHref,
+	parseSocialRunUri,
+} from '../../public/shared/runUri.mjs'
+
+Deno.test('formatSocialSearchHref encodes hashtag query', () => {
+	assertEquals(formatSocialSearchHref('#fount'), '/parts/shells:social/#search;fount')
+	assertEquals(formatSocialSearchHref('hello'), '/parts/shells:social/#search;hello')
+})
+
+Deno.test('parseSocialRunUri reads search subcommand', () => {
+	const parsed = parseSocialRunUri('search;fount')
+	assertEquals(parsed?.subcommand, 'search')
+	assertEquals(parsed?.searchQuery, 'fount')
+})
+
+Deno.test('parseSocialRunUri reads post detail', () => {
+	const parsed = parseSocialRunUri('post;abc;pid1')
+	assertEquals(parsed?.subcommand, 'post')
+	assertEquals(parsed?.entityHash, 'abc')
+	assertEquals(parsed?.postId, 'pid1')
+	assertEquals(parsed?.sharerNodeHash, undefined)
+})
+
+Deno.test('parseSocialRunUri reads post with sharerNodeHash', () => {
+	const parsed = parseSocialRunUri('post;abc;pid1;nodehash64')
+	assertEquals(parsed?.subcommand, 'post')
+	assertEquals(parsed?.entityHash, 'abc')
+	assertEquals(parsed?.postId, 'pid1')
+	assertEquals(parsed?.sharerNodeHash, 'nodehash64')
+})
+
+Deno.test('formatSocialPostHref builds detail hash', () => {
+	assertEquals(formatSocialPostHref('eh', 'pid'), '/parts/shells:social/#post;eh;pid')
+	assertEquals(formatSocialPostHref('eh', 'pid', 'nh'), '/parts/shells:social/#post;eh;pid;nh')
+})
+
+Deno.test('formatSocialProfileHref optional focus post', () => {
+	assertEquals(formatSocialProfileHref('eh'), '/parts/shells:social/#profile;eh')
+	assertEquals(formatSocialProfileHref('eh', 'pid'), '/parts/shells:social/#profile;eh;pid')
+})
+
+Deno.test('formatSocialPostPageUri for external share', () => {
+	assertEquals(formatSocialPostPageUri('eh', 'pid', 'nh'), 'fount://page/parts/shells:social/#post;eh;pid;nh')
+})

--- a/src/public/parts/shells/social/test/pure/search_engine.test.mjs
+++ b/src/public/parts/shells/social/test/pure/search_engine.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * 共享搜索引擎纯测试。
+ */
+/* global Deno */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { indexDocument, queryIndex, removeDocument, patchShardMeta } from 'fount/scripts/search/invertedIndex.mjs'
+import { tokenizeForIndex, tokenizeForQuery } from 'fount/scripts/search/tokenize.mjs'
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+Deno.test('tokenize mixes cjk bigrams and latin words', () => {
+	const tokens = tokenizeForIndex('你好世界 hello #tag')
+	assertEquals(tokens.includes('你好'), true)
+	assertEquals(tokens.includes('好世'), true)
+	assertEquals(tokens.includes('世界'), true)
+	assertEquals(tokens.includes('hello'), true)
+	assertEquals(tokens.includes('#tag'), true)
+})
+
+Deno.test('queryIndex verifies substring truth after bigram recall', async () => {
+	const indexDir = mkdtempSync(join(tmpdir(), 'fount_search_test_'))
+	try {
+		await indexDocument(indexDir, 's1', {
+			id: 'exact',
+			text: '这是测试文本内容',
+			ts: 1,
+			fields: {},
+		})
+		await indexDocument(indexDir, 's1', {
+			id: 'partial',
+			text: '这是测试另一段内容',
+			ts: 2,
+			fields: {},
+		})
+		const hits = await queryIndex({
+			indexDir,
+			shardKeys: ['s1'],
+			query: '测试文本',
+			limit: 10,
+			/**
+			 * 倒排索引候选二次校验。
+			 * @param {object} doc 索引文档行
+			 * @returns {boolean} 正文是否包含查询子串
+			 */
+			verify: doc => doc.text.includes('测试文本'),
+		})
+		assertEquals(hits.length, 1)
+		assertEquals(hits[0].id, 'exact')
+		await removeDocument(indexDir, 's1', 'exact')
+		const afterRemove = await queryIndex({
+			indexDir,
+			shardKeys: ['s1'],
+			query: '测试文本',
+			limit: 10,
+			/**
+			 * 倒排索引候选二次校验。
+			 * @param {object} doc 索引文档行
+			 * @returns {boolean} 正文是否包含查询子串
+			 */
+			verify: doc => doc.text.includes('测试文本'),
+		})
+		assertEquals(afterRemove.length, 0)
+	}
+	finally {
+		rmSync(indexDir, { recursive: true, force: true })
+	}
+})
+
+Deno.test('patchShardMeta stores coverage watermark', async () => {
+	const indexDir = mkdtempSync(join(tmpdir(), 'fount_search_test_'))
+	try {
+		const meta = await patchShardMeta(indexDir, 'ch1', { coverage: { '2026-01': true } })
+		assertEquals(meta.coverage?.['2026-01'], true)
+	}
+	finally {
+		rmSync(indexDir, { recursive: true, force: true })
+	}
+})
+
+Deno.test('tokenizeForQuery matches index tokens', () => {
+	assertEquals(tokenizeForQuery('测试').sort().join(','), tokenizeForIndex('测试').sort().join(','))
+})

--- a/src/public/parts/shells/social/test/pure/taste_cluster.test.mjs
+++ b/src/public/parts/shells/social/test/pure/taste_cluster.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * 口味聚类与 for_you 打分纯函数测试。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+
+import { isTimelineEventVisibleForFederation } from '../../src/federation/visibility.mjs'
+import { scorePostForYou } from '../../src/feed/ranking.mjs'
+import { pickClusterRepresentative } from '../../src/taste/cluster.mjs'
+import { weightedJaccard } from '../../src/taste/jaccard.mjs'
+import { claimTouchesActorTags, pruneClaimInbox } from '../../src/taste/mergeClaims.mjs'
+import { verifyTagMergeClaimWithStats } from '../../src/taste/mergeVerify.mjs'
+import { collapseTasteWeights, normalizeTasteStore, resolveTasteAlias, tasteWeightOf } from '../../src/taste/store.mjs'
+
+Deno.test('weightedJaccard measures overlap', () => {
+	const left = new Map([['a', 1], ['b', 2]])
+	const right = new Map([['a', 1], ['c', 2]])
+	const score = weightedJaccard(left, right)
+	assert(score > 0 && score < 1)
+	assertEquals(weightedJaccard(new Map(), right), 0)
+})
+
+Deno.test('pickClusterRepresentative prefers senior reactors', () => {
+	const junior = new Map([['r1', 1]])
+	const senior = new Map([['r1', 1], ['r2', 1]])
+	const audiences = [junior, senior, senior, junior]
+	const rep = pickClusterRepresentative(audiences)
+	assertEquals(rep, 'r1')
+})
+
+Deno.test('pruneClaimInbox drops expired rows', () => {
+	const now = Date.now()
+	const rows = pruneClaimInbox([
+		{ at: now - 8 * 24 * 60 * 60 * 1000, claim: { from: 'a', to: 'b' }, sourceNodeHash: 's1' },
+		{ at: now, claim: { from: 'c', to: 'd' }, sourceNodeHash: 's2' },
+	])
+	assertEquals(rows.length, 1)
+	assertEquals(rows[0].claim.from, 'c')
+})
+
+Deno.test('resolveTasteAlias stops on cycles', () => {
+	const aliases = {
+		a: { to: 'b', confidence: 1 },
+		b: { to: 'a', confidence: 1 },
+	}
+	assertEquals(resolveTasteAlias('a', aliases), 'a')
+})
+
+Deno.test('claimTouchesActorTags follows canonical to alias', () => {
+	const aliases = { to_raw: { to: 'canon', confidence: 1 } }
+	const actorTags = new Set(['canon'])
+	assertEquals(claimTouchesActorTags('from_new', 'to_raw', actorTags, aliases), true)
+	assertEquals(claimTouchesActorTags('from_new', 'unrelated', actorTags, aliases), false)
+})
+
+Deno.test('collapseTasteWeights folds aliases into one tag', () => {
+	const store = normalizeTasteStore({
+		computed: { a: 1, b: 2 },
+		manual: { a: 3 },
+		aliases: { b: { to: 'a', confidence: 1 } },
+	})
+	const collapsed = collapseTasteWeights(store)
+	assertEquals(collapsed.size, 1)
+	assertEquals(collapsed.get('a'), 6)
+})
+
+Deno.test('normalizeTasteStore reads computed and privacy', () => {
+	const store = normalizeTasteStore({
+		computed: { t1: 3 },
+		privacy: { publishPreferences: false },
+	})
+	assertEquals(store.computed.t1, 3)
+	assertEquals(store.privacy.publishPreferences, false)
+	assertEquals(store.privacy.publishReactions, true)
+	assertEquals(tasteWeightOf(store, 't1'), 3)
+})
+
+Deno.test('tasteWeightOf sums computed and manual', () => {
+	const store = normalizeTasteStore({
+		computed: { t1: 2 },
+		manual: { t1: -1 },
+	})
+	assertEquals(tasteWeightOf(store, 't1'), 1)
+})
+
+Deno.test('verifyTagMergeClaimWithStats rejects low usage', () => {
+	const stats = {
+		usage: new Map([['from', 1], ['to', 5]]),
+		audiences: new Map([
+			['from', new Map([['r1', 1]])],
+			['to', new Map([['r1', 1], ['r2', 1]])],
+		]),
+	}
+	const result = verifyTagMergeClaimWithStats(stats, { from: 'from', to: 'to' })
+	assertEquals(result.ok, false)
+	assertEquals(result.reason, 'usage')
+})
+
+Deno.test('verifyTagMergeClaimWithStats accepts good fit', () => {
+	const shared = new Map([['r1', 1], ['r2', 1], ['r3', 1]])
+	const stats = {
+		usage: new Map([['from', 3], ['to', 3]]),
+		audiences: new Map([
+			['from', shared],
+			['to', new Map(shared)],
+		]),
+	}
+	const result = verifyTagMergeClaimWithStats(stats, { from: 'from', to: 'to' })
+	assert(result.ok)
+	assert(result.confidence > 0)
+})
+
+Deno.test('scorePostForYou higher with tasteMatch than without', () => {
+	const now = Date.now()
+	const post = { id: 'p1', entityHash: 'author', hlc: { wall: now } }
+	const engagement = {
+		likes: new Map(),
+		dislikes: new Map(),
+		reposts: new Map(),
+		replies: new Map(),
+	}
+	const base = scorePostForYou(post, engagement, 0, 0, now)
+	const boosted = scorePostForYou(post, engagement, 0, 4, now)
+	assert(boosted > base)
+})
+
+Deno.test('scorePostForYou demotes on negative tasteMatch', () => {
+	const now = Date.now()
+	const post = { id: 'p1', entityHash: 'author', hlc: { wall: now } }
+	const engagement = {
+		likes: new Map(),
+		dislikes: new Map(),
+		reposts: new Map(),
+		replies: new Map(),
+	}
+	const base = scorePostForYou(post, engagement, 0, 0, now)
+	const demoted = scorePostForYou(post, engagement, 0, -4, now)
+	assert(demoted < base)
+})
+
+Deno.test('federation exports reactions only when publishReactions', () => {
+	const event = { type: 'like', content: {} }
+	/** @returns {boolean} 恒真 */
+	const canView = () => true
+	assertEquals(isTimelineEventVisibleForFederation(event, 'owner', {
+		publishReactions: true,
+		isOwner: false,
+		hideFromDiscovery: false,
+		followsOwner: false,
+		requesterEntityHash: null,
+	}, canView), true)
+	assertEquals(isTimelineEventVisibleForFederation(event, 'owner', {
+		publishReactions: false,
+		isOwner: false,
+		hideFromDiscovery: false,
+		followsOwner: false,
+		requesterEntityHash: null,
+	}, canView), false)
+})
+
+Deno.test('federation exports tag_name only when publishPreferences', () => {
+	const event = { type: 'tag_name', content: { tagHash: 't', locale: 'zh-CN', label: '猫' } }
+	/** @returns {boolean} 恒真 */
+	const canView = () => true
+	assertEquals(isTimelineEventVisibleForFederation(event, 'owner', {
+		publishPreferences: true,
+		publishReactions: true,
+		isOwner: false,
+		hideFromDiscovery: false,
+		followsOwner: false,
+		requesterEntityHash: null,
+	}, canView), true)
+	assertEquals(isTimelineEventVisibleForFederation(event, 'owner', {
+		publishPreferences: false,
+		publishReactions: true,
+		isOwner: false,
+		hideFromDiscovery: false,
+		followsOwner: false,
+		requesterEntityHash: null,
+	}, canView), false)
+})

--- a/src/public/parts/shells/social/test/pure/visibility_spec.test.mjs
+++ b/src/public/parts/shells/social/test/pure/visibility_spec.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * visibilitySpec / canViewPost / 相册 reducer 纯函数测试。
+ */
+/* global Deno */
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import { topologicalCanonicalOrder } from 'npm:@steve02081504/fount-p2p/dag/index'
+
+import { canViewPost } from '../../src/feedVisibility.mjs'
+import {
+	compareVisibilityStrictness,
+	isPublicDiscoverable,
+	minVisibilitySpec,
+	normalizeVisibilitySpec,
+	visibilitySpecsEqual,
+} from '../../src/lib/visibilitySpec.mjs'
+import {
+	createSocialTimelineState,
+	finalizeSocialTimelineView,
+	SOCIAL_TIMELINE_REDUCERS,
+} from '../../src/timeline/reducers.mjs'
+
+const AUTHOR = 'a'.repeat(128)
+const VIEWER = 'b'.repeat(128)
+const OTHER = 'c'.repeat(128)
+
+/**
+ * @param {object} overrides 覆盖
+ * @returns {object} viewerContext
+ */
+function viewerContext(overrides = {}) {
+	return {
+		viewerEntityHash: VIEWER,
+		following: new Set([VIEWER]),
+		followSince: new Map(),
+		at: Date.now(),
+		personalFilter: {
+			blockedEntityHashes: new Set(),
+			blockedSubjects: new Set(),
+			hiddenEntityHashes: new Set(),
+			hiddenSubjects: new Set(),
+		},
+		mutedKeywords: { entries: [] },
+		...overrides,
+	}
+}
+
+Deno.test('normalizeVisibilitySpec expands UI presets', () => {
+	const seven = normalizeVisibilitySpec({ visibility: 'followers_7d' })
+	assertEquals(seven.visibility, 'followers_since')
+	assertEquals(seven.minFollowMs, 7 * 24 * 60 * 60 * 1000)
+	const thirty = normalizeVisibilitySpec({ visibility: 'followers_30d' })
+	assertEquals(thirty.minFollowMs, 30 * 24 * 60 * 60 * 1000)
+})
+
+Deno.test('compareVisibilityStrictness / minVisibilitySpec', () => {
+	assertEquals(compareVisibilityStrictness('public', 'followers') < 0, true)
+	assertEquals(compareVisibilityStrictness('private', 'selected') > 0, true)
+	assertEquals(compareVisibilityStrictness(
+		{ visibility: 'followers_since', minFollowMs: 7 * 86400000 },
+		{ visibility: 'followers_since', minFollowMs: 30 * 86400000 },
+	) < 0, true)
+	const min = minVisibilitySpec(['private', 'followers', 'public'])
+	assertEquals(min?.visibility, 'public')
+})
+
+Deno.test('canViewPost covers new visibility tiers', () => {
+	const following = viewerContext({
+		following: new Set([VIEWER, AUTHOR]),
+		followSince: new Map([[AUTHOR, Date.now() - 10 * 86400000]]),
+	})
+	assertEquals(canViewPost({ entityHash: AUTHOR, content: { visibility: 'unlisted' } }, following), true)
+	assertEquals(canViewPost({ entityHash: AUTHOR, content: { visibility: 'followers_since', minFollowMs: 7 * 86400000 } }, following), true)
+	assertEquals(canViewPost({
+		entityHash: AUTHOR,
+		content: { visibility: 'followers_since', minFollowMs: 30 * 86400000 },
+	}, following), false)
+	assertEquals(canViewPost({
+		entityHash: AUTHOR,
+		content: { visibility: 'selected', allow: [VIEWER] },
+	}, following), true)
+	assertEquals(canViewPost({
+		entityHash: AUTHOR,
+		content: { visibility: 'selected', allow: [OTHER] },
+	}, following), false)
+	assertEquals(canViewPost({ entityHash: AUTHOR, content: { visibility: 'private' } }, following), false)
+	assertEquals(canViewPost({ entityHash: AUTHOR, content: { visibility: 'private' } }, viewerContext({
+		viewerEntityHash: AUTHOR,
+		following: new Set([AUTHOR]),
+	})), true)
+	assertEquals(canViewPost({
+		entityHash: AUTHOR,
+		content: { visibility: 'public', except: [VIEWER] },
+	}, following), false)
+})
+
+Deno.test('isPublicDiscoverable only public', () => {
+	assertEquals(isPublicDiscoverable({ visibility: 'public' }), true)
+	assertEquals(isPublicDiscoverable({ visibility: 'unlisted' }), false)
+	assertEquals(isPublicDiscoverable({ visibility: 'followers' }), false)
+})
+
+Deno.test('visibilitySpecsEqual', () => {
+	assertEquals(visibilitySpecsEqual('public', { visibility: 'public' }), true)
+	assertEquals(visibilitySpecsEqual(
+		{ visibility: 'selected', allow: [OTHER, VIEWER] },
+		{ visibility: 'selected', allow: [VIEWER, OTHER] },
+	), true)
+})
+
+Deno.test('album reducers maintain reverse index and virtual default', () => {
+	const events = [
+		{ id: 'p1', type: 'post', prev_event_ids: [], hlc: { wall: 1 }, content: { text: 'hi', mediaRefs: [{ kind: 'image' }], visibility: 'public' } },
+		{ id: 'p2', type: 'post', prev_event_ids: ['p1'], hlc: { wall: 2 }, content: { text: 'no media', visibility: 'public' } },
+		{ id: 'a1', type: 'album_create', prev_event_ids: ['p2'], hlc: { wall: 3 }, content: { albumId: 'vac', name: 'Vacation', visibility: 'followers' } },
+		{ id: 'l1', type: 'album_post_add', prev_event_ids: ['a1'], hlc: { wall: 4 }, content: { albumId: 'vac', postId: 'p1' } },
+	]
+	const order = topologicalCanonicalOrder(events.map(event => ({
+		id: event.id,
+		prev_event_ids: event.prev_event_ids,
+		hlc: event.hlc,
+		node_id: 'n',
+	})))
+	const state = createSocialTimelineState()
+	const byId = new Map(events.map(event => [event.id, event]))
+	for (const id of order) {
+		const event = byId.get(id)
+		const reduce = SOCIAL_TIMELINE_REDUCERS[event.type]
+		if (reduce) reduce(state, event)
+	}
+	const view = finalizeSocialTimelineView(state, order)
+	assertEquals(view.albums.vac.postIds, ['p1'])
+	assertEquals(view.albumsByPost.p1, ['vac'])
+	assertEquals(view.albums.default.virtual, true)
+	assertEquals(view.albums.default.postIds.includes('p1'), false)
+	assertEquals(view.albums.default.postIds.includes('p2'), false)
+})

--- a/src/public/parts/shells/social/test/seedForeignFeedAuthor.mjs
+++ b/src/public/parts/shells/social/test/seedForeignFeedAuthor.mjs
@@ -1,0 +1,60 @@
+import { Buffer } from 'node:buffer'
+
+import { encodeEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { pubKeyHash, publicKeyFromSeed } from 'npm:@steve02081504/fount-p2p/crypto'
+import { getEntityStore } from 'npm:@steve02081504/fount-p2p/node/instance'
+import { applyNetworkHint } from 'npm:@steve02081504/fount-p2p/node/network'
+
+import { seedRemoteTimeline } from './federation/remote_timeline.mjs'
+
+/** 前端治理菜单烟测用的固定远程作者种子（32 字节）。 */
+export const FOREIGN_FE_SEED = new Uint8Array(Buffer.from('0123456789abcdef'.repeat(4), 'hex'))
+
+const subject = pubKeyHash(publicKeyFromSeed(FOREIGN_FE_SEED))
+
+/** 联邦 ingest 的远程作者 entityHash（与 bootstrap 一致）。 */
+export const FOREIGN_FE_AUTHOR_HASH = encodeEntityHash('f'.repeat(64), subject)
+
+/** bootstrap 写入的公开帖正文前缀（Playwright 定位用）。 */
+export const FOREIGN_FE_POST_MARKER = 'fe-foreign-governance-post'
+
+/**
+ * 为前端测试 ingest 一条远程作者公开帖（供 mute/hide 菜单烟测）。
+ * @param {string} username 测试 replica 登录名
+ * @returns {Promise<{ entityHash: string, postId: string }>} 远程作者实体与帖子 ID
+ */
+export async function seedForeignFeedAuthorPost(username) {
+	applyNetworkHint({
+		nodeHash: 'f'.repeat(64),
+		source: 'test:foreign-feed-author',
+		kind: 'discover',
+		weight: 0.2,
+	})
+	const store = getEntityStore()
+	const existing = await store.readEntityJson(FOREIGN_FE_AUTHOR_HASH, 'profile.json')
+	if (!existing) 
+		await store.writeEntityJson(FOREIGN_FE_AUTHOR_HASH, 'profile.json', {
+			entityHash: FOREIGN_FE_AUTHOR_HASH,
+			nodeHash: 'f'.repeat(64),
+			subjectHash: subject,
+			localized: { 'zh-CN': { name: 'Foreign FE Author' } },
+			status: 'offline',
+			customStatus: '',
+			lastSeenAt: 0,
+			stats: { joinedAt: Date.now(), messageCount: 0, groupCount: 0, channelCount: 0 },
+		})
+	
+
+	const [post] = await seedRemoteTimeline(username, FOREIGN_FE_SEED, FOREIGN_FE_AUTHOR_HASH, [
+		{ type: 'social_meta', content: { hideFromDiscovery: false, createdAt: 1 } },
+		{
+			type: 'post',
+			content: {
+				text: `${FOREIGN_FE_POST_MARKER} ${Date.now()}`,
+				visibility: 'public',
+				locale: 'zh-CN',
+			},
+		},
+	])
+	return { entityHash: FOREIGN_FE_AUTHOR_HASH, postId: post.id }
+}

--- a/src/public/parts/shells/social/test/seedKnownEntity.mjs
+++ b/src/public/parts/shells/social/test/seedKnownEntity.mjs
@@ -1,0 +1,37 @@
+import { parseEntityHash } from 'npm:@steve02081504/fount-p2p/core/entity_id'
+import { getEntityStore, isNodeInitialized } from 'npm:@steve02081504/fount-p2p/node/instance'
+import { applyNetworkHint } from 'npm:@steve02081504/fount-p2p/node/network'
+
+import { SEEDED_TEST_TARGET_HASH } from './frontend/seedConstants.mjs'
+
+/** 前端 / live 烟测共用的可发现占位 entityHash（经 network hint 注册）。 */
+export { SEEDED_TEST_TARGET_HASH }
+
+/**
+ * 将 SEEDED_TEST_TARGET_HASH 注册为可解析目标（network hint + 最小 profile）。
+ * @returns {Promise<void>}
+ */
+export async function seedKnownTestEntityTarget() {
+	if (!isNodeInitialized()) return
+	const parsed = parseEntityHash(SEEDED_TEST_TARGET_HASH)
+	if (!parsed) return
+	applyNetworkHint({
+		nodeHash: parsed.nodeHash,
+		source: 'test:fixture',
+		kind: 'discover',
+		weight: 0.2,
+	})
+	const store = getEntityStore()
+	const existing = await store.readEntityJson(SEEDED_TEST_TARGET_HASH, 'profile.json')
+	if (existing) return
+	await store.writeEntityJson(SEEDED_TEST_TARGET_HASH, 'profile.json', {
+		entityHash: SEEDED_TEST_TARGET_HASH,
+		nodeHash: parsed.nodeHash,
+		subjectHash: parsed.subjectHash,
+		localized: {},
+		status: 'offline',
+		customStatus: '',
+		lastSeenAt: 0,
+		stats: { joinedAt: Date.now(), messageCount: 0, groupCount: 0, channelCount: 0 },
+	})
+}

--- a/src/scripts/test/playwright/ready.mjs
+++ b/src/scripts/test/playwright/ready.mjs
@@ -1,16 +1,10 @@
 /**
  * Playwright 等待 shell 前端 bootstrap 就绪（轮询 `globalThis.fount.test.getState`）。
- * Social gate 仍内联；social shell 落地后再改回模块导入。
  */
 import { HUB_GATE } from 'fount/public/parts/shells/chat/public/hub/gate.mjs'
 import { STICKERS_PAGE_GATE } from 'fount/public/parts/shells/chat/public/stickers/gate.mjs'
+import { SOCIAL_GATE } from 'fount/public/parts/shells/social/public/src/gate.mjs'
 import { ms } from 'fount/scripts/ms.mjs'
-
-const SOCIAL_GATE = {
-	id: 'social',
-	readyEvent: 'fount:social-ready',
-	errorEvent: 'fount:social-error',
-}
 
 /**
  * 在页面内等待 shell 就绪（轮询内存状态，不依赖 DOM attribute）。


### PR DESCRIPTION
## Summary
- Add `shells/social/**` (timeline / discover / live / federation hooks / frontend).
- Add `decl/socialAPI.ts`.
- Playwright `ready.mjs` now imports `SOCIAL_GATE` from the social shell.

Part of [together → master plan](docs/design/together-to-master-pr-plan.md).

## Test plan
- [ ] `fount test --no-parallel shells/social:pure` (or available pure subset)
- [ ] Server boots; open Social shell; timeline loads for local user
- [ ] Hub profile links to social profile URLs resolve