### PR TITLE
icon_anime: lava/soil condensation under gravity

### DIFF
--- a/imgs/icon_anime/AGENTS.md
+++ b/imgs/icon_anime/AGENTS.md
@@ -19,7 +19,7 @@ Process-wide singleton used by `fount logo`, the CLI log viewer, and the foregro
 | `intro` | Enter animation, then background `hold` (no park) |
 | `start` / `dismiss` | log_viewer while waiting for the server (`start` no-op if already running; `dismiss` when connected); server `dismiss`es when `init` returns `started` |
 | `farewell` | On `on_shutdown` (safe mid-intro, e.g. `already_running`) |
-| `signal` / `abort` | User abort of this icon session (Ctrl+C or hold Esc ≥4s). `dismiss` does not touch it |
+| `signal` / `abort` | User abort of this icon session (Ctrl+C or hold Esc ≥4s, one-shot). `dismiss` does not touch it. Further ESC repeats / Ctrl+C are ignored until the next `player.start` so farewell exit can finish. |
 
 Hosts own process-exit signaling and must wire `icon.signal` into it (log_viewer and server do). Non-TTY / no VT is gated only in `player.mjs` — session APIs stay callable (play paths no-op). On the alternate screen, `player` `block`/`unblock`s the global virtual console so console output is deferred; frame paint writes the native `targetStream` so the animation itself is not deferred.
 
