### PR TITLE
Track src/server/test folder icon (desktop.ini)

### DIFF
--- a/src/server/test/desktop.ini
+++ b/src/server/test/desktop.ini
@@ -1,0 +1,6 @@
+[.ShellClassInfo]
+IconResource=C:\WINDOWS\System32\SHELL32.dll,171
+[ViewState]
+Mode=
+Vid=
+FolderType=Generic


### PR DESCRIPTION
## Summary
- Add `src/server/test/desktop.ini` from together so the `server/test` folder keeps its Explorer icon.

Previously left out of the together split as junk; it is intentional folder metadata.

## Test plan
- [ ] File is tracked on master
- [ ] On Windows, `src/server/test` shows the configured shell icon after refresh