@@ -31,7 +31,7 @@ fount logo watch   # deno run --watch
 fount test icon_anime --no-parallel
 ```
 
-Controls: Ctrl+C or hold Esc ≥4s exits (icon teardown, then quit). Left quick-click → ripple; left hold/drag → cool spotlight (ambient dims). Right-drag → stroke wind; right long-still → tornado vortex (can suspend rain and lift free-liquid puddles). Alt-screen (`1049h`/`1049l`) restores prior scrollback on exit.
+Controls: Ctrl+C or hold Esc ≥4s exits (teardown plays farewell exit, then quit). Left quick-click → ripple; left hold/drag → cool spotlight (ambient dims). Right-drag → stroke wind; right long-still → tornado vortex (can suspend rain and lift free-liquid puddles). Alt-screen (`1049h`/`1049l`) restores prior scrollback on exit.
 
 ## Modules
 
@@ -75,8 +75,10 @@ Open-stage: ungrown base columns do not splash — rain falls through until it h
 - **One pressure language** / **one density language** — see [physics-notes.md](physics-notes.md). Do not invent parallel hydro models.
 - **Viscosity ladder** is the sole branch knob: `≤ VISC_INERTIAL` → inertial gas velocity; `< VISC_SOLID` → Stokes mass flux; `≥ VISC_SOLID` → frozen.
 - Water mass = `liq + moisture + condense + particles` (`totalWorldWater`); melt is separate. Closed transfers conserve; intentional sinks are world-edge / down-edge wipe / BODY impact. Particle expiry deposits back.
+- Soil condense hangs on the gravity-down face; when ĝ leaves that open underside it reabsorbs into moisture. Drip glyphs follow `condenseDripSource` (ĝ), not screen-down.
 - Terrain is **pedestal-anchored**; ungrown base keeps `HORIZON` until `POOL`/`SLOPE_*` overwrite. Resize shifts retained dynamics with the icon.
 - Gravity is a continuous unit vector everywhere (particles + grid). Depth = projection on ĝ; neighbor transfer uses weights `max(0, d̂·ĝ)`.
 - Four edges hold fractional roles `sink/source/wrap` from `n̂·ĝ` (sum to 1). Lava onset is **exposure work** `exposure[e] = max(0, exposure[e] + n̂·ĝ)` with decay when flipped (≥ `LAVA_ONSET_EXPOSURE`); 45° → two edges each need ~13·√2 s.
 - Gravity acquire: `document` → browser APIs; Termux → `termux-sensor` (pretty JSON indent=2, `parseSensorStdout`); else no-op. path CLI installs `termux-api` on `fount logo` / `log` / `server` when missing.
 - Rain edges weighted by `source`; side wrap by `wrap`. Meltdown absorb records absorb-time ĝ; regurgitate when `ĝ·absorbDir` drops.
+- Composition bottom (pedestal / lava edge) never rains — even when inverted ĝ makes it a physical sky; quiet until sink-edge exposure yields lava.

--- a/imgs/icon_anime/compose.mjs
+++ b/imgs/icon_anime/compose.mjs
@@ -5,8 +5,9 @@
  */
 
 import {
-	MAT, LIQ_DRAW, COND_DRAW, BUBBLE_MIN_CELLS,
-	isLiquidBarrier, isSoilMat, waterChar, liquidChar, dripChar, lavaChar,
+	MAT, LIQ_DRAW, BUBBLE_MIN_CELLS,
+	isLiquidBarrier, waterChar, liquidChar, dripChar, lavaChar,
+	condenseDripSource,
 } from './fluid/index.mjs'
 import { sampleLight, RIPPLE_SPEED, RIPPLE_WIDTH, torchEase } from './gesture/light.mjs'
 import { ICON_W, ICON_BODY_H, PILLARS, BODY_DIST, maxBodyD } from './icon.mjs'
@@ -477,9 +478,9 @@ export const composeFrame = (state) => {
 					fg[i] = FG_BUBBLE
 				}
 				else {
-					const above = vy > 0 ? (vy - 1) * W + wx : -1
-					if (above >= 0 && isSoilMat(mat[above]) && condense[above] >= COND_DRAW) {
-						ch[i] = dripChar(condense[above], wx + frame)
+					const dripSoil = condenseDripSource(world, wx, vy)
+					if (dripSoil >= 0) {
+						ch[i] = dripChar(condense[dripSoil], wx + frame)
 						fg[i] = FG_SPLASH
 					}
 					else if (solid[wi] && vy === surface[wx]) {

--- a/imgs/icon_anime/fluid/index.mjs
+++ b/imgs/icon_anime/fluid/index.mjs
@@ -57,7 +57,7 @@ export {
 } from './gas.mjs'
 
 /** 土壤湿度 / 凝结 / 滴落。 */
-export { stepSoil } from './soil.mjs'
+export { stepSoil, condenseDripSource } from './soil.mjs'
 
 /** 热力与相变。 */
 export { stepThermal, cellRho, meltVisc } from './thermal.mjs'

--- a/imgs/icon_anime/fluid/soil.mjs
+++ b/imgs/icon_anime/fluid/soil.mjs
@@ -2,13 +2,13 @@
  * 土壤湿度 / 凝结 / 滴落。
  *
  * 吸收上方自由液体、土壤间渗流、天花板凝结、Matthew 邻格转移、COND_DRIP 滴落。
- * 由 `stepLiquid` 在水力均衡前调用。
+ * 凝结膜挂在重力下沿；ĝ 转离开放下沿时收回水分。由 `stepLiquid` 在水力均衡前调用。
  */
 
 import {
 	MAT, SOIL_CAP,
 	SOIL_ABSORB_RATE, SOIL_SIDE_FRAC, SOIL_DOWN_FRAC, SOIL_CONDENSE_FRAC,
-	COND_DRIP, COND_MATTHEW_RATE, COND_MATTHEW_NOISE,
+	COND_DRAW, COND_DRIP, COND_MATTHEW_RATE, COND_MATTHEW_NOISE,
 	isSoilMat, isLiquidBarrier, soilAbsorbFactor,
 } from './mat.mjs'
 import {
@@ -40,6 +40,14 @@ const soilQueues = {
 	feedAmt: new Float32Array(0),
 	feedN: 0,
 }
+
+/** 正交邻格，用于收回后溢流。 */
+const ORTHO = [
+	[1, 0],
+	[-1, 0],
+	[0, 1],
+	[0, -1],
+]
 
 /**
  * 将 `moisture[cell]` 钳在 `[0, SOIL_CAP]`。
@@ -90,7 +98,77 @@ const pushFeed = (world, queues, from, amount) => {
 }
 
 /**
- * 土壤渗流：吸收自由液体、共享湿度、供给凝结、Matthew 转移、滴落。
+ * 空气格是否应显示来自重力上方土壤的悬挂凝结。
+ * @param {FluidWorld} world 世界
+ * @param {number} x 列
+ * @param {number} y 行
+ * @returns {number} 土壤格索引，无则 -1
+ */
+export const condenseDripSource = (world, x, y) => {
+	const { mat, condense, worldW: W } = world
+	const up = gravityUpWeights(world)
+	for (let i = 0; i < up.n; i++) {
+		if (up.w[i] < 0.5) continue
+		const sx = x + up.dx[i]
+		const sy = y + up.dy[i]
+		if (!inWorld(world, sx, sy)) continue
+		const soil = sy * W + sx
+		if (isSoilMat(mat[soil]) && condense[soil] >= COND_DRAW) return soil
+	}
+	return -1
+}
+
+/**
+ * 重力下沿是否仍为开放空气（悬挂凝结的附着面）。
+ * @param {FluidWorld} world 世界
+ * @param {number} x 列
+ * @param {number} y 行
+ * @param {{ dx: number[], dy: number[], w: number[], n: number }} down 下向权重
+ * @returns {boolean} 是否开放
+ */
+const hasOpenUnderside = (world, x, y, down) => {
+	const { mat, worldW: W } = world
+	for (let i = 0; i < down.n; i++) {
+		if (down.w[i] < 0.5) continue
+		const bx = x + down.dx[i]
+		const by = y + down.dy[i]
+		if (!inWorld(world, bx, by)) continue
+		if (mat[by * W + bx] === MAT.AIR) return true
+	}
+	return false
+}
+
+/**
+ * 将多余质量溢到邻接空气（先下向，再任意正交）。
+ * @param {FluidWorld} world 世界
+ * @param {number} x 列
+ * @param {number} y 行
+ * @param {number} amount 质量
+ * @param {{ dx: number[], dy: number[], w: number[], n: number }} down 下向权重
+ * @returns {number} 实际写入量
+ */
+const spillToAir = (world, x, y, amount, down) => {
+	if (amount <= 1e-8) return 0
+	for (let i = 0; i < down.n; i++) {
+		if (down.w[i] < 0.5) continue
+		const bx = x + down.dx[i]
+		const by = y + down.dy[i]
+		if (!inWorld(world, bx, by)) continue
+		if (world.mat[by * world.worldW + bx] !== MAT.AIR) continue
+		return addLiquid(world, bx, by, amount)
+	}
+	for (const [dx, dy] of ORTHO) {
+		const nx = x + dx
+		const ny = y + dy
+		if (!inWorld(world, nx, ny)) continue
+		if (world.mat[ny * world.worldW + nx] !== MAT.AIR) continue
+		return addLiquid(world, nx, ny, amount)
+	}
+	return 0
+}
+
+/**
+ * 土壤渗流：吸收自由液体、共享湿度、供给凝结、Matthew 转移、滴落、收回。
  * @param {FluidWorld} world 流体世界
  */
 export const stepSoil = (world) => {
@@ -244,22 +322,27 @@ export const stepSoil = (world) => {
 	applyDelta(moveTargets, moveCount)
 	applyDelta(feedFrom, feedN)
 
+	// Matthew along gravity-perpendicular (sideB is the +1 direction of the pair).
+	const sideDx = sideB.dx
+	const sideDy = sideB.dy
 	for (let y = 0; y < H; y++)
-		for (let x = 0; x < W - 1; x++) {
+		for (let x = 0; x < W; x++) {
+			const nx = x + sideDx
+			const ny = y + sideDy
+			if (!inWorld(world, nx, ny)) continue
 			const cell = y * W + x
-			const right = cell + 1
-			if (!isSoilMat(mat[cell]) || !isSoilMat(mat[right])) continue
+			const other = ny * W + nx
+			if (!isSoilMat(mat[cell]) || !isSoilMat(mat[other])) continue
 			const leftCondense = condense[cell]
-			const rightCondense = condense[right]
+			const rightCondense = condense[other]
 			if (leftCondense < 1e-8 || rightCondense < 1e-8) continue
 			const mass = leftCondense + rightCondense
-			// Cheap LCG — Matthew only needs jitter, not cryptographic randomness.
-			const noise = ((((cell * 374761393) ^ (right * 668265263) ^ (step * 1274126177)) >>> 0) / 4294967296 - 0.5)
+			const noise = ((((cell * 374761393) ^ (other * 668265263) ^ (step * 1274126177)) >>> 0) / 4294967296 - 0.5)
 				* COND_MATTHEW_NOISE * mass
 			const bias = (leftCondense - rightCondense) + noise
 			if (Math.abs(bias) < 1e-8) continue
-			const rich = bias > 0 ? cell : right
-			const poor = bias > 0 ? right : cell
+			const rich = bias > 0 ? cell : other
+			const poor = bias > 0 ? other : cell
 			const take = Math.min(condense[poor] * COND_MATTHEW_RATE, Math.abs(bias) * COND_MATTHEW_RATE)
 			if (take <= 1e-8) continue
 			condense[poor] -= take
@@ -282,5 +365,20 @@ export const stepSoil = (world) => {
 				condense[cell] = amount - added
 				break
 			}
+		}
+
+	// ĝ 转离开放下沿 → 悬挂凝结收回（回潮，满则溢到邻接空气）。
+	for (let y = 0; y < H; y++)
+		for (let x = 0; x < W; x++) {
+			const cell = y * W + x
+			if (!isSoilMat(mat[cell]) || condense[cell] <= 1e-8) continue
+			if (hasOpenUnderside(world, x, y, down)) continue
+			const back = condense[cell]
+			condense[cell] = 0
+			const room = Math.max(0, SOIL_CAP - moisture[cell])
+			const toMoist = Math.min(back, room)
+			moisture[cell] += toMoist
+			const rest = back - toMoist
+			if (rest > 1e-8) spillToAir(world, x, y, rest, down)
 		}
 }

--- a/imgs/icon_anime/fluid/soil.mjs
+++ b/imgs/icon_anime/fluid/soil.mjs
@@ -42,7 +42,7 @@ const soilQueues = {
 }
 
 /** 正交邻格，用于收回后溢流。 */
-const ORTHO = [
+const ORTHOGONAL_OFFSETS = [
 	[1, 0],
 	[-1, 0],
 	[0, 1],
@@ -105,14 +105,13 @@ const pushFeed = (world, queues, from, amount) => {
  * @returns {number} 土壤格索引，无则 -1
  */
 export const condenseDripSource = (world, x, y) => {
-	const { mat, condense, worldW: W } = world
+	const { mat, condense, worldW } = world
 	const up = gravityUpWeights(world)
-	for (let i = 0; i < up.n; i++) {
-		if (up.w[i] < 0.5) continue
-		const sx = x + up.dx[i]
-		const sy = y + up.dy[i]
-		if (!inWorld(world, sx, sy)) continue
-		const soil = sy * W + sx
+	for (let offsetIndex = 0; offsetIndex < up.n; offsetIndex++) {
+		const soilX = x + up.dx[offsetIndex]
+		const soilY = y + up.dy[offsetIndex]
+		if (!inWorld(world, soilX, soilY)) continue
+		const soil = soilY * worldW + soilX
 		if (isSoilMat(mat[soil]) && condense[soil] >= COND_DRAW) return soil
 	}
 	return -1
@@ -127,19 +126,18 @@ export const condenseDripSource = (world, x, y) => {
  * @returns {boolean} 是否开放
  */
 const hasOpenUnderside = (world, x, y, down) => {
-	const { mat, worldW: W } = world
-	for (let i = 0; i < down.n; i++) {
-		if (down.w[i] < 0.5) continue
-		const bx = x + down.dx[i]
-		const by = y + down.dy[i]
-		if (!inWorld(world, bx, by)) continue
-		if (mat[by * W + bx] === MAT.AIR) return true
+	const { mat, worldW } = world
+	for (let offsetIndex = 0; offsetIndex < down.n; offsetIndex++) {
+		const belowX = x + down.dx[offsetIndex]
+		const belowY = y + down.dy[offsetIndex]
+		if (!inWorld(world, belowX, belowY)) continue
+		if (mat[belowY * worldW + belowX] === MAT.AIR) return true
 	}
 	return false
 }
 
 /**
- * 将多余质量溢到邻接空气（先下向，再任意正交）。
+ * 将多余质量溢到邻接空气（按下向权重分配，再任意正交）。
  * @param {FluidWorld} world 世界
  * @param {number} x 列
  * @param {number} y 行
@@ -149,22 +147,36 @@ const hasOpenUnderside = (world, x, y, down) => {
  */
 const spillToAir = (world, x, y, amount, down) => {
 	if (amount <= 1e-8) return 0
-	for (let i = 0; i < down.n; i++) {
-		if (down.w[i] < 0.5) continue
-		const bx = x + down.dx[i]
-		const by = y + down.dy[i]
-		if (!inWorld(world, bx, by)) continue
-		if (world.mat[by * world.worldW + bx] !== MAT.AIR) continue
-		return addLiquid(world, bx, by, amount)
+	let written = 0
+	let weightSum = 0
+	for (let offsetIndex = 0; offsetIndex < down.n; offsetIndex++) {
+		const belowX = x + down.dx[offsetIndex]
+		const belowY = y + down.dy[offsetIndex]
+		if (!inWorld(world, belowX, belowY)) continue
+		if (world.mat[belowY * world.worldW + belowX] !== MAT.AIR) continue
+		weightSum += down.w[offsetIndex]
 	}
-	for (const [dx, dy] of ORTHO) {
-		const nx = x + dx
-		const ny = y + dy
-		if (!inWorld(world, nx, ny)) continue
-		if (world.mat[ny * world.worldW + nx] !== MAT.AIR) continue
-		return addLiquid(world, nx, ny, amount)
+	if (weightSum > 1e-8)
+		for (let offsetIndex = 0; offsetIndex < down.n; offsetIndex++) {
+			const belowX = x + down.dx[offsetIndex]
+			const belowY = y + down.dy[offsetIndex]
+			if (!inWorld(world, belowX, belowY)) continue
+			if (world.mat[belowY * world.worldW + belowX] !== MAT.AIR) continue
+			written += addLiquid(world, belowX, belowY, amount * (down.w[offsetIndex] / weightSum))
+		}
+	let rest = amount - written
+	if (rest <= 1e-8) return written
+	for (const [offsetX, offsetY] of ORTHOGONAL_OFFSETS) {
+		const neighborX = x + offsetX
+		const neighborY = y + offsetY
+		if (!inWorld(world, neighborX, neighborY)) continue
+		if (world.mat[neighborY * world.worldW + neighborX] !== MAT.AIR) continue
+		const got = addLiquid(world, neighborX, neighborY, rest)
+		written += got
+		rest -= got
+		if (rest <= 1e-8) break
 	}
-	return 0
+	return written
 }
 
 /**
@@ -353,32 +365,39 @@ export const stepSoil = (world) => {
 		for (let x = 0; x < W; x++) {
 			const cell = y * W + x
 			if (!isSoilMat(mat[cell]) || condense[cell] < COND_DRIP) continue
-			for (let i = 0; i < down.n; i++) {
-				if (down.w[i] < 0.5) continue
-				const bx = x + down.dx[i]
-				const by = y + down.dy[i]
-				if (!inWorld(world, bx, by)) continue
-				const below = by * W + bx
-				if (mat[below] !== MAT.AIR) continue
-				const amount = condense[cell]
-				const added = addLiquid(world, bx, by, amount)
-				condense[cell] = amount - added
-				break
+			let weightSum = 0
+			for (let offsetIndex = 0; offsetIndex < down.n; offsetIndex++) {
+				const belowX = x + down.dx[offsetIndex]
+				const belowY = y + down.dy[offsetIndex]
+				if (!inWorld(world, belowX, belowY)) continue
+				if (mat[belowY * W + belowX] !== MAT.AIR) continue
+				weightSum += down.w[offsetIndex]
 			}
+			if (weightSum <= 1e-8) continue
+			const amount = condense[cell]
+			let written = 0
+			for (let offsetIndex = 0; offsetIndex < down.n; offsetIndex++) {
+				const belowX = x + down.dx[offsetIndex]
+				const belowY = y + down.dy[offsetIndex]
+				if (!inWorld(world, belowX, belowY)) continue
+				if (mat[belowY * W + belowX] !== MAT.AIR) continue
+				written += addLiquid(world, belowX, belowY, amount * (down.w[offsetIndex] / weightSum))
+			}
+			condense[cell] = amount - written
 		}
 
-	// ĝ 转离开放下沿 → 悬挂凝结收回（回潮，满则溢到邻接空气）。
+	// ĝ 转离开放下沿 → 悬挂凝结收回（回潮，满则溢到邻接空气；溢不完留在 condense）。
 	for (let y = 0; y < H; y++)
 		for (let x = 0; x < W; x++) {
 			const cell = y * W + x
 			if (!isSoilMat(mat[cell]) || condense[cell] <= 1e-8) continue
 			if (hasOpenUnderside(world, x, y, down)) continue
 			const back = condense[cell]
-			condense[cell] = 0
 			const room = Math.max(0, SOIL_CAP - moisture[cell])
 			const toMoist = Math.min(back, room)
 			moisture[cell] += toMoist
 			const rest = back - toMoist
-			if (rest > 1e-8) spillToAir(world, x, y, rest, down)
+			const spilled = rest > 1e-8 ? spillToAir(world, x, y, rest, down) : 0
+			condense[cell] = rest - spilled
 		}
 }

--- a/imgs/icon_anime/physics-notes.md
+++ b/imgs/icon_anime/physics-notes.md
@@ -27,7 +27,7 @@ Day-to-day map / hosting: [AGENTS.md](AGENTS.md). Read this when changing fluid,
 - Weighted ortho neighbors: `w = max(0, d̂·ĝ)` down / `d̂·(−ĝ)` up. Settle / buoyancy / bubbles / soil / free-surface follow these.
 - Edge roles (`edgeRoles`): for outward normal n̂, `sink=max(0,n̂·ĝ)`, `source=max(0,−n̂·ĝ)`, `wrap=1−|n̂·ĝ|`.
 - Exposure work: each tick `exposure[e] = max(0, exposure[e] + n̂_e·ĝ)`. Lava when `exposure[e] ≥ LAVA_ONSET_EXPOSURE` (312 under pure down = 13s@24fps). At 45°, two edges each accumulate cos45/frame → onset ≈ 13·√2 s.
-- Rain spawn uses `source` weights (gravity-down edge never rains). Side wrap uses `wrap`; particles pick wrap vs out with `hash01`.
+- Rain spawn uses `source` weights (gravity-down edge never rains). Composition bottom is never a rain sky (pedestal/lava edge) — inverted ĝ yields no rain there, then lava on the sink edge after exposure. Side wrap uses `wrap`; particles pick wrap vs out with `hash01`.
 - Absorb on source-weighted edges records `absorbGx/Gy`; regurgitate when `ĝ·absorbDir < threshold`, ejecting on current source edges.
 
 ## Terrain
@@ -62,7 +62,7 @@ Day-to-day map / hosting: [AGENTS.md](AGENTS.md). Read this when changing fluid,
 - `liqVx`/`liqVy`: EMA from mass transfers each `stepLiquid` — drives free-liquid glyphs.
 - Communicating vessels: relax `φ = P/(ρg) - depth` along the liquid graph (BFS from lowest-φ surface — no teleport across disconnected air).
 - `POOL` retains fill and spills/leaks; `BODY` is splash-only barrier; pillars are not materials.
-- Soil: absorb diminishes as cell wets (`soilAbsorbFactor`); rain hits sink only `SOIL_HIT_ABSORB_FRAC`. Seepage slow enough for surface puddles. Sideways share + prefer below (gravity-weighted); air below → underside `condense`; Matthew transfer between condensation cells; `COND_DRAW` / `COND_DRIP` thresholds. Heating evaporates moisture before melt.
+- Soil: absorb diminishes as cell wets (`soilAbsorbFactor`); rain hits sink only `SOIL_HIT_ABSORB_FRAC`. Seepage slow enough for surface puddles. Sideways share + prefer below (gravity-weighted); air below → underside `condense`; Matthew along ĝ⊥; `COND_DRAW` / `COND_DRIP` thresholds. When ĝ leaves an open underside, condense reabsorbs into moisture (excess spills to ortho air). Compose drips via `condenseDripSource` (gravity-up soil), not screen-Y. Heating evaporates moisture before melt.
 - Material rebuild clears labels only; `releaseNonSoilWater` dumps moisture/condense from non-soil into free liquid so `POOL` overwrite does not erase water.
 - `exit` stops when the icon is gone — no rain/liquid drain wait.
 

--- a/imgs/icon_anime/player.mjs
+++ b/imgs/icon_anime/player.mjs
@@ -76,7 +76,10 @@ export function createEscHold(holdMs = ESC_HOLD_MS, gapMs = ESC_HOLD_GAP_MS) {
 			fired = true
 			return true
 		},
-		/** @returns {void} */
+		/**
+		 * 清除 start、last、fired，重新允许一次触发。
+		 * @returns {void}
+		 */
 		reset() {
 			start = null
 			last = 0

--- a/imgs/icon_anime/player.mjs
+++ b/imgs/icon_anime/player.mjs
@@ -53,28 +53,34 @@ export const ESC_HOLD_GAP_MS = 500
 
 /**
  * ESC 长按计时：靠终端键重复确认仍在按住；无松开事件。
+ * 触发一次后保持闩锁，避免退场动画播放期间键重复再次 abort。
  * @param {number} [holdMs] 触发中止的持续时长
  * @param {number} [gapMs] 允许的最大重复间隔
- * @returns {{ note: (now: number) => boolean, reset: () => void }} note 在达到 holdMs 时返回 true
+ * @returns {{ note: (now: number) => boolean, reset: () => void }} note 在达到 holdMs 时返回 true（仅一次）
  */
 export function createEscHold(holdMs = ESC_HOLD_MS, gapMs = ESC_HOLD_GAP_MS) {
 	/** @type {number | null} */
 	let start = null
 	let last = 0
+	let fired = false
 	return {
 		/**
 		 * @param {number} now 单调时钟（ms）
-		 * @returns {boolean} 是否已连续按住满 holdMs
+		 * @returns {boolean} 是否刚达到 holdMs（已触发过则恒 false）
 		 */
 		note(now) {
+			if (fired) return false
 			if (start == null || now - last > gapMs) start = now
 			last = now
-			return now - start >= holdMs
+			if (now - start < holdMs) return false
+			fired = true
+			return true
 		},
 		/** @returns {void} */
 		reset() {
 			start = null
 			last = 0
+			fired = false
 		},
 	}
 }
@@ -200,6 +206,18 @@ export function start({ onResize, onPointer, onUserAbort } = {}) {
 	process.stdin.setRawMode(true)
 	process.stdin.resume()
 	const escHold = createEscHold()
+	/** 首次用户中止后闩上，避免 farewell 退场被 ESC 重复 / 连按 Ctrl+C 掐断。 */
+	let userAbortArmed = true
+	/**
+	 * 触发一次用户中止（幂等）。
+	 * @returns {void}
+	 */
+	const tripUserAbort = () => {
+		if (!userAbortArmed) return
+		userAbortArmed = false
+		abort()
+		onUserAbort?.()
+	}
 	/**
 	 * Ctrl+C / 长按 ESC 中止；SGR 鼠标 → onPointer。
 	 * @param {Buffer} buf stdin 块
@@ -207,16 +225,11 @@ export function start({ onResize, onPointer, onUserAbort } = {}) {
 	 */
 	onData = (buf) => {
 		stdinCarry = consumeStdin(stdinCarry, buf, {
-			/** Ctrl+C：中止播放并通知会话。 */
-			abort: () => {
-				abort()
-				onUserAbort?.()
-			},
+			abort: tripUserAbort,
 			/** ESC 键重复：连续按住满 ESC_HOLD_MS 则中止。 */
 			onEsc: () => {
 				if (!escHold.note(performance.now())) return
-				abort()
-				onUserAbort?.()
+				tripUserAbort()
 			},
 			onPointer,
 		})

--- a/imgs/icon_anime/scene.mjs
+++ b/imgs/icon_anime/scene.mjs
@@ -526,6 +526,8 @@ const onParticleHit = (world, x, y, m, particle, wet, state) => {
 
 /**
  * 四边出雨权重（source 角色）。导出供测试。
+ * 组成底边（地形/岩浆侧）永不作出雨天：倒置时 ĝ 穿入底边会把雨从基座往上喷，
+ * 应静等 sink 边曝露后出岩浆，而不是底边冒雨。
  * @param {number} gx 单位重力 x
  * @param {number} gy 单位重力 y
  * @returns {{ nx: number, ny: number, w: number }[]} 边权重
@@ -542,9 +544,11 @@ export const rainEdgeWeights = (gx, gy) => {
 		// source = max(0, −n̂·ĝ); sink edge never rains
 		e.w = Math.max(0, -dot)
 	}
+	// Pedestal / lava edge of the composition — never a rain sky.
+	edges[1].w = 0
 	// Side edges get a small base so left/right can randomly rain under default g.
-	const top = edges.find(e => e.ny < 0)
-	if (top && top.w > 0.5) {
+	const top = edges[0]
+	if (top.w > 0.5) {
 		edges[2].w = Math.max(edges[2].w, 0.12)
 		edges[3].w = Math.max(edges[3].w, 0.12)
 	}

--- a/imgs/icon_anime/scene.mjs
+++ b/imgs/icon_anime/scene.mjs
@@ -547,8 +547,7 @@ export const rainEdgeWeights = (gx, gy) => {
 	// Pedestal / lava edge of the composition — never a rain sky.
 	edges[1].w = 0
 	// Side edges get a small base so left/right can randomly rain under default g.
-	const top = edges[0]
-	if (top.w > 0.5) {
+	if (edges[0].w > 0.5) {
 		edges[2].w = Math.max(edges[2].w, 0.12)
 		edges[3].w = Math.max(edges[3].w, 0.12)
 	}

--- a/imgs/icon_anime/test/anim.test.mjs
+++ b/imgs/icon_anime/test/anim.test.mjs
@@ -360,6 +360,9 @@ Deno.test('createEscHold: abort after continuous ESC ≥ 4s; gap resets', async 
 	for (let t = 100; t < ESC_HOLD_MS; t += 100)
 		assertEquals(hold.note(t), false)
 	assertEquals(hold.note(ESC_HOLD_MS), true)
+	// Once tripped, further repeats must not re-fire (would abort farewell mid-exit).
+	assertEquals(hold.note(ESC_HOLD_MS + 50), false)
+	assertEquals(hold.note(ESC_HOLD_MS + 200), false)
 	// Gap beyond ESC_HOLD_GAP_MS restarts the hold clock
 	const again = createEscHold()
 	assertEquals(again.note(0), false)
@@ -369,6 +372,23 @@ Deno.test('createEscHold: abort after continuous ESC ≥ 4s; gap resets', async 
 	for (let t = 100; t < ESC_HOLD_MS; t += 100)
 		assertEquals(again.note(restart + t), false)
 	assertEquals(again.note(restart + ESC_HOLD_MS), true)
+	assertEquals(again.note(restart + ESC_HOLD_MS + 100), false)
+})
+
+Deno.test('createEscHold: reset re-arms after a trip', async () => {
+	const { createEscHold, ESC_HOLD_MS } = await import('../player.mjs')
+	const hold = createEscHold()
+	assertEquals(hold.note(0), false)
+	for (let t = 100; t < ESC_HOLD_MS; t += 100)
+		assertEquals(hold.note(t), false)
+	assertEquals(hold.note(ESC_HOLD_MS), true)
+	assertEquals(hold.note(ESC_HOLD_MS + 10), false)
+	hold.reset()
+	const t0 = 50_000
+	assertEquals(hold.note(t0), false)
+	for (let t = 100; t < ESC_HOLD_MS; t += 100)
+		assertEquals(hold.note(t0 + t), false)
+	assertEquals(hold.note(t0 + ESC_HOLD_MS), true)
 })
 
 Deno.test('wind gesture: stroke speed + clockwise vortex + release clear', async () => {

--- a/imgs/icon_anime/test/anim.test.mjs
+++ b/imgs/icon_anime/test/anim.test.mjs
@@ -379,16 +379,16 @@ Deno.test('createEscHold: reset re-arms after a trip', async () => {
 	const { createEscHold, ESC_HOLD_MS } = await import('../player.mjs')
 	const hold = createEscHold()
 	assertEquals(hold.note(0), false)
-	for (let t = 100; t < ESC_HOLD_MS; t += 100)
-		assertEquals(hold.note(t), false)
+	for (let elapsedMs = 100; elapsedMs < ESC_HOLD_MS; elapsedMs += 100)
+		assertEquals(hold.note(elapsedMs), false)
 	assertEquals(hold.note(ESC_HOLD_MS), true)
 	assertEquals(hold.note(ESC_HOLD_MS + 10), false)
 	hold.reset()
-	const t0 = 50_000
-	assertEquals(hold.note(t0), false)
-	for (let t = 100; t < ESC_HOLD_MS; t += 100)
-		assertEquals(hold.note(t0 + t), false)
-	assertEquals(hold.note(t0 + ESC_HOLD_MS), true)
+	const resetTimestamp = 50_000
+	assertEquals(hold.note(resetTimestamp), false)
+	for (let elapsedMs = 100; elapsedMs < ESC_HOLD_MS; elapsedMs += 100)
+		assertEquals(hold.note(resetTimestamp + elapsedMs), false)
+	assertEquals(hold.note(resetTimestamp + ESC_HOLD_MS), true)
 })
 
 Deno.test('wind gesture: stroke speed + clockwise vortex + release clear', async () => {

--- a/imgs/icon_anime/test/fluid.test.mjs
+++ b/imgs/icon_anime/test/fluid.test.mjs
@@ -9,11 +9,12 @@ import {
 	stepFluid, labelAirRegions, pressureAt, liquidPressureAt, totalSealedGas, totalGridWater,
 	totalWorldWater, P_ATM, ATM_HYDRO,
 	clearMaterials, idx, RHO_G, RHO_AIR,
-	COND_DRIP, SOIL_CAP, SOIL_HIT_ABSORB_FRAC, soilAbsorbFactor, LIQ_DRAW,
+	COND_DRIP, COND_DRAW, SOIL_CAP, SOIL_HIT_ABSORB_FRAC, soilAbsorbFactor, LIQ_DRAW,
 	waterChar, liquidChar, pickWaterGlyph, FALL_HEAVY,
 	WATER_STILL, WATER_FALL, WATER_HIGH_L, WATER_HIGH_R, WATER_LOW_DL, WATER_LOW_DR,
 	globalWindAt, windShear, gasVelocityAt, dynamicPressure,
 	staticPressureAt, spawnParticle, liftLiquidByWind, verticalGasDrag, GAS_DRAG, GAS_DRAG_Y,
+	applyGravityToWorld, PARTICLE_GRAVITY, condenseDripSource,
 } from '../fluid/index.mjs'
 
 /**
@@ -402,6 +403,61 @@ Deno.test('fluid: soil ceiling condenses then drips into air below', () => {
 	}
 	assert(sawCondense || world.liq[idx(world, 5, 5)] > 0.05 || world.liq[idx(world, 5, 6)] > 0.05 || world.liq[idx(world, 5, 7)] > 0.05)
 	assertAlmostEquals(totalGridWater(world), before, 1e-3)
+})
+
+Deno.test('fluid: soil condense retracts when gravity leaves the open underside', () => {
+	const world = createWorld({ width: 12, height: 12, margin: 1, bottomExtra: 1 })
+	clearMaterials(world)
+	// Horizontal soil slab: air below, solid/seal above and around — flip to up removes underside air.
+	for (let x = 3; x <= 7; x++) {
+		setMat(world, x, 4, MAT.SOLID)
+		setMat(world, x, 3, MAT.SEAL)
+	}
+	world.condense[idx(world, 5, 4)] = 0.7
+	world.moisture[idx(world, 5, 4)] = 0.2
+	const water0 = totalGridWater(world)
+	applyGravityToWorld(world, { gx: 0, gy: -1, mag: PARTICLE_GRAVITY })
+	for (let i = 0; i < 3; i++) stepSoil(world)
+	assertLess(world.condense[idx(world, 5, 4)], 0.05)
+	assertGreater(world.moisture[idx(world, 5, 4)], 0.2)
+	assertAlmostEquals(totalGridWater(world), water0, 1e-3)
+})
+
+Deno.test('fluid: soil condense / drip follow sideways gravity', () => {
+	const world = createWorld({ width: 14, height: 12, margin: 1, bottomExtra: 1 })
+	clearMaterials(world)
+	// Vertical soil wall with air on the left; gravity pulls left.
+	for (let y = 3; y <= 8; y++) {
+		setMat(world, 7, y, MAT.SOLID)
+		setMat(world, 10, y, MAT.SEAL)
+	}
+	addMoisture(world, 7, 5, 1)
+	applyGravityToWorld(world, { gx: -1, gy: 0, mag: PARTICLE_GRAVITY })
+	const before = totalGridWater(world)
+	let saw = false
+	for (let i = 0; i < 50; i++) {
+		stepSoil(world)
+		if (world.condense[idx(world, 7, 5)] >= COND_DRAW * 0.5) saw = true
+		if (world.liq[idx(world, 6, 5)] > 0.05) saw = true
+	}
+	assert(saw)
+	// Must not keep forming / dripping on the old screen-down face.
+	assertLess(world.liq[idx(world, 7, 6)], world.liq[idx(world, 6, 5)] + 0.2)
+	assertAlmostEquals(totalGridWater(world), before, 1e-3)
+})
+
+Deno.test('fluid: condense drip glyph follows gravity, not screen-down', () => {
+	const world = createWorld({ width: 10, height: 10, margin: 0, bottomExtra: 0 })
+	clearMaterials(world)
+	setMat(world, 5, 5, MAT.SOLID)
+	world.condense[idx(world, 5, 5)] = COND_DRAW + 0.1
+	// Default down: drip shows on cell below soil.
+	assertEquals(condenseDripSource(world, 5, 6), idx(world, 5, 5))
+	assertEquals(condenseDripSource(world, 4, 5), -1)
+	// Sideways: drip on the gravity-down neighbor, not screen-below.
+	applyGravityToWorld(world, { gx: -1, gy: 0, mag: PARTICLE_GRAVITY })
+	assertEquals(condenseDripSource(world, 4, 5), idx(world, 5, 5))
+	assertEquals(condenseDripSource(world, 5, 6), -1)
 })
 
 Deno.test('fluid: condensation Matthew effect amplifies the lead with noise', () => {

--- a/imgs/icon_anime/test/fluid.test.mjs
+++ b/imgs/icon_anime/test/fluid.test.mjs
@@ -417,7 +417,7 @@ Deno.test('fluid: soil condense retracts when gravity leaves the open underside'
 	world.moisture[idx(world, 5, 4)] = 0.2
 	const water0 = totalGridWater(world)
 	applyGravityToWorld(world, { gx: 0, gy: -1, mag: PARTICLE_GRAVITY })
-	for (let i = 0; i < 3; i++) stepSoil(world)
+	for (let stepIndex = 0; stepIndex < 3; stepIndex++) stepSoil(world)
 	assertLess(world.condense[idx(world, 5, 4)], 0.05)
 	assertGreater(world.moisture[idx(world, 5, 4)], 0.2)
 	assertAlmostEquals(totalGridWater(world), water0, 1e-3)
@@ -434,15 +434,16 @@ Deno.test('fluid: soil condense / drip follow sideways gravity', () => {
 	addMoisture(world, 7, 5, 1)
 	applyGravityToWorld(world, { gx: -1, gy: 0, mag: PARTICLE_GRAVITY })
 	const before = totalGridWater(world)
-	let saw = false
-	for (let i = 0; i < 50; i++) {
+	let sawCondenseOrDrip = false
+	for (let stepIndex = 0; stepIndex < 120; stepIndex++) {
 		stepSoil(world)
-		if (world.condense[idx(world, 7, 5)] >= COND_DRAW * 0.5) saw = true
-		if (world.liq[idx(world, 6, 5)] > 0.05) saw = true
+		if (world.condense[idx(world, 7, 5)] >= COND_DRAW * 0.5) sawCondenseOrDrip = true
+		if (world.liq[idx(world, 6, 5)] > 0.05) sawCondenseOrDrip = true
 	}
-	assert(saw)
+	assert(sawCondenseOrDrip)
 	// Must not keep forming / dripping on the old screen-down face.
-	assertLess(world.liq[idx(world, 7, 6)], world.liq[idx(world, 6, 5)] + 0.2)
+	assertAlmostEquals(world.liq[idx(world, 7, 6)], 0, 0.05)
+	assertGreater(world.liq[idx(world, 6, 5)], 0.05)
 	assertAlmostEquals(totalGridWater(world), before, 1e-3)
 })
 
@@ -458,6 +459,66 @@ Deno.test('fluid: condense drip glyph follows gravity, not screen-down', () => {
 	applyGravityToWorld(world, { gx: -1, gy: 0, mag: PARTICLE_GRAVITY })
 	assertEquals(condenseDripSource(world, 4, 5), idx(world, 5, 5))
 	assertEquals(condenseDripSource(world, 5, 6), -1)
+})
+
+Deno.test('fluid: soil condense uses weak gravity-projection face', () => {
+	// ĝ mostly +x with weak +y (w_y < 0.5) — only the weak face is open air.
+	const gx = 0.92
+	const gy = Math.sqrt(1 - gx * gx)
+	assertLess(gy, 0.5)
+
+	const world = createWorld({ width: 12, height: 12, margin: 1, bottomExtra: 1 })
+	clearMaterials(world)
+	setMat(world, 5, 5, MAT.SOLID)
+	// Seal every ortho face except weak-down (5,6) so reclaim only triggers after ĝ flips.
+	setMat(world, 6, 5, MAT.SEAL)
+	setMat(world, 4, 5, MAT.SEAL)
+	setMat(world, 5, 4, MAT.SEAL)
+	applyGravityToWorld(world, { gx, gy, mag: PARTICLE_GRAVITY })
+
+	world.condense[idx(world, 5, 5)] = COND_DRAW + 0.1
+	assertEquals(condenseDripSource(world, 5, 6), idx(world, 5, 5))
+
+	world.condense[idx(world, 5, 5)] = COND_DRIP
+	const water0 = totalGridWater(world)
+	stepSoil(world)
+	assertGreater(world.liq[idx(world, 5, 6)], 0.05)
+	assertAlmostEquals(world.liq[idx(world, 6, 5)], 0, 1e-6)
+	assertAlmostEquals(totalGridWater(world), water0, 1e-3)
+
+	// Still hanging on the weak open underside — no reclaim yet.
+	world.condense[idx(world, 5, 5)] = 0.6
+	world.moisture[idx(world, 5, 5)] = 0.2
+	world.liq[idx(world, 5, 6)] = 0
+	const hangWater = totalGridWater(world)
+	stepSoil(world)
+	assertGreater(world.condense[idx(world, 5, 5)], 0.5)
+	assertAlmostEquals(totalGridWater(world), hangWater, 1e-3)
+
+	// Flip ĝ away from the weak face → sealed downs → reclaim into moisture.
+	applyGravityToWorld(world, { gx: -gx, gy: -gy, mag: PARTICLE_GRAVITY })
+	stepSoil(world)
+	assertLess(world.condense[idx(world, 5, 5)], 0.05)
+	assertGreater(world.moisture[idx(world, 5, 5)], 0.2)
+	assertAlmostEquals(totalGridWater(world), hangWater, 1e-3)
+})
+
+Deno.test('fluid: condense reclaim keeps unsunk mass for later ticks', () => {
+	const world = createWorld({ width: 8, height: 8, margin: 0, bottomExtra: 0 })
+	clearMaterials(world)
+	// Soil fully sealed — reclaim cannot spill; rest must stay in condense.
+	for (let y = 2; y <= 4; y++)
+		for (let x = 2; x <= 4; x++)
+			setMat(world, x, y, MAT.SEAL)
+	setMat(world, 3, 3, MAT.SOLID)
+	world.moisture[idx(world, 3, 3)] = SOIL_CAP
+	world.condense[idx(world, 3, 3)] = 0.55
+	applyGravityToWorld(world, { gx: 0, gy: -1, mag: PARTICLE_GRAVITY })
+	const water0 = totalGridWater(world)
+	stepSoil(world)
+	assertAlmostEquals(world.moisture[idx(world, 3, 3)], SOIL_CAP, 1e-6)
+	assertAlmostEquals(world.condense[idx(world, 3, 3)], 0.55, 1e-6)
+	assertAlmostEquals(totalGridWater(world), water0, 1e-6)
 })
 
 Deno.test('fluid: condensation Matthew effect amplifies the lead with noise', () => {

--- a/imgs/icon_anime/test/gravity_lava.test.mjs
+++ b/imgs/icon_anime/test/gravity_lava.test.mjs
@@ -8,7 +8,7 @@ import {
 	createWorld, addMelt, setMat, stepFluid, stepThermal, stepBoundary,
 	stepParticles, spawnParticle, MAT, LIQ_DRAW, T_MAX, T_LIQUIDUS, T_SOLIDUS,
 	LAVA_ONSET_EXPOSURE, rhoOf, viscOf, SUBSTANCE, totalMelt, applyGravityToWorld,
-	neighborCoord, regurgitateTemp, clearMaterials, EDGE_BOTTOM, EDGE_LEFT,
+	neighborCoord, regurgitateTemp, clearMaterials, EDGE_TOP, EDGE_BOTTOM, EDGE_LEFT,
 	pressureAt, liquidPressureAt, hydraulicPhi, gravityDepth,
 	totalWorldWater, addLiquid, labelAirRegions, totalSealedGas,
 } from '../fluid/index.mjs'
@@ -58,6 +58,17 @@ Deno.test('rain edges: pure left gravity → right edge dominates', () => {
 	assertEquals(left.w, 0)
 })
 
+Deno.test('rain edges: inverted gravity → no bottom rain (composition ground)', () => {
+	// gy<0 makes the screen bottom a physical sky; raining from there looks like
+	// the pedestal spurting upward. Composition bottom never rains — wait for lava.
+	const edges = rainEdgeWeights(0, -1)
+	const bot = edges.find(e => e.ny > 0)
+	const top = edges.find(e => e.ny < 0)
+	assertEquals(bot.w, 0)
+	assertEquals(top.w, 0)
+	assertEquals(edges.reduce((s, e) => s + e.w, 0), 0)
+})
+
 Deno.test('rain edges: pickRainEdge respects weights', () => {
 	const edges = rainEdgeWeights(0, 1)
 	const picks = { top: 0, left: 0, right: 0, bottom: 0 }
@@ -70,6 +81,30 @@ Deno.test('rain edges: pickRainEdge respects weights', () => {
 	}
 	assertEquals(picks.bottom, 0)
 	assertGreater(picks.top, picks.left)
+})
+
+Deno.test('lava: inverted gravity — quiet then onset on new down edge (top)', () => {
+	const world = createWorld({ width: 10, height: 10, margin: 0, bottomExtra: 0 })
+	clearMaterials(world)
+	world.gravity = { gx: 0, gy: -1, mag: BASE_PARTICLE_G }
+	applyGravityToWorld(world, world.gravity)
+	const edges = rainEdgeWeights(0, -1)
+	assertEquals(edges.find(e => e.ny > 0).w, 0)
+	for (let i = 0; i < LAVA_ONSET_EXPOSURE - 2; i++)
+		stepBoundary(world)
+	assertLess(totalMelt(world), 0.01)
+	for (let i = 0; i < 4; i++)
+		stepBoundary(world)
+	assertGreater(totalMelt(world), 0.1)
+	const W = world.worldW
+	let topMelt = 0
+	let botMelt = 0
+	for (let x = 0; x < W; x++) {
+		topMelt += world.melt[x]
+		botMelt += world.melt[(world.worldH - 1) * W + x]
+	}
+	assertGreater(topMelt, botMelt)
+	assertGreater(world.boundary.exposure[EDGE_TOP], LAVA_ONSET_EXPOSURE - 1)
 })
 
 Deno.test('particles: vector gravity displaces in g direction', () => {

--- a/imgs/icon_anime/test/gravity_lava.test.mjs
+++ b/imgs/icon_anime/test/gravity_lava.test.mjs
@@ -40,10 +40,10 @@ Deno.test('gravity: flat device returns null', () => {
 
 Deno.test('rain edges: default down → no bottom, top dominant, sides nonzero', () => {
 	const edges = rainEdgeWeights(0, 1)
-	const top = edges.find(e => e.ny < 0)
-	const bot = edges.find(e => e.ny > 0)
-	const left = edges.find(e => e.nx < 0)
-	const right = edges.find(e => e.nx > 0)
+	const top = edges.find(edge => edge.ny < 0)
+	const bot = edges.find(edge => edge.ny > 0)
+	const left = edges.find(edge => edge.nx < 0)
+	const right = edges.find(edge => edge.nx > 0)
 	assertGreater(top.w, 0.5)
 	assertEquals(bot.w, 0)
 	assertGreater(left.w, 0)
@@ -52,8 +52,8 @@ Deno.test('rain edges: default down → no bottom, top dominant, sides nonzero',
 
 Deno.test('rain edges: pure left gravity → right edge dominates', () => {
 	const edges = rainEdgeWeights(-1, 0)
-	const right = edges.find(e => e.nx > 0)
-	const left = edges.find(e => e.nx < 0)
+	const right = edges.find(edge => edge.nx > 0)
+	const left = edges.find(edge => edge.nx < 0)
 	assertGreater(right.w, left.w)
 	assertEquals(left.w, 0)
 })
@@ -62,21 +62,19 @@ Deno.test('rain edges: inverted gravity → no bottom rain (composition ground)'
 	// gy<0 makes the screen bottom a physical sky; raining from there looks like
 	// the pedestal spurting upward. Composition bottom never rains — wait for lava.
 	const edges = rainEdgeWeights(0, -1)
-	const bot = edges.find(e => e.ny > 0)
-	const top = edges.find(e => e.ny < 0)
-	assertEquals(bot.w, 0)
-	assertEquals(top.w, 0)
-	assertEquals(edges.reduce((s, e) => s + e.w, 0), 0)
+	assertEquals(edges.find(edge => edge.ny > 0).w, 0)
+	assertEquals(edges.find(edge => edge.ny < 0).w, 0)
+	assertEquals(edges.reduce((weightSum, edge) => weightSum + edge.w, 0), 0)
 })
 
 Deno.test('rain edges: pickRainEdge respects weights', () => {
 	const edges = rainEdgeWeights(0, 1)
 	const picks = { top: 0, left: 0, right: 0, bottom: 0 }
-	for (let i = 0; i < 200; i++) {
-		const e = pickRainEdge(edges, i / 200)
-		if (e.ny < 0) picks.top++
-		else if (e.ny > 0) picks.bottom++
-		else if (e.nx < 0) picks.left++
+	for (let stepIndex = 0; stepIndex < 200; stepIndex++) {
+		const edge = pickRainEdge(edges, stepIndex / 200)
+		if (edge.ny < 0) picks.top++
+		else if (edge.ny > 0) picks.bottom++
+		else if (edge.nx < 0) picks.left++
 		else picks.right++
 	}
 	assertEquals(picks.bottom, 0)
@@ -86,24 +84,23 @@ Deno.test('rain edges: pickRainEdge respects weights', () => {
 Deno.test('lava: inverted gravity — quiet then onset on new down edge (top)', () => {
 	const world = createWorld({ width: 10, height: 10, margin: 0, bottomExtra: 0 })
 	clearMaterials(world)
-	world.gravity = { gx: 0, gy: -1, mag: BASE_PARTICLE_G }
-	applyGravityToWorld(world, world.gravity)
+	applyGravityToWorld(world, { gx: 0, gy: -1, mag: BASE_PARTICLE_G })
 	const edges = rainEdgeWeights(0, -1)
-	assertEquals(edges.find(e => e.ny > 0).w, 0)
-	for (let i = 0; i < LAVA_ONSET_EXPOSURE - 2; i++)
+	assertEquals(edges.find(edge => edge.ny > 0).w, 0)
+	for (let stepIndex = 0; stepIndex < LAVA_ONSET_EXPOSURE - 2; stepIndex++)
 		stepBoundary(world)
 	assertLess(totalMelt(world), 0.01)
-	for (let i = 0; i < 4; i++)
+	for (let stepIndex = 0; stepIndex < 4; stepIndex++)
 		stepBoundary(world)
 	assertGreater(totalMelt(world), 0.1)
-	const W = world.worldW
+	const worldWidth = world.worldW
 	let topMelt = 0
-	let botMelt = 0
-	for (let x = 0; x < W; x++) {
-		topMelt += world.melt[x]
-		botMelt += world.melt[(world.worldH - 1) * W + x]
+	let bottomMelt = 0
+	for (let column = 0; column < worldWidth; column++) {
+		topMelt += world.melt[column]
+		bottomMelt += world.melt[(world.worldH - 1) * worldWidth + column]
 	}
-	assertGreater(topMelt, botMelt)
+	assertGreater(topMelt, bottomMelt)
 	assertGreater(world.boundary.exposure[EDGE_TOP], LAVA_ONSET_EXPOSURE - 1)
 })
 
@@ -137,14 +134,13 @@ Deno.test('lava: onset after LAVA_ONSET_EXPOSURE on down edge', () => {
 Deno.test('lava: 45° accumulates exposure on two edges; onset ≈ 312·√2', () => {
 	const world = createWorld({ width: 10, height: 10, margin: 0, bottomExtra: 0 })
 	clearMaterials(world)
-	const s = Math.SQRT1_2
-	world.gravity = { gx: -s, gy: s, mag: BASE_PARTICLE_G }
-	applyGravityToWorld(world, world.gravity)
-	const need = LAVA_ONSET_EXPOSURE / s
-	for (let i = 0; i < (need | 0) - 2; i++)
+	const invSqrt2 = Math.SQRT1_2
+	applyGravityToWorld(world, { gx: -invSqrt2, gy: invSqrt2, mag: BASE_PARTICLE_G })
+	const need = LAVA_ONSET_EXPOSURE / invSqrt2
+	for (let stepIndex = 0; stepIndex < (need | 0) - 2; stepIndex++)
 		stepBoundary(world)
 	assertLess(totalMelt(world), 0.01)
-	for (let i = 0; i < 6; i++)
+	for (let stepIndex = 0; stepIndex < 6; stepIndex++)
 		stepBoundary(world)
 	assertGreater(totalMelt(world), 0.1)
 	// Both bottom and left should have been sourcing lava.
@@ -158,10 +154,10 @@ Deno.test('lava: down-edge melt clamped to T_MAX', () => {
 	world.gravity = defaultGravity()
 	world.boundary.exposure[EDGE_BOTTOM] = LAVA_ONSET_EXPOSURE
 	stepBoundary(world)
-	const W = world.worldW
-	const H = world.worldH
-	for (let x = 0; x < W; x++) {
-		const cell = (H - 1) * W + x
+	const worldWidth = world.worldW
+	const worldHeight = world.worldH
+	for (let column = 0; column < worldWidth; column++) {
+		const cell = (worldHeight - 1) * worldWidth + column
 		if (world.melt[cell] > 0.02)
 			assertAlmostEquals(world.temp[cell], T_MAX, 1e-6)
 	}
@@ -221,8 +217,7 @@ Deno.test('boundary: up-edge absorb and regurgitate conserves units+heat', () =>
 
 Deno.test('boundary: side wrap preserves same-row neighbor', () => {
 	const world = createWorld({ width: 10, height: 8, margin: 0, bottomExtra: 0 })
-	world.gravity = defaultGravity()
-	applyGravityToWorld(world, world.gravity)
+	applyGravityToWorld(world, defaultGravity())
 	const nb = neighborCoord(world, 0, 3, -1, 0)
 	assertEquals(nb.wrapped, true)
 	assertEquals(nb.x, world.worldW - 1)


### PR DESCRIPTION
## Summary
- Condensation film hangs and drains under gravity in icon_anime soil/lava fluid
- Related physics notes, player/scene tweaks, and gravity/fluid tests

## Test plan
- [ ] `fount test --no-parallel imgs/icon_anime`
- [ ] Spot-check logo / icon_anime animation visually if convenient


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

新增土壤与熔岩的重力驱动凝结、附着和滴流行为。凝结源会随重力方向定位、迁移，并在失去开放通道时回收或向空气溢流。雨水边界、反向重力熔岩沉降和滴水绘制逻辑同步修正。玩家中止机制改为一次触发，避免重复回调；相关文档和回归测试已补齐。

主要风险在流体状态转移、边界判定和渲染逻辑之间耦合增加，复杂度偏高。当前未见明显架构破坏或审美风险，但应重点验证反向重力下的视觉连续性与水量守恒。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->