### PR TITLE
Refresh shell llms.txt docs and tighten AGENTS guidelines

### DIFF
--- a/src/public/pages/llms.txt
+++ b/src/public/pages/llms.txt
@@ -191,7 +191,7 @@ fount 是一个 AI Agent 框架，本文档描述 Web 服务器提供的基础 A
 
 ---
 
-## P2P 用户级
+## P2P 服务器级
 
 服务器级路由，与 shell Load 无关。
 

--- a/src/public/pages/llms.txt
+++ b/src/public/pages/llms.txt
@@ -191,9 +191,9 @@ fount 是一个 AI Agent 框架，本文档描述 Web 服务器提供的基础 A
 
 ---
 
-## P2P 用户级（identity / profile）
+## P2P 用户级
 
-服务器级路由，与 shell Load 无关；数据在 `{userDict}/settings/federation.json` 与 `{userDict}/entities/{entityHash}/`。
+服务器级路由，与 shell Load 无关。
 
 ### GET/PUT /api/p2p/federation
 - 认证：需要
@@ -203,9 +203,7 @@ fount 是一个 AI Agent 框架，本文档描述 Web 服务器提供的基础 A
 - 认证：需要
 - 用途：节点网络图、节点 denylist、mailbox 积压摘要。
 
-实体面（viewer / profile / EVFS / personal-lists / 密钥 rotate·revoke）在 chat shell：`/api/parts/shells:chat/{viewer,entities…}`。见 `shells/chat/public/llms.txt`。
-
-Social/Mailbox 联邦 fanout 经 Chat shell 注册的 `TrustGraphProvider`；Chat 未 Load 时 explore 仅本地结果。
+实体面（viewer / profile / EVFS / personal-lists / 密钥 rotate·revoke）在 chat shell：`/api/parts/shells:chat/{viewer,entities…}`。
 
 ---
 

--- a/src/public/pages/llms.txt
+++ b/src/public/pages/llms.txt
@@ -203,7 +203,7 @@ fount 是一个 AI Agent 框架，本文档描述 Web 服务器提供的基础 A
 - 认证：需要
 - 用途：节点网络图、节点 denylist、mailbox 积压摘要。
 
-实体面（viewer / profile / EVFS / personal-lists / 密钥 rotate·revoke）在 chat shell：`/api/parts/shells:chat/{viewer,entities…}`。
+实体面（viewer / profile / EVFS / personal-lists / 密钥 rotate·revoke）在 chat shell：`/api/parts/shells:chat/viewer`、`/api/parts/shells:chat/entities/*`。
 
 ---
 

--- a/src/public/parts/shells/AGENTS.md
+++ b/src/public/parts/shells/AGENTS.md
@@ -15,7 +15,7 @@ alwaysApply: false
 ## Standard Structure
 
 - `main.mjs`: Backend entry. Default export must include `Load({ router })`.
-- `public/`: Frontend assets. `public/llms.txt`: AI-readable API docs.
+- `public/`: Frontend assets. `public/llms.txt`: AI-readable docs — **Chinese only**; keep part intro, operational conclusions/guidelines, and every HTTP/WS API with usage. No research notes, design-doc § refs, wire-protocol dumps, or in-process client APIs (those belong in `AGENTS.md` / `decl/`).
 - `src/endpoints.mjs`: **Backend** Express routes via `router.get/post/ws`. Path: `/api/parts/shells:<name>/...`.
 - **Frontend HTTP**: `public/src/endpoints.mjs` or `public/src/endpoints/*.mjs` — **named exports only**. No path-string clients (`socialApi('/…')`, `api(method, path)`, UI-facing `groupFetch(path)`). UI / shared / providers must not `fetch` shell REST; use endpoints. Global `/api/whoami`, `/api/getdetails…`, EVFS → `@src/public/pages/scripts/endpoints/`. HTML templates → `renderTemplate` / `mountTemplate` / `withTemplates`, never `fetch(…html)`.
 - **HTTP API**: Success = 2xx JSON (no `success` wrapper); failures = `throw httpError(code, message, { json?, skip_report? })` from `@src/scripts/http_error.mjs`.

--- a/src/public/parts/shells/access/public/llms.txt
+++ b/src/public/parts/shells/access/public/llms.txt
@@ -1,13 +1,6 @@
-# access shell 支持的 Web 端点说明
+# access shell
 
-本 shell 仅提供登录/访问相关静态页面（如登录表单），无独立 HTTP 或 WebSocket API 端点。
-登录等请使用基础 API：/api/login、/api/register、/api/logout、/api/whoami 等。本 shell 通过 /parts/shells:access/ 提供前端入口。
-
----
-
-## 提供的页面
+仅提供登录 / 注册静态页，无独立 shell HTTP 或 WebSocket API。认证请用基础 API：`/api/login`、`/api/register`、`/api/logout`、`/api/whoami` 等（见 `src/public/pages/llms.txt`）。
 
 ### GET /parts/shells:access/
-- 用途：登录/访问页面，提供用户登录和注册界面。包含登录表单、注册表单等功能，是用户访问系统的入口页面。
-
----
+- 用途：登录与注册入口页。

--- a/src/public/parts/shells/achievements/public/llms.txt
+++ b/src/public/parts/shells/achievements/public/llms.txt
@@ -1,25 +1,27 @@
-# achievements shell 支持的 Web 端点说明
+# achievements shell Web API
 
-本 shell 提供成就来源列表与解锁/锁定操作。
+成就来源列表与解锁 / 锁定。
+
+路径前缀：`/api/parts/shells:achievements`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:achievements/
-- 用途：成就系统页面，用于查看所有可用的成就、已解锁的成就状态，以及手动解锁或锁定成就。显示各 part 的成就定义和完成情况。
+- 用途：成就查看与手动解锁 / 锁定。
 
 ---
 
-## 成就
+## API
 
 ### GET /api/parts/shells:achievements/sources
-- 用途：获取成就来源列表（含各 part 的成就定义及已解锁状态等）。
+- 用途：成就来源列表（定义与已解锁状态）。
 
 ### POST /api/parts/shells:achievements/unlock
-- Body：JSON。`partpath`（字符串，必填），如 `shells/achievements`。`id`（字符串，必填），成就 ID，与 sources 中该 part 下的成就 id 一致。
-- 用途：解锁指定 part 的指定成就。
+- Body：`partpath`、`id`（均必填）
+- 用途：解锁指定成就。
 
 ### POST /api/parts/shells:achievements/lock
-- Body：JSON。`partpath`（字符串，必填）、`id`（字符串，必填），成就 ID。`reason`（字符串，可选），如 `relock_by_clicking`。
-- 用途：锁定（撤销）指定成就。
+- Body：`partpath`、`id`（必填），`reason`（可选）
+- 用途：锁定（撤销）成就。

--- a/src/public/parts/shells/browserIntegration/public/llms.txt
+++ b/src/public/parts/shells/browserIntegration/public/llms.txt
@@ -1,42 +1,43 @@
-# browserIntegration shell 支持的 Web 端点说明
+# browserIntegration shell Web API
 
-本 shell 提供浏览器集成：用户脚本、历史记录、回调与自动运行脚本管理。
+浏览器用户脚本、历史、回调与自动运行脚本管理。
+
+路径前缀：`/api/parts/shells:browserIntegration`。均需登录（虚拟脚本文件视实现而定）。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:browserIntegration/
-- 用途：浏览器集成管理页面，用于管理浏览器用户脚本、查看操作历史、配置自动运行脚本等功能。支持与浏览器扩展和用户脚本的集成，实现跨页面的功能调用。
+- 用途：浏览器集成管理页。
 
 ---
 
 ## 用户脚本与历史
 
 ### GET /virtual_files/parts/shells:browserIntegration/script.user.js
-- 用途：获取用于浏览器集成的用户脚本内容。
+- 用途：浏览器集成用户脚本全文。
 
 ### GET /virtual_files/parts/shells:browserIntegration/script.meta.js
-- 用途：仅返回用户脚本的元数据块（UserScript 头），供 Tampermonkey 等扩展做更新检查用。
+- 用途：仅 UserScript 元数据头（供扩展更新检查）。
 
 ### GET /api/parts/shells:browserIntegration/history
-- 用途：获取浏览器集成相关操作历史。
+- 用途：操作历史。
 
 ### POST /api/parts/shells:browserIntegration/callback
-- Body：JSON。`partpath`（字符串，必填），实现 browserIntegration 回调的 part 路径。`data`、`pageId`、`script` 等由集成流程决定。
-- 用途：处理来自浏览器或扩展的回调（如 OAuth、注入结果等）。
+- Body：`partpath`（必填）；`data`、`pageId`、`script` 等由集成流程决定
+- 用途：浏览器 / 扩展回调入口。
 
 ---
 
 ## 自动运行脚本
 
 ### GET /api/parts/shells:browserIntegration/autorun-scripts
-- 用途：获取当前用户配置的自动运行脚本列表。返回 `{ scripts: [...] }`，每项含 `id`、`urlRegex`、`script`、`comment`、`createdAt` 等。
+- 用途：`{ scripts: [...] }`（`id`、`urlRegex`、`script`、`comment`、`createdAt` 等）。
 
 ### POST /api/parts/shells:browserIntegration/autorun-scripts
-- Body：JSON。`urlRegex`（字符串，必填），匹配 URL 的正则。`script`（字符串，必填），要执行的脚本内容。`comment`（字符串，可选）。
-- 用途：添加新的自动运行脚本。返回 `{ script: newScript }`（201），newScript 含生成的 `id`。
+- Body：`urlRegex`、`script`（必填），`comment`（可选）
+- 用途：添加脚本 → `201 { script }`。
 
 ### DELETE /api/parts/shells:browserIntegration/autorun-scripts/:id
-- 路径：id 为脚本 ID（GET autorun-scripts 返回的每项 script.id，UUID 字符串）。
-- 用途：删除指定自动运行脚本。
+- 用途：按 UUID 删除脚本。

--- a/src/public/parts/shells/cabinet/public/llms.txt
+++ b/src/public/parts/shells/cabinet/public/llms.txt
@@ -1,8 +1,31 @@
-# shells:cabinet
+# cabinet shell Web API
 
-P2P 文件柜：个人 EVFS 柜 + 无托管共享柜（签名 op-log）。
+P2P 文件柜：个人 EVFS 柜 + 无托管共享柜（签名 op-log）。字段一律 snake_case。
 
-## HTTP（前缀 `/api/parts/shells:cabinet`，需登录）
+路径前缀：`/api/parts/shells:cabinet`。均需登录。
+
+---
+
+## 重要结论
+
+- 加密文件夹：`POST …/unlock` 得 `unlock_token`，之后列目录带请求头 `X-Cabinet-Unlock`。
+- 可恢复删除：`DELETE …/entries` 且 `recoverable:true` → `recovery_token`；丢弃时须 `finalize-delete`，否则 blob 残留。
+- Chat 绑定：群 DAG `cabinet_bind` / `cabinet_key_update` / `cabinet_unbind`。绑定 / 解绑与 `role_access` 需 `ADMIN` / `MANAGE_ADMINS`；仅密钥 wrap 轮换仍需 `MANAGE_ROLES`。Hub 文件面板列 role 可访问柜；目录管理在本 shell。
+
+---
+
+## 页面与路由
+
+| 路径 / hash | 说明 |
+| --- | --- |
+| `GET /parts/shells:cabinet/` | 主壳 |
+| `#cabinet:{id}` / `#cabinet:{id}/{folderId}` | 个人柜 |
+| `#shared:{cabinetId}` / `#shared:{cabinetId}/{folderId}` | 共享柜 |
+| `#user:{entityHash}` / `#user:{entityHash}/{cabinetId}`[/`{folderId}`] | 远端只读浏览 |
+
+---
+
+## HTTP
 
 | 方法 | 路径 | 说明 |
 | --- | --- | --- |
@@ -11,45 +34,19 @@ P2P 文件柜：个人 EVFS 柜 + 无托管共享柜（签名 op-log）。
 | POST | `/cabinets` | 新建个人柜，或 `{ type:'shared', name }` |
 | PATCH | `/cabinets/:cabinet_id` | 重命名 / visibility / sync_binding |
 | DELETE | `/cabinets/:cabinet_id` | 删除柜 |
-| GET | `/cabinets/:id/index?parent_id=&show_hidden=` | 列目录；加密文件夹需 `X-Cabinet-Unlock` |
+| GET | `/cabinets/:id/index?parent_id=&show_hidden=` | 列目录（含 `folder_trail`）；加密夹需 `X-Cabinet-Unlock` |
 | POST | `/cabinets/:id/unlock` | body `{ folder_id, password }` → `{ unlock_token }` |
 | POST | `/cabinets/:id/entries` | 登记条目；可带 `plaintext_base64` 上传 |
 | PATCH | `/cabinets/:id/entries/:entry_id` | 重命名 / description / attrs / preview / set_password |
 | POST | `/cabinets/:id/entries/copy` | `{ entry_ids, target_parent_id, as_links?, target_cabinet_id? }` |
-| DELETE | `/cabinets/:id/entries` | `{ entry_ids, recoverable? }`；`recoverable:true` 时返回 `recovery_token`，暂不硬删 blob |
+| DELETE | `/cabinets/:id/entries` | `{ entry_ids, recoverable? }`；可恢复时返回 `recovery_token` |
 | POST | `/cabinets/:id/entries/restore` | `{ recovery_token }` 按原 id 恢复 |
-| POST | `/cabinets/:id/entries/finalize-delete` | `{ recovery_token }` 丢弃恢复令牌并硬删 blob |
+| POST | `/cabinets/:id/entries/finalize-delete` | `{ recovery_token }` 硬删 blob |
 | GET | `/cabinets/:id/entries/:entry_id/resolve` | 解析链接 |
 | GET | `/cabinets/:id/entries/:entry_id/download` | 共享柜文件明文下载 |
 | GET | `/cabinets/:id/zip?folder_id=` | 文件夹 zip |
 | PUT | `/cabinets/:id/sync-binding` | `{ path, interval_ms }` |
 | POST | `/cabinets/:id/sync` | 立即同步 |
 | POST | `/cabinets/:id/preview` | 上传预览图 |
-| GET | `/remote/:entityHash/cabinets` | 远端公开/followers 柜列表 |
-| GET | `/remote/:entityHash/cabinets/:id/index?parent_id=&show_hidden=` | 远端柜目录（同本地 index 形状：`entries` + `folder_trail`） |
-
-字段一律 snake_case。
-
-## Hash 路由
-
-- `#cabinet:{id}` / `#cabinet:{id}/{folderId}`
-- `#shared:{cabinetId}` / `#shared:{cabinetId}/{folderId}`（共享柜）
-- `#user:{entityHash}` / `#user:{entityHash}/{cabinetId}` / `#user:{entityHash}/{cabinetId}/{folderId}`（远端只读浏览）
-
-## 快捷键（页面会话）
-
-| 键 | 动作 |
-| --- | --- |
-| Ctrl/Cmd+C / X / V / Shift+V | 复制 / 剪切 / 粘贴 / 粘贴为链接 |
-| Ctrl/Cmd+A | 全选 |
-| Ctrl/Cmd+D | 删除（可撤销） |
-| Delete | 返回上一级 |
-| Ctrl/Cmd+Z / Y（或 Shift+Z） | 撤销 / 重做 |
-| Ctrl/Cmd+N | 新窗口打开当前位置 |
-| F2 | 重命名 |
-
-剪贴板经 `sessionStorage` + `BroadcastChannel` 同源跨窗口共享。撤销栈仅当前页面会话；删除走 `recoverable` 令牌，栈淘汰或关页时 `finalize-delete`。
-
-## Chat 绑定
-
-群 DAG：`cabinet_bind` / `cabinet_key_update` / `cabinet_unbind`（需 `MANAGE_ROLES`）。Hub 文件面板列 role 可访问柜。
+| GET | `/remote/:entityHash/cabinets` | 远端公开 / followers 柜列表 |
+| GET | `/remote/:entityHash/cabinets/:id/index?parent_id=&show_hidden=` | 远端柜目录（形状同本地 index） |

--- a/src/public/parts/shells/cabinet/public/llms.txt
+++ b/src/public/parts/shells/cabinet/public/llms.txt
@@ -21,7 +21,7 @@ P2P 文件柜：个人 EVFS 柜 + 无托管共享柜（签名 op-log）。字段
 | `GET /parts/shells:cabinet/` | 主壳 |
 | `#cabinet:{id}` / `#cabinet:{id}/{folderId}` | 个人柜 |
 | `#shared:{cabinetId}` / `#shared:{cabinetId}/{folderId}` | 共享柜 |
-| `#user:{entityHash}` / `#user:{entityHash}/{cabinetId}`[/`{folderId}`] | 远端只读浏览 |
+| `#user:{entityHash}` / `#user:{entityHash}/{cabinetId}` / `#user:{entityHash}/{cabinetId}/{folderId}` | 远端只读浏览 |
 
 ---
 

--- a/src/public/parts/shells/cabinet/public/llms.txt
+++ b/src/public/parts/shells/cabinet/public/llms.txt
@@ -34,19 +34,19 @@ P2P 文件柜：个人 EVFS 柜 + 无托管共享柜（签名 op-log）。字段
 | POST | `/cabinets` | 新建个人柜，或 `{ type:'shared', name }` |
 | PATCH | `/cabinets/:cabinet_id` | 重命名 / visibility / sync_binding |
 | DELETE | `/cabinets/:cabinet_id` | 删除柜 |
-| GET | `/cabinets/:id/index?parent_id=&show_hidden=` | 列目录（含 `folder_trail`）；加密夹需 `X-Cabinet-Unlock` |
-| POST | `/cabinets/:id/unlock` | body `{ folder_id, password }` → `{ unlock_token }` |
-| POST | `/cabinets/:id/entries` | 登记条目；可带 `plaintext_base64` 上传 |
-| PATCH | `/cabinets/:id/entries/:entry_id` | 重命名 / description / attrs / preview / set_password |
-| POST | `/cabinets/:id/entries/copy` | `{ entry_ids, target_parent_id, as_links?, target_cabinet_id? }` |
-| DELETE | `/cabinets/:id/entries` | `{ entry_ids, recoverable? }`；可恢复时返回 `recovery_token` |
-| POST | `/cabinets/:id/entries/restore` | `{ recovery_token }` 按原 id 恢复 |
-| POST | `/cabinets/:id/entries/finalize-delete` | `{ recovery_token }` 硬删 blob |
-| GET | `/cabinets/:id/entries/:entry_id/resolve` | 解析链接 |
-| GET | `/cabinets/:id/entries/:entry_id/download` | 共享柜文件明文下载 |
-| GET | `/cabinets/:id/zip?folder_id=` | 文件夹 zip |
-| PUT | `/cabinets/:id/sync-binding` | `{ path, interval_ms }` |
-| POST | `/cabinets/:id/sync` | 立即同步 |
-| POST | `/cabinets/:id/preview` | 上传预览图 |
-| GET | `/remote/:entityHash/cabinets` | 远端公开 / followers 柜列表 |
-| GET | `/remote/:entityHash/cabinets/:id/index?parent_id=&show_hidden=` | 远端柜目录（形状同本地 index） |
+| GET | `/cabinets/:cabinet_id/index?parent_id=&show_hidden=` | 列目录（含 `folder_trail`）；加密夹需 `X-Cabinet-Unlock` |
+| POST | `/cabinets/:cabinet_id/unlock` | body `{ folder_id, password }` → `{ unlock_token }` |
+| POST | `/cabinets/:cabinet_id/entries` | 登记条目；可带 `plaintext_base64` 上传 |
+| PATCH | `/cabinets/:cabinet_id/entries/:entry_id` | 重命名 / description / attrs / preview / set_password |
+| POST | `/cabinets/:cabinet_id/entries/copy` | `{ entry_ids, target_parent_id, as_links?, target_cabinet_id? }` |
+| DELETE | `/cabinets/:cabinet_id/entries` | `{ entry_ids, recoverable? }`；可恢复时返回 `recovery_token` |
+| POST | `/cabinets/:cabinet_id/entries/restore` | `{ recovery_token }` 按原 id 恢复 |
+| POST | `/cabinets/:cabinet_id/entries/finalize-delete` | `{ recovery_token }` 硬删 blob |
+| GET | `/cabinets/:cabinet_id/entries/:entry_id/resolve` | 解析链接 |
+| GET | `/cabinets/:cabinet_id/entries/:entry_id/download` | 共享柜文件明文下载 |
+| GET | `/cabinets/:cabinet_id/zip?folder_id=` | 文件夹 zip |
+| PUT | `/cabinets/:cabinet_id/sync-binding` | `{ path, interval_ms }` |
+| POST | `/cabinets/:cabinet_id/sync` | 立即同步 |
+| POST | `/cabinets/:cabinet_id/preview` | 上传预览图 |
+| GET | `/remote/:entity_hash/cabinets` | 远端公开 / followers 柜列表 |
+| GET | `/remote/:entity_hash/cabinets/:cabinet_id/index?parent_id=&show_hidden=` | 远端柜目录（形状同本地 index） |

--- a/src/public/parts/shells/chat/public/llms.txt
+++ b/src/public/parts/shells/chat/public/llms.txt
@@ -1,8 +1,25 @@
 # chat shell Web API
 
-HTTP 前缀：`/api/parts/shells:chat/`。群集合：`GET`/`POST` `/api/parts/shells:chat/groups/`（须在 `:groupId` 动态段之前注册）。本地会话：`/api/parts/shells:chat/sessions/`。
+chat shell 提供联邦群组与 DM、Hub 主壳、实体身份与 EVFS 文件、以及会话编排（角色 / 世界 / 人格）。
 
-WebSocket：`/ws/parts/shells:chat/groups/:ownerNodeHash/:groupId`（Hub、群壳、RPC 共用；须为 replica 活跃成员）；通话 `/ws/parts/shells:chat/call/:groupId/:channelId`；流媒体 `/ws/parts/shells:chat/av-relay/:roomId`。
+路径简写（下文表格均用简写）：
+
+- `P` = `/api/parts/shells:chat`
+- `G` = `P/groups`
+- `C` = `G/:groupId/channels/:channelId`
+
+约定：所有 HTTP 与 WS 路由都需要登录（`authenticate`）；成功 = 2xx JSON（无 `success` 包装），失败抛 `httpError(code, message)`。群集合路由 `G/` 注册在 `:groupId` 动态段之前。
+
+---
+
+## 重要结论
+
+- HTTP 恒为当前登录用户的 operator 实体，没有换身份参数；本机 agent 自签操作走进程内客户端，不经本文件所列 HTTP。
+- 平台 bot（Discord / Telegram / WeChat）用虚拟桥接会话：群 id 形如 `bridge:{platform}:{platformChatId}`，只存在于进程内，不建真实 Hub 群、不入 DAG。
+- 消息附件：元数据登记走群文件（`POST G/:groupId/chunks` + `POST G/:groupId/files`），字节读取走 EVFS `GET P/entities/:entityHash/files/chat/{fileId}`。
+- 成员治理的路径参数是 `:memberKey`，不是签名 pubKeyHash；实体身份取 DAG `member.entityHash` 或 operator，不要用临时签名公钥反推实体。
+- 实体 / 观看者 / 实体搜索都在本 shell（`P/viewer`、`P/entities/*`）；节点网络层（identity、relay、denylist）在 `/api/p2p/*`。
+- 退群与删群是三条不同路由：普通成员退群 `POST G/leave`；管理员删整群本地 DAG 数据 `DELETE G/:groupId`；只删本机会话数据 `DELETE P/sessions/:groupId`（Hub 私聊删除用这条）。
 
 ---
 
@@ -10,300 +27,220 @@ WebSocket：`/ws/parts/shells:chat/groups/:ownerNodeHash/:groupId`（Hub、群�
 
 | 路径 | 说明 |
 |------|------|
-| `GET /parts/shells:chat/` | 重定向至 `/parts/shells:chat/hub/`，保留 `location.hash` |
-| `GET /parts/shells:chat/hub/` | 主壳：会话列表、频道、消息；`#group:{groupId}:{channelId}`；`?char=` 角色直达 |
-| `GET /parts/shells:chat/emoji-packs/` | 表情包探索：附近公开群包 / 作者包；仅加群或关注 |
+| `GET /parts/shells:chat/` | 重定向到 `/parts/shells:chat/hub/`，保留 `location.hash` |
+| `GET /parts/shells:chat/hub/` | 主壳：会话列表、频道、消息。`#group:{groupId}:{channelId}` 定位；`?char=` 角色直达；`?contact={entityHash}` 打开 DM |
+| `GET /parts/shells:chat/emoji-packs/` | 表情包探索页：附近公开群包 / 作者包 |
 
 ---
 
-## 群会话
+## WebSocket
 
-### `GET /api/parts/shells:chat/groups/`
-当前用户已加入的联邦群 / DM 摘要，按 DAG 消息活动时间排序。
+| 路径 | 说明 |
+|------|------|
+| `/ws/parts/shells:chat/groups/:ownerNodeHash/:groupId` | 群主通道：Hub 推送、群壳事件、跨节点 RPC 共用；须为该 replica 的活跃成员 |
+| `/ws/parts/shells:chat/call/:groupId/:channelId` | 频道群组通话信令与 roster |
+| `/ws/parts/shells:chat/av-relay/:roomId` | 音视频 / 屏幕共享帧中继 |
 
-### `POST /api/parts/shells:chat/groups/`
-- **普通群**：`name`、`description`、`defaultChannelName`、`defaultChannelId` 等 → `201` + `groupId`、`defaultChannelId`。
-- **DM**：`{ "template": "dm", "myPubKeyHex": "…", "peerPubKeyHex": "…" }`（各 64 hex，均走 ECDH，§14）。
-  - 可选 `dmIntroNonce` + `dmIntroSignatureHex`（DM Link proof，成对出现）
-  - 响应可含 `dmSessionTag`、`dmRoomLabelPrefix`
-
-### `DELETE /api/parts/shells:chat/groups/:groupId`
-删除整群本地 DAG 数据；需当前成员具备 `ADMIN` 或 `MANAGE_ADMINS`。普通成员退群用 `POST …/groups/leave`（body `groupIds` 数组，单群亦传一项）。
-
-### `DELETE /api/parts/shells:chat/sessions/:groupId`
-删除本机会话数据（角色私聊 / 本地 chat 目录），无群管理员权限要求。Hub 私聊删除应使用此路由。
-
-### `GET /api/parts/shells:chat/groups/:groupId/channels/:channelId/export`
-导出频道完整归档 JSON（`format: fount-channel-archive`）：冷热历史终态、删除墓碑、反应计数、附件元数据。需 `VIEW_CHANNEL`。
-
-### `POST /api/parts/shells:chat/groups/:groupId/channels/import`
-将频道归档导入为**当前群的新 text 频道**（multipart 字段 `archive`，或 JSON body）。需 `MANAGE_CHANNELS`。历史由导入者重新签名，附 `importedFrom`；不嵌入附件二进制。响应 `{ channelId, messageCount }`。
-
-### `GET /api/parts/shells:chat/groups/:groupId/state`
-分层 DTO：`{ meta, viewer, federation }`。
-- **meta**：`channels`、`groupSettings`、`roles`、`pinsByChannel`、`members`（`{ memberKey, kind, ownerEntityHash?, … }`）、`bannedMembers`（`{ memberKey }`）、`memberCount`、`consensusBranchTip`、`localViewBranchTip` 等物化字段。
-- **viewer**：`isMember`、`memberKey`、`entityHash`、`roles`、`suspectedRemoved` 等当前用户视角。
-- **federation**：联邦同步/隔离相关字段。
-
-### `GET /api/parts/shells:chat/reputation`
-全局主观信誉表（`loadReputation()`，非群 scoped）。
-
-### `GET /api/parts/shells:chat/groups/:groupId/events`
-查询：`since`、`limit`、`channelId`（可选）。`syncScope === 'channel'` 时仅返回该频道懒加载切片。
-
-### `POST /api/parts/shells:chat/groups/:groupId/events/signed`
-批量追加远程已签名联邦 DAG 事件行（完整 signed event 体）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/events/local`
-批量追加本地未签名授权类 DAG 事件（简体形，经 `localAuthz` 校验）。
-
-### `GET /api/parts/shells:chat/groups/:groupId/snapshot`
-本地 checkpoint 快照 JSON。
-
-### `GET /api/parts/shells:chat/groups/:groupId/search`
-Query：`q`（≥2 字符）、`channelId?`、`limit`（默认 30，最大 100）。跨频道全文搜索（bigram+词元倒排索引，子串真值校验）；过滤成员资格与 personal block；响应 `{ query, items[] }`（含 `eventId`、`channelId` 定位字段）。
-
-### `GET /api/parts/shells:chat/groups/:groupId/members/page/:idx`
-活跃成员分页（每页 ≤500）；成员行 `{ memberKey, kind, ownerEntityHash?, … }`；含 `membersRoot`、`membersPagesCount`。
-
-### `GET /api/parts/shells:chat/groups/:groupId/dag/tips`
-当前 DAG 叶 id；≥2 表示分叉。响应含 `tipScores`（主观分）与 `tipConsensusScores`（客观治理事件计数）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/dag/merge-tips`
-写入 `dag_tip_merge` 合并全部叶；需 `MANAGE_CHANNELS`。
-
-### `GET /api/parts/shells:chat/groups/:groupId/peers`
-P2P roster + 用户级 `network.json`（`trustedPeers`、`explorePeers`）与 `denylist.json`（`blockedPeers` 视图）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/federation/catchup`
-向邻居补洞同步。响应含 `tipsCollected`、`wantIds`、`eventsFilled`、`wantIdsStillMissing`、`wantIdsRateLimited`（出站 wantIds 退避时为 true）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/federation/join-snapshot`
-入群后向邻居请求 `fed_join_snapshot_*`：校验通过后写入本地 `snapshot.json` 并触发物化；附带明文 `channelHistories`（每频道最多 500 行）。DAG 事件仍须 gossip/catchup 补齐。
-
-### `POST /api/parts/shells:chat/groups/:groupId/federation/rotate-room-secret`
-写入或轮换群级 `roomSecret`（`group_settings_update`）；需 `ADMIN` 或 `MANAGE_ADMINS`。
-
-### `POST /api/parts/shells:chat/groups/:groupId/federation/rebind`
-按当前活跃频道触发联邦分区重绑（确保 `sync + ch-xx` 已 join）。body: `{ channelId? }`。
-
-### `POST /api/parts/shells:chat/groups/:groupId/federation/tuning`
-更新联邦调优参数（写 DAG `group_settings_update`）：`federationPartitionCount`（2-64）、`rtcConnectionBudgetMax`（8-128）、`rtcJoinRatePerMin`（4-60）；需 `ADMIN` 或 `MANAGE_ADMINS`。
-
-### `POST /api/parts/shells:chat/groups/:groupId/invite-ticket`
-签发短时群邀请码（默认 TTL 1h）；响应含 `signalingAppId`、`roomSecret`、`introducerPubKeyHash` 与 `clipboardText` 深链；需 `INVITE_MEMBERS` 或 `ADMIN`/`MANAGE_ADMINS`。无 `roomSecret` 时 `409`。
-
-### `POST /api/parts/shells:chat/groups/:groupId/join`
-Body：`inviteCode?`、`signalingAppId?`、`roomSecret?`（首次联邦 bootstrap）、`pow?`、`introducerPubKeyHash?`、`reputationEdge?`、`dmIntroNonce?`、`dmIntroSignatureHex?`（DM 引荐时 `introducerPubKeyHash` 与 nonce/签名配套）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/fork/block-opposing`
-body: `{ "acceptedTipId": "<64 hex DAG tip>" }` — 将**非**该叶的其他分支上治理类事件签发者写入用户 `denylist.json`（§0.5）。
-
-### `POST /api/parts/shells:chat/groups/:groupId/fork`
-治理分叉：复制分支为新 `groupId`。
-
-### `PUT /api/parts/shells:chat/groups/:groupId/governance-branch`
-选定本地治理分支 tip。
-
-### 无状态入群 PoW（`joinPolicy=pow`）
-
-`member_join.content.powSolution` 为 `{ anchorRef, epoch, nonce, joinerNodeHash? }`：`anchorRef` 须为群近期 DAG tip 或 checkpoint root；`sha256(groupId:anchorRef:joinerNodeHash:epoch:nonce)` 前导零 bit ≥ `groupSettings.powDifficulty`。邀请票响应含 `powAnchors` / `powAnchorRef` 供新人离线求解；checkpoint 已收录的历史 join replay 豁免 PoW。
+不入 DAG 的易失帧走 WS：`typing`、`stream_chunk`（流式增量，终稿是 `message_edit`，没有 `stream_end`）、`stop_generation`，以及服务端推送的 `channel_message`、`dag_event`、`message_replaced`、`read_marker` 等。
 
 ---
 
-## 实体私有偏好与发现（HTTP 恒 operator；与 `groups/` 并列）
+## operator 私有偏好与发现
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET/PUT | `/trusted-authors` | 不安全渲染可信作者 `pubKeyHash[]` |
-| GET/PUT | `/bookmarks` | operator 实体私有 `{ entries: [{ groupId, channelId, eventId, title?, href? }] }`（存 `entities/{entityHash}/bookmarks.json`） |
-| GET | `/inbox?kinds=&limit=&cursor=` | operator inbox `{ items[], nextCursor, unreadCount }`（newest-first；无换收件人参数） |
-| GET/PUT | `/inbox/seen` | operator 已读水位 `{ seenAt }` |
-| GET | `/groups/:groupId/mentions/suggest?q=&limit=` | 群内 @ autocomplete `{ suggestions: [{ entityHash, displayName, memberKey, kind }] }` |
-| GET/PUT | `/group-folders` | Hub 侧栏文件夹 `{ folders: [...] }`（operator 实体私有） |
-| GET/PUT | `/aliases` | `{ entities, groups }` petnames（operator 实体私有） |
-| GET/PUT | `/notify-prefs` | 通知偏好（存储名 `notificationPreferences`；operator 实体私有） |
-| GET/PUT | `/translation-prefs` | `{ prefs: { autoTranslate, targetLocale?, excludeLocales? } }`（实体私有） |
-| POST | `/translate` | body `{ text, targetLang }` → `{ translated, cached }` |
-| GET/PUT | `/care` | 特别关心列表；PUT body `{ targetEntityHash, cared? }` |
-| GET | `/emoji-usage` | 表情用量与收藏 `{ log, lastUsedAtByPack, collection }` |
-| POST | `/emoji-usage/record` | 记录用量 body item（unicode / pack） |
-| POST | `/emoji-usage/collection/packs` | 收藏 pack body `{ packId }`（须可用） |
-| DELETE | `/emoji-usage/collection/packs/:packId` | 取消收藏 |
-| GET | `/emoji-usage/frequent?limit=` | 700 窗口内常用表情 `{ entries }` |
-| GET | `/groups/:groupId/emoji-packs` | 群表情包摘要列表 |
-| POST | `/groups/:groupId/emoji-packs` | 创建 pack `{ packId?, localized? }` |
-| GET | `/groups/:groupId/emoji-packs/:packId` | pack manifest |
-| PUT | `/groups/:groupId/emoji-packs/:packId` | 更新 pack localized |
-| DELETE | `/groups/:groupId/emoji-packs/:packId` | 删除 pack |
-| POST | `/groups/:groupId/emoji-packs/:packId/emojis` | 上传表情（multipart `emoji`） |
-| DELETE | `/groups/:groupId/emoji-packs/:packId/emojis/:emojiId` | 删除表情 |
-| GET | `/groups/:groupId/emoji-packs/:packId/emojis/:emojiId/data` | 表情二进制；`?json=1` → dataUrl |
-| GET | `/emoji-content/:packId/:emojiId` | 按 packId 解析内容（群包 ∪ 实体作者包） |
-| GET | `/emoji-packs` | 可用 pack 列表（已加入群包 ∪ 自有实体包） |
-| GET | `/entities/:entityHash/emoji-packs` | 实体作者包摘要 |
-| POST | `/entities/:entityHash/emoji-packs` | 创建作者包 `{ packId?, localized? }` |
-| GET/PUT/DELETE | `/entities/:entityHash/emoji-packs/:packId` | 读写删 pack |
-| POST | `/entities/:entityHash/emoji-packs/:packId/emojis` | multipart `emoji` 上传 |
-| DELETE | `/entities/:entityHash/emoji-packs/:packId/emojis/:emojiId` | 删除表情 |
-| GET | `/entities/:entityHash/emoji-packs/:packId/emojis/:emojiId/data` | 表情二进制；`?json=1` → dataUrl |
-| GET | `/groups/:groupId/preview` | 群卡片预览（公开信息；私密群隐藏加入入口） |
-| GET | `/discovery` | 本地群发现索引（`?limit=`）；条目含 `sources[]` 来源 node |
-| POST | `/discovery/refresh` | 向已加入群联邦邻居广播 `discovery_announce` |
-
-**用户级 P2P**：网络传输 `GET/PUT /api/p2p/federation`（identity、relayUrls、batterySaver）；实体面 `GET /api/parts/shells:chat/viewer`（operator entity + profile + `agents[]`）；`GET/PUT /api/parts/shells:chat/entities/:entityHash` 及 avatar/status/heartbeat/rotate/revoke（本机可写直写；声明主人对远端实体时 `PUT`/avatar/banner 经主人 EVFS `owned/{target}/profile_update/*` 发布，HTTP 202 `{ queued, contentHash, ts }`）；`GET /api/parts/shells:chat/entities/search?q=`（≥2 字符）按 handle 精确 / 展示名模糊在信任图多跳搜实体，响应 `{ query, entities[] }`（含 `handle`、`name`、`activePubKeyHex`、`nodeScore`、交互标志）；`PUT /api/parts/shells:chat/entities/owner` body `{ ownerEntityHash: string|null }` 设置/清除当前 operator 的所属主人（identity + profile + 群内 `member_owner_update`）。群传输密钥仍在 DAG `groupSettings.roomSecret`。Profile 公开负载含顶层 `handle`（`[a-z0-9_.-]{2,32}`，不唯一）与 `activePubKeyHex`/`keyGeneration`。
-
-**群设置（发现）**：`group_settings_update` 可写 `discoveryPublic`、`discoveryTitle`、`discoveryBlurb`（不含 `roomSecret`）。另含 `eventRetentionDepth`、`eventRetentionMs`、`compactTriggerEventDepth`、`messageRateLimitPerMin`、`iceServers`（WebRTC；TURN 凭据仅本机物化）、`autoChannelGc`（默认 true：物化时自动删除沉寂孤岛频道，每次最多 2 个）。联邦调优三字段经 `POST …/federation/tuning` 写入：`federationPartitionCount`、`rtcConnectionBudgetMax`、`rtcJoinRatePerMin`。本地 `messages/{channelId}.jsonl` 为明文展示侧车；DAG `events.jsonl` 仍为 GSH 密文。
-
-**联邦 action（除既有 dag/gossip/chunk 外）**：`fed_bootstrap_request` / `fed_bootstrap_response`（房间口令轮换后恢复）；`discovery_announce` / `discovery_query` / `discovery_query_response`（`advertisements`）；`mailbox_put` / `mailbox_want` / `mailbox_give`（离线 DM 存转：按收件人×发送者桶配额淘汰，入站按来源节点限速，开放转发 + 信任优先路由）；`fed_partition_bridge`（跨分区桥接，TTL 与去重限制，过载时按优先级丢弃）。线协议无版本字段，破坏性变更靠 action 名与字段形状区分。
-
-**HLC 入站**：联邦相关类型若未来 skew 超 `hlcMaxSkewMs`，消息类写入 `quarantine.jsonl` 待时钟恢复后重放，其余 aclGated 类型硬拒；`session_*` 仅本地 append 允许，联邦入站拒收。
-
-**贴纸消息**：wire `type:'sticker'` + `emojiRef`（`:[emoji:packId/emojiId]:`）；与行内 emoji 同源，composer 单按钮——点击插 token，长按/右键发贴纸。不再有独立 `/stickers/*` API。
-
-| POST | `/attachments` | multipart 聊天附件入库，响应 `{ hashes: string[] }` |
-| GET | `/attachments/:hash` | 按 BLAKE2b hash 取附件字节 |
-
-**深链（§16）**：canonical `fount://run/shells:chat/dm;<pubKeyHex>;<nonce>;<introSignatureHex>[;nodeUrl]` 与 `…/join;<groupId>;<inviteCode>[;<roomSecret>[;<introducerPubKeyHash>]]`。`member_join.content.introducerPubKeyHash` 物化进 `inviteEdges` 供信誉连坐。`peer_invite.fileKeyWraps` 入群后导入群文件主密钥代际。`public/shared/runUri.mjs`。站外分享：`https://steve02081504.github.io/fount/protocol?url=` + encodeURIComponent(runUri)。
+| GET / PUT | `P/trusted-authors` | 不安全渲染的可信作者 `{ hashes: string[] }` |
+| GET / PUT / POST / DELETE | `P/bookmarks` | 书签 `{ entries: [{ groupId, channelId, eventId, title?, href? }] }`；POST 增一条，DELETE 删一条 |
+| GET | `P/inbox?kinds=&limit=&cursor=` | 收件箱 `{ items[], nextCursor, unreadCount }`（newest-first） |
+| GET / PUT | `P/inbox/seen` | 已读水位；PUT body `{ at }` → `{ seenAt }` |
+| GET / PUT | `P/group-folders` | Hub 侧栏文件夹 `{ folders }` |
+| GET / PUT | `P/aliases` | petname `{ entities, groups }` |
+| GET / PUT | `P/notify-prefs` | 通知偏好 |
+| GET / PUT | `P/translation-prefs` | `{ prefs: { autoTranslate, targetLocale?, excludeLocales? } }` |
+| POST | `P/translate` | body `{ text, targetLang }` → `{ translated, cached }` |
+| GET / PUT | `P/care` | 特别关心列表；PUT body `{ targetEntityHash, cared? }` |
+| GET | `P/emoji-usage` | `{ log, lastUsedAtByPack, collection }` |
+| POST | `P/emoji-usage/record` | 记录一次使用（unicode 或 pack 表情） |
+| POST / DELETE | `P/emoji-usage/collection/packs` · `…/packs/:packId` | 收藏 / 取消收藏表情包，body `{ packId }` |
+| GET | `P/emoji-usage/frequent?limit=` | 近期常用表情 `{ entries }` |
+| GET | `P/search?q=&limit=&cursor=` | 跨群全局消息搜索 |
+| GET | `P/mailbox/summary` | 离线 DM 存转邮箱摘要 |
+| GET / POST | `P/discovery?limit=` · `P/discovery/refresh` | 本地群发现索引 / 向联邦邻居广播发现公告 |
+| GET | `P/reputation` | 全局主观信誉表（非群 scoped） |
+| PUT | `P/bridge/identity-bind` | body `{ platform, platformUserId, entityHash }`：把平台账号绑到实体 |
+| DELETE | `P/sessions/:groupId` | 删本机会话数据（角色私聊 / 本地 chat 目录），无群权限要求 |
+| GET | `P/emoji-packs` | 可用表情包（已加入群包 ∪ 自有实体包） |
+| GET | `P/emoji-packs/discover?limit=` | 附近公开群包 / 作者包报价 |
+| GET | `P/emoji-content/:packId/:emojiId` | 按 packId 解析表情内容（群包 ∪ 实体作者包） |
 
 ---
 
-## DAG session 事件（AI 编排真源）
-
-写入 `events.jsonl` 并物化为 `state.session`：`session_char_bind` / `session_char_unbind` / `session_world_bind` / `session_world_bind_channel` / `session_world_clear` / `session_persona_set` / `session_char_frequency_set`。插件名单为节点本地 `local_plugins.json`（不入 DAG）。频道 `message` 可在 `extension.chat.sessionSnapshot` 附会话快照供历史水合。
-
-`world_state`：共享世界状态（`content`: `worldname`, `action` (`set`|`delete`), `key`, `value?`）；物化到 `state.worldStates[worldname]`（HLC LWW）。replicated/hosted world 经 `WorldChatHost.state` 读写；`localData` 为本机私有 JSON。联邦入站 content 上限 64KB。
-
-`session_world_bind` / `session_world_bind_channel` 的 `content` 含 `worldname`、`ownerUsername`、`homeNodeHash`（`local` 分布可缺省）、`distribution`（`'local' | 'replicated' | 'hosted'`，绑定者从本机 world part 读出，缺省 `hosted`）。`resolveWorld` 按 `distribution` 决定本机执行或 RPC；未绑定/未安装时回退内置 `BUILTIN_WORLD`（`distribution: 'local'`）。
-
-**写路径（DAG-first）**：human（Hub `POST …/messages` 与 CLI `send`）→ persona `BeforeUserSend` → `commitChannelMessageEvent`；char / greeting 同进该门面。world `AddChatLogEntry` 为落盘前改写/拒绝；`AfterAddChatLogEntry` 仅在 `broadcastAndPersist` 对 `message`（及流式终稿 `message_edit`）触发一次。canonical `message` content（**文本变体**）：`{ content: string, name?, avatar?, files?, extension?: { chat?: { sessionSnapshot?, entryId?, … } } }`；完整 wire 判别联合以 `channelWireMessage_t` 为准（含 `sticker` / `vote` / `group_invite` / `call`）。内存 `chatLog` 仅为 hydration 缓存。
-
-**Chat 日志类型**：fount 面在 `src/decl/chatLog.ts`（`timeSlice` / 水合后 `extension.chat`）；DAG wire 判别联合在 `shells/chat/decl/channelWire.ts`（`channelWireMessage_t`；文本省略 `type`）。shell `decl/chatLog.ts` re-export 两者。persona `BeforeUserSend` / `GetChatLogForViewer` 见 `src/decl/userAPI.ts`。未绑定 world/persona 时 shell 用内置极小实现（`BUILTIN_WORLD` / `BUILTIN_PERSONA`）。
-
-**跨节点 RPC**：群 WS `group_ws_rpc_identity`（`clientNodeId` = 本机 node UUID）+ `rpc_call`（`targetNodeId` 定向）。**RPC 线协议** `memberId`：`owner:charname`（角色）、`owner:world:worldname`（世界）、`owner:persona:name`（人格）。**会话/viewer 层**另用 entity hash 作主键（`chatViewer_t.memberId`、`GetSpeakingOrder` turn 等）。`GetReply` 参数为 `SerializableRequest` `{ groupId, channelId, charname, replicaUsername }`；执行端本地 `getChatRequest`（含 `other_personas` 远程 persona proxy）后生成并 mirror DAG。`other_chars` 为常驻频率∪频道活跃 Top-N（`groupSettings.otherCharsActiveLimit`，默认 8）。本机插件名单仅 `local_plugins.json`；world `GetChatPlugins` 在本机 merge（同名本机优先），hosted 仅主机侧生效。
-
----
-
-## 单群：chatLog 会话层
-
-路径前缀：`/api/parts/shells:chat/groups/:groupId/`
+## 实体与身份
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/initial-data` | 角色、persona、world、插件、日志摘要 |
-| GET | `/chars` | 角色列表 |
-| GET | `/plugins` | 插件列表 |
-| GET | `/persona` / `/world` | 当前 persona / world |
-| PUT | `/persona` | Body：`personaname` |
-| GET | `/branch` | 当前 RPG 分支索引与条目摘要 |
-| PUT | `/world` | Body：`worldname` |
-| PUT | `/branch` | Body：`delta` 或 `{ latest: true, channelId? }`；RPG 分支导航 |
-| POST/DELETE | `/char`、`/char/:charname` | 增删角色 |
-| PUT | `/char/:charname/frequency` | 发言频率 |
-| POST/DELETE | `/plugin`、`/plugin/:pluginname` | 增删插件 |
+| GET | `P/viewer?groupId=` | 当前 operator 实体 + profile + `agents[]`；带 `groupId` 时附群内视角 |
+| GET | `P/personal-lists` | `{ entries: [{ scope, value, kind: 'block'｜'hide' }] }` |
+| GET | `P/entities/search?q=&limit=` | `q` ≥2 字符；handle 精确 / 展示名模糊，在信任图多跳搜实体 → `{ query, entities[] }` |
+| GET / PUT | `P/entities/:entityHash` | 读 / 写实体 identity + profile。本机可写实体直写；对远端实体声明主人身份时经主人 EVFS `owned/{target}/profile_update/*` 发布，返回 `202 { queued, contentHash, ts }` |
+| GET | `P/entities/:entityHash/stats?groupId=` | 实体统计（可按群 scoped） |
+| POST | `P/entities/:entityHash/heartbeat` | 在线心跳 |
+| POST | `P/entities/:entityHash/status` | 更新在线状态 / 状态文本 |
+| POST | `P/entities/:entityHash/rebuild-from-part` | 从对应 part 重建实体 profile |
+| PUT | `P/entities/owner` | body `{ ownerEntityHash: string｜null }`：设置 / 清除当前 operator 的所属主人 |
+| POST | `P/federation/rotate` · `P/federation/revoke` | 轮换 / 吊销实体联邦密钥代际 |
+| GET / PUT / POST | `P/entities/:entityHash/files/*logicalPath` | EVFS：读文件字节 / 写文件 / 上传（消息附件字节在 `chat/{fileId}`） |
+
+实体作者表情包（与群包同构）：
+
+| 方法 | 路径 |
+|------|------|
+| GET / POST | `P/entities/:entityHash/emoji-packs`（列表 / 创建 `{ packId?, localized? }`） |
+| GET / PUT / DELETE | `P/entities/:entityHash/emoji-packs/:packId` |
+| POST | `P/entities/:entityHash/emoji-packs/:packId/emojis`（multipart 字段 `emoji`） |
+| DELETE | `P/entities/:entityHash/emoji-packs/:packId/emojis/:emojiId` |
+| GET | `P/entities/:entityHash/emoji-packs/:packId/emojis/:emojiId/data`（`?json=1` → dataUrl） |
 
 ---
 
-## 频道与联邦消息
-
-前缀：`/api/parts/shells:chat/groups/:groupId/channels/:channelId/`
+## 群：生命周期与状态
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| POST | `/messages` | 发 DAG `message`（human 唯一入口；先 persona `BeforeUserSend`）；需 `SEND_MESSAGES`。content 可带 `locale`、`content_warning`、`sensitive_media`、`forwardedFrom`、`replyTo`（内联引用：`{ eventId, senderName?, preview? }`）、`fileAlts`。agent 自动触发替代载荷字段名为 `generated`（非 quote-reply） |
-| GET | `/member-read-markers` | 本机侧车视角各成员水位 `{ markers: { [entityHash]: { eventId, seq } } }` |
-| PUT | `/read-marker` | body `{ eventId, seq }`；写入实体 readMarkers + 群成员侧车；WS `read_marker`（含 `entityHash`） |
-| GET | `/messages` | raw 查询 `since`、`before`、`limit`；合并 overlay；返回 `{ messages, reactions }`（治理/调试；不含 world/persona 视图滤镜） |
-| GET | `/view-log` | viewer 视图（本机 user）：同 query；物化后 world→persona 滤镜再投影回行 DTO；Hub 主读口；`{ messages, reactions }` |
-| POST | `/view-log/batch-get` | body `{ eventIds: string[] }`（≤500）；按 id 批量取 **viewer 投影**行 + reactions（导航/编辑补拉；被滤 id 不返回） |
-| POST | `/messages/batch-get` | body `{ eventIds: string[] }`（≤500）；按 id 批量取 raw 行 + reactions（治理/审计） |
-| PUT | `/messages/:eventId` | DAG `message_edit`；先 persona `BeforeUserEdit` + world `MessageEdit`；body `{ content: object }` |
-| DELETE | `/messages/:eventId` | DAG `message_delete`；先 persona `BeforeUserDelete` + world `MessageDelete` |
-| PUT | `/messages/:eventId/feedback` | DAG `message_feedback`（`up`/`down`） |
-| POST | `/reactions` | `{ targetEventId, emoji }` — 添加反应 |
-| DELETE | `/reactions` | body `{ targetEventId, emoji, targetPubKeyHash? }` — 移除反应 |
-| POST | `/pins` | `{ targetEventId }`；需 `PIN_MESSAGES` |
-| DELETE | `/pins/:eventId` | 取消置顶；需 `PIN_MESSAGES` |
-| POST | `/votes` | 创建投票 `message`（`content.type: 'vote'`） |
-| POST | `/votes/:ballotId/cast` | `vote_cast` |
-| POST | `/trigger-reply` | 频道内触发角色回复 |
-| POST | `/threads` | 建子频道；需 `CREATE_THREADS` |
-| POST | `/streaming-auth` | 流媒体观看 token；频道 `type: streaming` 且配置 `streamingSfuWss` |
-| GET | `/call-status` | 群组通话状态 `{ active, peerCount, callId?, participants? }` |
-| POST | `/list-items` | 列表频道条目更新 |
+| GET | `G/` | 已加入的群 / DM 摘要，按消息活动时间排序 |
+| POST | `G/` | 建群：`name`、`description`、`defaultChannelName`、`defaultChannelId` → `201 { groupId, defaultChannelId }`。建 DM：`{ template: 'dm', myPubKeyHex, peerPubKeyHex }`（各 64 hex），可选 `dmIntroNonce` + `dmIntroSignatureHex` 成对出现 |
+| GET | `G/:groupId/preview` | 非成员群卡片预览（私密群隐藏加入入口） |
+| DELETE | `G/:groupId` | 删整群本地 DAG 数据；需 `ADMIN` 或 `MANAGE_ADMINS` |
+| GET | `G/:groupId/state` | 分层 DTO `{ meta, viewer, federation }`：`meta` 含 `channels`/`groupSettings`/`roles`/`members`/`pinsByChannel`/`cabinets`/`files`；`viewer` 是当前用户视角（`isMember`、`memberKey`、`entityHash`、`roles`）；`federation` 是同步与隔离状态 |
+| GET | `G/:groupId/snapshot` | 本地 checkpoint 快照 JSON |
+| POST | `G/:groupId/compact` | 压实 DAG（按保留策略裁剪） |
+| GET | `G/:groupId/search?q=&channelId=&limit=` | 群内全文搜索（`q` ≥2，默认 30 / 上限 100）→ `{ query, items[] }` |
+| GET | `G/:groupId/audit-log` | 治理审计流 |
+| GET / PUT | `G/:groupId/branch` | RPG 分支索引；PUT body `{ delta }` 或 `{ latest: true, channelId? }` |
+| PUT | `G/:groupId/default-channel` · `G/:groupId/meta` · `G/:groupId/settings` | 默认频道 / 群资料 / 群设置 |
+| POST / PUT / DELETE | `G/:groupId/channels` · `C`（`PUT`/`DELETE`） | 频道增改删 |
+| GET | `C/export` | 导出频道完整归档 JSON（冷热历史终态、墓碑、反应计数、附件元数据）；需 `VIEW_CHANNEL` |
+| POST | `G/:groupId/channels/import` | 把归档导入为本群新 text 频道（multipart 字段 `archive` 或 JSON body）；需 `MANAGE_CHANNELS` → `{ channelId, messageCount }` |
 
-**群组通话**：文本频道顶栏「通话」→ WS `/ws/parts/shells:chat/call/:groupId/:channelId`（room=`groupId:channelId:call`，av-relay + roster）。首人入房发 `content.type:'call'` 卡片，参与者变化 `message_edit`，空房定稿 `status:'ended'`。屏幕共享用 `frame_type=2`。
+## 群：DAG 与联邦
 
-**流式（§6.4）**：DAG `message`（`is_generating: true`）→ VOLATILE `stream_chunk`（`pendingStreamId` = 占位 event id，`channelId` 必填，`chunkSeq` + `slices` diff 数组，Ed25519 签名）→ DAG `message_edit` 终稿。超时未终稿由 `streamGeneratingIdleMs`（默认 150000ms）标记失败。
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `G/:groupId/events?since=&limit=&channelId=` | 查询 DAG 事件行 |
+| POST | `G/:groupId/events/signed` | 批量追加远程已签名联邦事件（完整 signed event 体） |
+| POST | `G/:groupId/events/local` | 批量追加本地未签名授权类事件（经 `localAuthz` 校验） |
+| GET | `G/:groupId/dag/tips` | 当前 DAG 叶；≥2 表示分叉，附 `tipScores` / `tipConsensusScores` |
+| POST | `G/:groupId/dag/merge-tips` | 写 `dag_tip_merge` 合并全部叶；需 `MANAGE_CHANNELS` |
+| POST | `G/:groupId/fork` | 治理分叉：复制分支为新 `groupId` |
+| POST | `G/:groupId/fork/block-opposing` | body `{ acceptedTipId }`：把非该叶分支上的治理事件签发者写入本机 denylist |
+| PUT | `G/:groupId/governance-branch` | 选定本地治理分支 tip |
+| GET | `G/:groupId/peers` | P2P roster + 用户级 `trustedPeers` / `explorePeers` / `blockedPeers` 视图 |
+| POST | `G/:groupId/federation/catchup` | 向邻居补洞；响应含 `tipsCollected`、`wantIds`、`eventsFilled`、`wantIdsStillMissing`、`wantIdsRateLimited` |
+| POST | `G/:groupId/federation/join-snapshot` | 入群后向邻居请求快照，校验后落 `snapshot.json` 并物化 |
+| POST | `G/:groupId/federation/rotate-room-secret` | 写入 / 轮换群级 `roomSecret`；需 `ADMIN` 或 `MANAGE_ADMINS` |
+| POST | `G/:groupId/federation/tuning` | `federationPartitionCount`（2-64）、`rtcConnectionBudgetMax`（8-128）、`rtcJoinRatePerMin`（4-60）；需 `ADMIN` 或 `MANAGE_ADMINS` |
+| POST | `G/:groupId/federation/rebind` | body `{ channelId? }`：按活跃频道重绑联邦分区 |
+| POST | `G/:groupId/federation/shun-dismiss` | 关闭「疑似被移除」提示横幅 |
+| POST | `G/:groupId/federation/offline-mark` | 标记本机离线起点（用于回来后补洞） |
+| GET | `G/:groupId/archive/summary` | 冷归档存储摘要 |
+| POST | `G/:groupId/archive/sync` | 触发冷归档同步 |
+| DELETE | `G/:groupId/archive` | 删除指定月份之前的冷归档（body 指定 `beforeMonth`） |
+| POST | `G/:groupId/reputation/slash` · `G/:groupId/reputation/reset` | 记罚分 / 重置该群主观信誉 |
 
----
+## 群：成员、角色与权限
 
-## 角色与权限
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `G/:groupId/members/page/:pageIdx` | 活跃成员分页（每页 ≤500），附 `membersRoot`、`membersPagesCount` |
+| GET | `G/:groupId/mentions/suggest?q=&limit=` | 群内 @ 补全 `{ suggestions: [{ entityHash, displayName, memberKey, kind }] }` |
+| POST | `G/:groupId/invite-ticket` | 签发短时邀请码（默认 TTL 1h），响应含 `signalingAppId`、`roomSecret`、`introducerPubKeyHash`、`clipboardText` 深链；无 `roomSecret` 时 `409`；需 `INVITE_MEMBERS` 或管理权限 |
+| POST | `G/:groupId/join` | body `inviteCode?`、`signalingAppId?`、`roomSecret?`、`pow?`、`introducerPubKeyHash?`、`reputationEdge?`、`dmIntroNonce?`、`dmIntroSignatureHex?` |
+| POST | `G/leave` | 退群，body `{ groupIds: string[] }`（单群也传数组）：写 `member_leave` 并删本机群数据 |
+| POST | `G/:groupId/members/:memberKey/kick`｜`/ban`｜`/unban` | 成员治理，路径参数是 `memberKey` |
+| GET | `G/:groupId/permissions` | 当前用户在本群的有效权限 |
+| GET / PUT | `C/permissions` | 频道级权限覆盖 |
+| POST / PUT / DELETE | `G/:groupId/roles`、`G/:groupId/roles/:roleId`、`G/:groupId/roles/:roleId/permissions` | 角色增改删与权限位 |
+| POST | `G/:groupId/owner-succession` | 多管理员联署接替群主，body `{ proposedOwnerPubKeyHash, ballotId, adminSignatures: [{ pubKeyHex, signature }], thresholdRatio? }` |
+
+## 群：文件与共享柜
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `G/:groupId/chunks/have` | 预检 `{ data }` 或 `{ ciphertextHash, size }`；`have: true` 时客户端用 `registerOnly` 跳传 |
+| POST | `G/:groupId/chunks` | 上传块；可带 `registerOnly: true`（密文已存在时仅登记 wrappedKey） |
+| POST | `G/:groupId/files` | 登记消息附件元数据 → DAG `file_upload` |
+| DELETE | `G/:groupId/files/:fileId` | DAG `file_delete` |
+| GET | `G/:groupId/files/:fileId/meta` | 附件元数据，含 `uploaderPubKeyHash` |
+| GET | `G/:groupId/files/:fileId/download-status` | 分片下载进度 `{ done, total, percent, status, seededAt }` |
+| POST | `G/:groupId/files/:fileId/download-resume` | 触发断点续传并返回当前任务状态 |
+| POST | `G/:groupId/file-key-rotate` | 轮换群文件主密钥代际 |
+| POST | `G/:groupId/cabinets/bind` · `…/unbind` | 绑定 / 解绑共享柜；需 `ADMIN` 或 `MANAGE_ADMINS`。目录管理本身在 Cabinet shell |
+
+## 群：表情包
 
 | 方法 | 路径 |
 |------|------|
-| POST | `…/groups/:groupId/roles` |
-| PUT | `…/groups/:groupId/roles/:roleId` |
-| PUT | `…/groups/:groupId/roles/:roleId/permissions` |
-| DELETE | `…/groups/:groupId/roles/:roleId` |
+| GET / POST | `G/:groupId/emoji-packs`（列表 / 创建 `{ packId?, localized? }`） |
+| GET / PUT / DELETE | `G/:groupId/emoji-packs/:packId` |
+| POST | `G/:groupId/emoji-packs/:packId/emojis`（multipart 字段 `emoji`） |
+| DELETE | `G/:groupId/emoji-packs/:packId/emojis/:emojiId` |
+| GET | `G/:groupId/emoji-packs/:packId/emojis/:emojiId/data`（`?json=1` → dataUrl） |
 
 ---
 
-## 成员治理
+## 频道消息（前缀 `C`）
 
-| 方法 | 路径 |
-|------|------|
-| POST | `…/groups/:groupId/members/:pubKeyHash/kick` |
-| POST | `…/groups/:groupId/members/:pubKeyHash/ban` |
-| POST | `…/groups/leave` | 退群（body `{ groupIds }`；`member_leave` + 删除本机群数据，服务端有限并发） |
-| POST | `…/groups/:groupId/members/:pubKeyHash/unban` |
-| POST | `…/groups/:groupId/file-key-rotate` | 轮换群文件主密钥 GSH |
-| POST | `…/groups/:groupId/owner-succession` | 多管理员联署接替群主（MANAGE_ADMINS 转移）；body: `{ proposedOwnerPubKeyHash, ballotId, adminSignatures: [{ pubKeyHex, signature }], thresholdRatio? }` |
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `C/messages` | 发 DAG `message`（人类唯一入口，先过 persona `BeforeUserSend`）；需 `SEND_MESSAGES`。content 可带 `locale`、`content_warning`、`sensitive_media`、`forwardedFrom`、`replyTo`（`{ eventId, senderName?, preview? }`）、`fileAlts` |
+| GET | `C/messages?since=&before=&limit=` | raw 行 + `{ messages, reactions }`（治理 / 调试，无 world→persona 滤镜） |
+| GET | `C/view-log?since=&before=&limit=` | 观看者投影（Hub 主读口）：物化后经 world→persona 滤镜投影回行 DTO |
+| POST | `C/view-log/batch-get` | body `{ eventIds }`（≤500）：按 id 批量取投影行（被滤 id 不返回） |
+| POST | `C/messages/batch-get` | body `{ eventIds }`（≤500）：按 id 批量取 raw 行（治理 / 审计） |
+| PUT | `C/messages/:eventId` | DAG `message_edit`，body `{ content: object }` |
+| DELETE | `C/messages/:eventId` | DAG `message_delete` |
+| PUT | `C/messages/:eventId/feedback` | DAG `message_feedback`（`up` / `down`） |
+| POST / DELETE | `C/reactions` | 加反应 `{ targetEventId, emoji }` / 移除 `{ targetEventId, emoji, targetPubKeyHash? }` |
+| POST / DELETE | `C/pins` · `C/pins/:eventId` | 置顶 / 取消置顶，需 `PIN_MESSAGES` |
+| GET | `C/pin-context/:eventId` | 取某条置顶消息的上下文切片 |
+| POST | `C/votes` · `C/votes/:ballotId/cast` | 创建投票消息 / 投票 |
+| POST | `C/trigger-reply` | 在频道内触发角色回复 |
+| POST | `C/threads` | 建子频道；需 `CREATE_THREADS` |
+| PUT | `C/read-marker` | body `{ eventId, seq }`：写实体已读水位 + 群成员侧车，并广播 WS `read_marker` |
+| GET | `C/member-read-markers` | `{ markers: { [entityHash]: { eventId, seq } } }` |
+| POST | `C/history-want` | 请求补齐更早历史（懒加载 / 冷归档回填） |
+| GET | `C/stream-buffer/:pendingStreamId` | 拉取流式生成中的已收增量缓冲 |
+| POST | `C/list-items` | 更新列表频道条目 |
+| GET | `C/call-status` | 群组通话状态 `{ active, peerCount, callId?, participants? }` |
+| GET | `C/streaming-view` | 流媒体频道观看信息 |
+| POST | `C/streaming-auth` | 观看 token；频道 `type: streaming` 且配置了 `streamingSfuWss` |
+| POST / DELETE | `C/whip` | WHIP 推流建立 / 断开 |
 
----
+流式：DAG `message`（`is_generating: true`）→ WS `stream_chunk`（`pendingStreamId` = 占位 event id，`chunkSeq` + `slices` diff，Ed25519 签名）→ DAG `message_edit` 终稿。超时未定稿按 `streamGeneratingIdleMs`（默认 150000ms）标记失败。
 
-## 群文件（§10.3 收敛加密）
-
-| 方法 | 路径 |
-|------|------|
-| POST | `…/groups/:groupId/chunks/have` | 预检 `{ data }` 或 `{ ciphertextHash, size }`；`have: true` 时客户端 `registerOnly` 跳传 |
-| POST | `…/groups/:groupId/chunks` | 上传块；body 可加 `registerOnly: true`（密文已存在时仅登记 wrappedKey） |
-| POST | `…/groups/:groupId/files` | 登记消息附件元数据 → DAG `file_upload` |
-| DELETE | `…/groups/:groupId/files/:fileId` | DAG `file_delete` |
-| GET | `…/groups/:groupId/files/:fileId/meta` | 含 `uploaderPubKeyHash`（物化自 `file_upload.sender`） |
-| GET | `…/groups/:groupId/files/:fileId/download-status` | 分片下载任务摘要（`done/total/percent/status/seededAt`） |
-| POST | `…/groups/:groupId/files/:fileId/download-resume` | 触发断点续传并返回当前下载任务状态 |
-| POST | `…/groups/:groupId/cabinets/bind` | 绑定共享柜 `{ cabinet_id, name?, write_pubkey?, role_access }` → DAG `cabinet_bind`（须 `ADMIN`/`MANAGE_ADMINS`） |
-| POST | `…/groups/:groupId/cabinets/unbind` | 解绑 `{ cabinet_id }` → DAG `cabinet_unbind`（须 `ADMIN`/`MANAGE_ADMINS`） |
-
-消息附件字节：`GET /api/parts/shells:chat/entities/{groupEntityHash}/files/chat/{fileId}`。
-
-`GET …/state` 响应含 `cabinets`（role→rw/ro）、`files[]`（消息附件摘要）。目录管理在 Cabinet 共享柜。
-
-不可验证 `reputation_slash`（无 `verified`/`proof`）经联邦 VOLATILE `reputation_slash_alert` 传播（TTL=`slashAlertTtl`），不入 DAG；可验证类仍 `POST …/events/signed` 或本地 `POST …/events/local`。
-
----
-
-## VOLATILE（WebSocket，不入 DAG）
-
-- `typing`、`stream_chunk`（`slices` diff + 签名；结束 = `message_edit`，无 `stream_end`）
-- `stop_generation`（控制帧）
-- `channel_message`、`dag_event`、`message_replaced` 等由服务端推送
+群组通话：文本频道顶栏进入 → WS `call/:groupId/:channelId`（room = `groupId:channelId:call`）。首人入房发 `content.type: 'call'` 卡片，参与者变化用 `message_edit`，空房定稿 `status: 'ended'`；屏幕共享用 `frame_type=2`。
 
 ---
 
-## ChatClient 对象模型（进程内 API）
+## 会话（角色 / 世界 / 人格，前缀 `G/:groupId`）
 
-import 入口：`src/public/parts/shells/chat/src/api/client/index.mjs` → `getChatClient(username, entityHash?)`。
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `G/:groupId/initial-data` | 角色、persona、world、插件、日志摘要一次取回 |
+| GET | `G/:groupId/chars` · `/plugins` · `/persona` · `/world` | 当前角色 / 插件 / 人格 / 世界 |
+| PUT | `G/:groupId/persona` | body `{ personaname }` |
+| PUT | `G/:groupId/world` | body `{ worldname }` |
+| POST / DELETE | `G/:groupId/char` · `G/:groupId/char/:charname` | 加 / 移除角色 |
+| PUT | `G/:groupId/char/:charname/frequency` | 角色发言频率 |
+| POST / DELETE | `G/:groupId/plugin` · `G/:groupId/plugin/:pluginname` | 加 / 移除插件（插件名单是节点本地 `local_plugins.json`，不入 DAG） |
 
-- **统一实体模型**：人类与本机 agent 同为实体；缺省 entityHash = operator。HTTP 路由薄封装恒为 operator；agent 只经本入口绑定自身实体。无私有状态换身份参数。
-- **写事件**：该实体 per-group `local_signer_seed` 自签；权限主体恒为 `sender`。无代签 / `acting*` 归因字段。
-- **对象**：`ChatClient` → `Group` → `Channel` / `Member` / `Role`；`Message` 由 `channel.send` 或 `client.messageFrom(onMessageEvent)` 水合。`Message.content` 恒为 fount 正文（`string`，同 `chatLogEntry_t` / `OnMessage`）；附件在 `Message.files`。
-- **生命周期**：`createGroup` / `openDm` / `join` 均以绑定实体签名（DM 对端须为可解析用户 pubKeyHash）。
-- **私有状态**：`bookmarks` / `groupFolders` / `aliases` / `readMarkers` / `notifications` / `inbox` / `emojis`（emoji_usage）/ `care` 均挂在绑定实体或用户 shellData 下。
-- **会话 / 联邦 / 节点**：`Group.session.*`、`Group.federation.catchup/setTuning`、`Group.fork/blockOpposingFork`、`Group.reputation`、`ChatClient.reputation`、`ChatClient.nodeDenylist`、`Channel.triggerReply` / `streamingAuth`、`updateProfile` / `updateEntityProfile` / `setOwner`。
-- **写路径**：消息发送走 `commitChannelMessageEvent`；其余写操作走 `appendSignedLocalEvent(..., { entityHash })`。
-- **桥接（虚拟会话）**：平台 bot 不建真实 Hub 群。虚拟群 id = `bridge:{platform}:{platformChatId}`；进程内 chat log + `bridgeOperations` 出站。`group.bridge` 含 `platform` / `platformChatId` / `chatKind` / `botname`；`group.bridgeBot().stop()` / `client.bridgeBots()`。无 char 级杀进程。
-- **code_execution**：`getChatRequest` / 虚拟 bridge request 注入 `fount_chat` → `{ fount: { chat, group, channel, message? } }`；平台插件另注入原生命名空间。沙箱不暴露 `bridgeOperations`。
+会话绑定的真源是 DAG 事件（`session_char_bind` / `session_world_bind` / `session_persona_set` / `session_char_frequency_set` 等），物化为 `state.session`；上面的 HTTP 路由都是往 DAG 追加事件的薄封装。未绑定 world / persona 时 shell 用内置极小实现。
 
-壳级说明见 `public/AGENTS.md`；操作平权见 `docs/review/human-agent-operational-parity-review.md`。
+---
+
+## 深链
+
+- DM：`fount://run/shells:chat/dm;<pubKeyHex>;<nonce>;<introSignatureHex>[;nodeUrl]`
+- 入群：`fount://run/shells:chat/join;<groupId>;<inviteCode>[;<roomSecret>[;<introducerPubKeyHash>]]`
+
+解析与生成在 `public/shared/runUri.mjs`；站外分享包一层 `https://steve02081504.github.io/fount/protocol?url=` + `encodeURIComponent(runUri)`。

--- a/src/public/parts/shells/chat/src/entity/endpoints.mjs
+++ b/src/public/parts/shells/chat/src/entity/endpoints.mjs
@@ -211,8 +211,7 @@ export function registerEntityEndpoints(router) {
 		if (!resolveAgentCharPartName(replicaUsername, entityHash))
 			throw httpError(400, 'rebuild-from-part is only for local agents')
 		const { syncAgentProfileFromCharPart } = await import('../profile/syncFromCharPart.mjs')
-		const stored = await syncAgentProfileFromCharPart(replicaUsername, entityHash, { force: true })
-		if (!stored)
+		if (!await syncAgentProfileFromCharPart(replicaUsername, entityHash, { force: true }))
 			throw httpError(400, 'rebuild failed')
 		const locales = localesFromRequest(req, replicaUsername)
 		const groupId = String(req.query?.groupId || '').trim() || undefined
@@ -224,8 +223,7 @@ export function registerEntityEndpoints(router) {
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!operatorEntityHash)
 			throw httpError(400, 'operator identity not configured')
-		const raw = req.body?.ownerEntityHash
-		const ownerEntityHash = raw ? String(raw).trim().toLowerCase() : null
+		const ownerEntityHash = req.body?.ownerEntityHash ? String(req.body.ownerEntityHash).trim().toLowerCase() : null
 		if (ownerEntityHash && !isEntityHash128(ownerEntityHash))
 			throw httpError(400, 'invalid ownerEntityHash')
 		const row = await setEntityOwner(replicaUsername, operatorEntityHash, ownerEntityHash)

--- a/src/public/parts/shells/chat/src/entity/endpoints.mjs
+++ b/src/public/parts/shells/chat/src/entity/endpoints.mjs
@@ -5,6 +5,7 @@ import {
 	loadPersonalHideEntries,
 } from 'npm:@steve02081504/fount-p2p/node/personal_block'
 
+import { httpError } from '../../../../../../scripts/http_error.mjs'
 import { authenticate, getUserByReq } from '../../../../../../server/auth/index.mjs'
 
 import { registerEntityFileEndpoints } from './filesEndpoints.mjs'
@@ -114,10 +115,10 @@ export function registerEntityEndpoints(router) {
 		const entityHash = req.params[0].toLowerCase()
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!isEntityHash128(entityHash))
-			return res.status(400).json({ error: 'invalid entityHash' })
+			throw httpError(400, 'invalid entityHash')
 		const groupId = String(req.query?.groupId || '').trim() || undefined
 		if (!await canReadEntityStats(replicaUsername, operatorEntityHash, entityHash, groupId))
-			return res.status(403).json({ error: 'Permission denied' })
+			throw httpError(403, 'Permission denied')
 		res.status(200).json({ stats: await getStats(entityHash) })
 	})
 
@@ -125,7 +126,7 @@ export function registerEntityEndpoints(router) {
 		const entityHash = req.params[0].toLowerCase()
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!await isWritableLocalEntityForUser(replicaUsername, entityHash))
-			return res.status(403).json({ error: 'Permission denied' })
+			throw httpError(403, 'Permission denied')
 		const { lastSeenAt } = await recordHeartbeat(replicaUsername, entityHash)
 		pollOwnedEntityProfileUpdates(replicaUsername).catch(handleError)
 		const profile = await getProfile(entityHash, replicaUsername, { skipPresentation: true })
@@ -139,7 +140,7 @@ export function registerEntityEndpoints(router) {
 		const entityHash = req.params[0].toLowerCase()
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!await isWritableLocalEntityForUser(replicaUsername, entityHash))
-			return res.status(403).json({ error: 'Permission denied' })
+			throw httpError(403, 'Permission denied')
 		const updated = await updateStatus(replicaUsername, entityHash, req.body.status, req.body.customStatus)
 		res.status(200).json({
 			status: updated.status,
@@ -177,7 +178,7 @@ export function registerEntityEndpoints(router) {
 		const entityHash = req.params[0].toLowerCase()
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!operatorEntityHash)
-			return res.status(400).json({ error: 'operator identity not configured' })
+			throw httpError(400, 'operator identity not configured')
 		const groupId = String(req.body?.groupId || req.query?.groupId || '').trim() || undefined
 		const locales = localesFromRequest(req, replicaUsername)
 		try {
@@ -194,7 +195,7 @@ export function registerEntityEndpoints(router) {
 		}
 		catch (error) {
 			if (error?.status === 403 || /Permission denied|not declared owner/i.test(String(error?.message || '')))
-				return res.status(403).json({ error: error.message || 'Permission denied' })
+				throw httpError(403, error.message || 'Permission denied')
 			throw error
 		}
 	})
@@ -203,16 +204,16 @@ export function registerEntityEndpoints(router) {
 		const entityHash = req.params[0].toLowerCase()
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!operatorEntityHash)
-			return res.status(400).json({ error: 'operator identity not configured' })
-		if (!isWritableLocalEntityForUser(replicaUsername, entityHash))
-			return res.status(403).json({ error: 'entity not writable on this replica' })
+			throw httpError(400, 'operator identity not configured')
+		if (!await isWritableLocalEntityForUser(replicaUsername, entityHash))
+			throw httpError(403, 'entity not writable on this replica')
 		const { resolveAgentCharPartName } = await import('./member.mjs')
 		if (!resolveAgentCharPartName(replicaUsername, entityHash))
-			return res.status(400).json({ error: 'rebuild-from-part is only for local agents' })
+			throw httpError(400, 'rebuild-from-part is only for local agents')
 		const { syncAgentProfileFromCharPart } = await import('../profile/syncFromCharPart.mjs')
 		const stored = await syncAgentProfileFromCharPart(replicaUsername, entityHash, { force: true })
 		if (!stored)
-			return res.status(400).json({ error: 'rebuild failed' })
+			throw httpError(400, 'rebuild failed')
 		const locales = localesFromRequest(req, replicaUsername)
 		const groupId = String(req.query?.groupId || '').trim() || undefined
 		const profile = await getProfile(entityHash, replicaUsername, { groupId, locales })
@@ -222,11 +223,11 @@ export function registerEntityEndpoints(router) {
 	router.put(`${CHAT_PREFIX}/entities/owner`, authenticate, async (req, res) => {
 		const { replicaUsername, operatorEntityHash } = await getReplicaFromReq(req)
 		if (!operatorEntityHash)
-			return res.status(400).json({ error: 'operator identity not configured' })
+			throw httpError(400, 'operator identity not configured')
 		const raw = req.body?.ownerEntityHash
 		const ownerEntityHash = raw ? String(raw).trim().toLowerCase() : null
 		if (ownerEntityHash && !isEntityHash128(ownerEntityHash))
-			return res.status(400).json({ error: 'invalid ownerEntityHash' })
+			throw httpError(400, 'invalid ownerEntityHash')
 		const row = await setEntityOwner(replicaUsername, operatorEntityHash, ownerEntityHash)
 		res.status(200).json({
 			entityHash: operatorEntityHash,

--- a/src/public/parts/shells/chat/src/entity/filesEndpoints.mjs
+++ b/src/public/parts/shells/chat/src/entity/filesEndpoints.mjs
@@ -62,20 +62,20 @@ export function registerEntityFileEndpoints(router, authenticate, getUserByReq) 
 		const entityHash = String(req.params.entityHash || '').toLowerCase()
 		const logicalPath = parseEvfsLogicalPath(readWildcardPath(req.params.logicalPath))
 		if (!isEntityHash128(entityHash) || !logicalPath)
-			return res.status(400).json({ error: 'invalid path' })
+			throw httpError(400, 'invalid path')
 
 		const { username } = getUserByReq(req)
 		const manifest = await loadFileManifest(entityHash, logicalPath)
 		if (!manifest)
-			return res.status(404).json({ error: 'not found' })
+			throw httpError(404, 'not found')
 		if (!await canReadManifest(username, entityHash, manifest))
-			return res.status(403).json({ error: 'Permission denied' })
+			throw httpError(403, 'Permission denied')
 
 		if (String(req.query?.manifest || '') === '1')
 			return res.status(200).json({ manifest })
 
 		const plain = await readManifestPlaintextStream(username, manifest, { username })
-		if (!plain) return res.status(404).json({ error: 'chunk unavailable' })
+		if (!plain) throw httpError(404, 'chunk unavailable')
 		applySafeContentHeaders(res, {
 			mimeType: manifest.mimeType,
 			filename: logicalPath.split('/').pop() || 'file',
@@ -105,20 +105,20 @@ export function registerEntityFileEndpoints(router, authenticate, getUserByReq) 
 		const entityHash = String(req.params.entityHash || '').toLowerCase()
 		const logicalPath = parseEvfsLogicalPath(readWildcardPath(req.params.logicalPath))
 		if (!isEntityHash128(entityHash) || !logicalPath)
-			return res.status(400).json({ error: 'invalid path' })
+			throw httpError(400, 'invalid path')
 
 		const { username } = getUserByReq(req)
 		if (!await canWriteManifestPath(username, entityHash, logicalPath))
-			return res.status(403).json({ error: 'Permission denied' })
+			throw httpError(403, 'Permission denied')
 
 		const contentType = String(req.headers['content-type'] || '').toLowerCase()
 		if (!contentType.startsWith('application/octet-stream'))
-			return res.status(415).json({ error: 'require application/octet-stream' })
+			throw httpError(415, 'require application/octet-stream')
 		const contentLength = Number(req.headers['content-length'] || 0)
 		if (!Number.isFinite(contentLength) || contentLength <= 0)
-			return res.status(400).json({ error: 'content-length required' })
+			throw httpError(400, 'content-length required')
 		if (contentLength > MAX_EVFS_UPLOAD_BYTES)
-			return res.status(413).json({ error: 'file too large' })
+			throw httpError(413, 'file too large')
 
 		const manifest = await putFileManifestFromStream({
 			ownerEntityHash: entityHash,

--- a/src/public/parts/shells/chat/src/entity/filesEndpoints.mjs
+++ b/src/public/parts/shells/chat/src/entity/filesEndpoints.mjs
@@ -88,11 +88,11 @@ export function registerEntityFileEndpoints(router, authenticate, getUserByReq) 
 		const entityHash = String(req.params.entityHash || '').toLowerCase()
 		const logicalPath = parseEvfsLogicalPath(readWildcardPath(req.params.logicalPath))
 		if (!isEntityHash128(entityHash) || !logicalPath)
-			return res.status(400).end()
+			throw httpError(400, 'invalid path')
 		const { username } = getUserByReq(req)
 		const manifest = await loadFileManifest(entityHash, logicalPath)
 		if (!manifest || !await canReadManifest(username, entityHash, manifest))
-			return res.status(404).end()
+			throw httpError(404, 'not found')
 		applySafeContentHeaders(res, {
 			mimeType: manifest.mimeType,
 			filename: logicalPath.split('/').pop() || 'file',

--- a/src/public/parts/shells/config/public/llms.txt
+++ b/src/public/parts/shells/config/public/llms.txt
@@ -1,26 +1,29 @@
-# config shell 支持的 Web 端点说明
+# config shell Web API
 
-本 shell 提供 part 配置的读取、写入与展示信息。
+读写指定 part 的配置，并获取配置页展示信息。
+
+路径前缀：`/api/parts/shells:config`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:config/
-- 用途：part 配置页面，用于查看和编辑指定 part 的配置。可通过 URL 参数指定 partpath（`?partpath=${path}`）。支持动态配置 UI 展示。
+- 查询：`partpath`（如 `?partpath=chars/my-char`）
+- 用途：part 配置编辑页。
 
 ---
 
-## 配置数据
+## API
 
 ### GET /api/parts/shells:config/getdata
-- 查询：`partpath`（字符串，必填）。part 路径，如 `chars/my-char`，路径中可用冒号代替斜杠（会规范化为 /）。
-- 用途：获取指定 part 的配置数据。
+- 查询：`partpath`（必填；冒号会规范化为 `/`）
+- 用途：读取配置数据。
 
 ### POST /api/parts/shells:config/setdata
-- Body：JSON。`partpath`（字符串，必填）、`data`（要保存的配置对象）。
-- 用途：保存指定 part 的配置。
+- Body：`partpath`、`data`
+- 用途：保存配置。
 
 ### GET /api/parts/shells:config/getPartDisplay
-- 查询：`partpath`（字符串，必填）。
-- 用途：获取指定 part 的展示信息（名称、描述、配置 UI 等），用于配置界面。返回 `{ html, js }` 等。
+- 查询：`partpath`（必填）
+- 用途：配置 UI 展示信息，返回 `{ html, js }` 等。

--- a/src/public/parts/shells/debug_info/public/llms.txt
+++ b/src/public/parts/shells/debug_info/public/llms.txt
@@ -1,17 +1,28 @@
-# debug_info shell 支持的 Web 端点说明
+# debug_info shell Web API
 
-本 shell 提供调试用系统信息接口。
+本 shell 提供调试用系统信息、自动更新开关查询、重启与打开源码目录。
+
+路径前缀：`/api/parts/shells:debug_info`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:debug_info/
-- 用途：调试信息页面，用于查看服务器系统信息、运行环境详情、连接状态等调试相关信息，便于问题排查和系统诊断。
+- 用途：调试信息页（系统信息、连接状态等）。
 
 ---
 
-## 系统信息
+## API
 
 ### GET /api/parts/shells:debug_info/system_info
-- 用途：获取当前服务器/运行环境的系统信息，用于调试与问题排查。
+- 用途：服务器 / 运行环境系统信息。
+
+### GET /api/parts/shells:debug_info/auto_update_enabled
+- 用途：当前是否启用自动更新。
+
+### POST /api/parts/shells:debug_info/restart
+- 用途：请求重启 fount 进程。
+
+### POST /api/parts/shells:debug_info/open_source
+- 用途：在本机打开源码目录（依赖本机环境）。

--- a/src/public/parts/shells/deskpet/public/llms.txt
+++ b/src/public/parts/shells/deskpet/public/llms.txt
@@ -1,30 +1,34 @@
-# deskpet shell 支持的 Web 端点说明
+# deskpet shell Web API
 
-本 shell 提供桌面宠物的启动、停止与运行列表查询。桌面宠物由「角色」（chars）担任，需该角色 part 实现 deskpet 接口并提供宠物 URL。
+桌面宠物启停。宠物由实现了 deskpet 接口的角色（chars）担任。
+
+路径前缀：`/api/parts/shells:deskpet`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:deskpet/
-- 用途：桌面宠物管理页面，用于启动、停止和管理桌面宠物。显示可用的宠物角色列表、正在运行的宠物状态等信息。
+- 用途：桌面宠物管理页。
 
 ### GET /parts/shells:deskpet/default_pet
-- 用途：默认宠物页面，用于设置和查看默认桌面宠物配置。
+- 用途：默认宠物配置页。
 
 ### GET /parts/shells:deskpet/set_cookie_and_redirect
-- 查询：apikey（临时 API Key）、redirect（目标宠物页 URL，URL 编码）
-- 用途：WebView 启动链：将 apikey 写入 `fount-apikey` Cookie 后跳转到 redirect；后续同源请求带 Cookie 即可认证。
+- 查询：`apikey`、`redirect`（URL 编码）
+- 用途：WebView 启动链：写入 `fount-apikey` Cookie 后跳转 `redirect`。
 
-## 桌面宠物
+---
+
+## API
 
 ### POST /api/parts/shells:deskpet/start
-- Body：JSON，字段 `charname`（字符串，必填）。角色名，即 chars 下的 part 名称，例如 `my-pet`（对应 partpath `chars/my-pet`）。需先通过 GET /api/getlist/chars 等确认该角色存在且已实现 deskpet 接口。
-- 用途：启动指定角色对应的桌面宠物窗口。
+- Body：`charname`（必填）
+- 用途：启动指定角色的桌面宠物窗口。
 
 ### POST /api/parts/shells:deskpet/stop
-- Body：JSON，字段 `charname`（字符串，必填）。与 start 相同，为要停止的宠物对应的角色名。
-- 用途：停止指定桌面宠物。
+- Body：`charname`（必填）
+- 用途：停止指定宠物。
 
 ### GET /api/parts/shells:deskpet/getrunningpetlist
-- 用途：获取当前用户正在运行的桌面宠物列表。返回 JSON 数组，每项为角色名字符串（charname），与 start/stop 的 `charname` 一致，可直接用于调用 stop。
+- 用途：正在运行的宠物角色名数组。

--- a/src/public/parts/shells/discordbot/public/llms.txt
+++ b/src/public/parts/shells/discordbot/public/llms.txt
@@ -1,52 +1,54 @@
-# discordbot shell 支持的 Web 端点说明
+# discordbot shell Web API
 
-本 shell 提供 Discord 机器人的启动、停止与配置管理。
+本 shell 管理 Discord 机器人：配置 CRUD 与启停。绑定角色后走 `char.interfaces.chat.GetReply`；会话为虚拟桥接群，不建真实 Hub 群。
+
+路径前缀：`/api/parts/shells:discordbot`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:discordbot/
-- 用途：Discord 机器人管理页面，用于创建、配置、启动和停止 Discord 机器人。支持管理多个机器人配置、查看运行状态、编辑机器人设置等功能。
+- 用途：Discord 机器人管理页。
 
 ---
 
-## 机器人生命周期
+## 生命周期
 
 ### POST /api/parts/shells:discordbot/start
-- Body：botname
-- 用途：启动指定 Discord 机器人。
+- Body：`botname`
+- 用途：启动指定机器人。
 
 ### POST /api/parts/shells:discordbot/stop
-- Body：botname
-- 用途：停止指定 Discord 机器人。
+- Body：`botname`
+- 用途：停止指定机器人。
 
 ### GET /api/parts/shells:discordbot/getbotlist
-- 用途：获取当前用户所有 Discord 机器人配置名称列表。
+- 用途：全部机器人配置名列表。
 
 ### GET /api/parts/shells:discordbot/getrunningbotlist
-- 用途：获取当前正在运行的 Discord 机器人名称列表。
+- 用途：正在运行的机器人名列表。
 
 ---
 
 ## 配置
 
 ### GET /api/parts/shells:discordbot/getbotconfig
-- 查询：botname
-- 用途：获取指定机器人的配置。
+- 查询：`botname`
+- 用途：读取指定配置。
 
 ### GET /api/parts/shells:discordbot/getbotConfigTemplate
-- 查询：charname（可选，用于基于角色的模板）
-- 用途：获取机器人配置模板。
+- 查询：`charname`（可选）
+- 用途：配置模板；可按角色预填。
 
 ### POST /api/parts/shells:discordbot/setbotconfig
-- Body：botname, config
-- 用途：保存指定机器人的配置。
+- Body：`botname`、`config`
+- 用途：保存配置。
 
 ### POST /api/parts/shells:discordbot/deletebotconfig
-- Body：botname
-- 用途：删除指定机器人配置（若在运行会先停止）。
+- Body：`botname`
+- 用途：删除配置（若在运行会先停止）。
 
 ### POST /api/parts/shells:discordbot/newbotconfig
-- Body：JSON。`botname`（字符串，必填），新机器人配置名称。
-- 用途：创建新的空机器人配置。
+- Body：`botname`（必填）
+- 用途：新建空配置。

--- a/src/public/parts/shells/easynew/public/llms.txt
+++ b/src/public/parts/shells/easynew/public/llms.txt
@@ -1,34 +1,36 @@
-# easynew shell 支持的 Web 端点说明
+# easynew shell Web API
 
-本 shell 提供基于模板快速新建 part（角色、世界、persona 等）的功能。
+基于模板快速新建 part（角色、世界、persona 等）。
+
+路径前缀：`/api/parts/shells:easynew`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:easynew/
-- 用途：快速新建 part 页面，提供基于模板的向导式创建界面。支持创建角色、世界、persona 等不同类型的 part，通过模板简化创建流程。
+- 用途：模板向导入口。
 
 ### GET /parts/shells:easynew/parts/easychar
-- 用途：快速创建角色页面，专门用于通过模板创建新角色。
+- 用途：快速创建角色。
 
 ### GET /parts/shells:easynew/parts/easypersona
-- 用途：快速创建 persona 页面，专门用于通过模板创建新 persona。
+- 用途：快速创建 persona。
 
 ### GET /parts/shells:easynew/parts/easyworld
-- 用途：快速创建世界页面，专门用于通过模板创建新世界。
+- 用途：快速创建世界。
 
 ---
 
-## 模板与创建
+## API
 
 ### GET /api/parts/shells:easynew/templates
-- 用途：获取可用的新建模板列表。返回对象，key 为 templateName，用于 template-html 与 create。
+- 用途：可用模板对象（key 为 `templateName`）。
 
 ### GET /api/parts/shells:easynew/template-html
-- 查询：`templateName`（字符串，必填），模板名称，与 templates 返回的 key 一致。
-- 用途：获取指定模板的 HTML 表单内容，用于前端渲染新建向导。
+- 查询：`templateName`（必填）
+- 用途：模板 HTML 表单。
 
 ### POST /api/parts/shells:easynew/create
-- Body：表单或 JSON。`templateName`（字符串，必填）。其余字段由模板的 main.mjs New() 决定，可含表单字段及可选文件（multipart 时通过 req.files 传递）。
-- 用途：根据模板与表单数据创建新 part。返回 `{ message, partName }`。
+- Body：`templateName`（必填）+ 模板字段；multipart 时可带文件
+- 用途：创建 part → `{ message, partName }`。

--- a/src/public/parts/shells/export/public/llms.txt
+++ b/src/public/parts/shells/export/public/llms.txt
@@ -1,30 +1,33 @@
-# export shell 支持的 Web 端点说明
+# export shell Web API
 
-本 shell 提供 part 导出、fount JSON 导出、分享与虚拟文件下载。
+导出 part、生成 fount JSON、创建分享链接与虚拟文件下载。
+
+路径前缀：`/api/parts/shells:export`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:export/
-- 用途：part 导出页面，用于导出指定的 part（角色、世界、插件等）为可下载文件或分享链接。可通过 URL 参数指定 partpath（`?partpath=${path}`）。支持导出为 ZIP/7z 压缩包或 fount JSON 格式。
+- 查询：`partpath`（可选）
+- 用途：导出 / 分享页。
 
 ---
 
-## 导出与分享
+## API
 
 ### GET /api/parts/shells:export/export
-- 查询：`partpath`（字符串，必填），如 `chars/my-char`。`withData`（可选，字符串 `'true'` 则包含数据）。
-- 用途：导出指定 part 为可下载文件（ZIP 或 7z），直接返回文件流。
+- 查询：`partpath`（必填）、`withData`（可选，`'true'` 含数据）
+- 用途：导出为 ZIP/7z 文件流。
 
 ### GET /api/parts/shells:export/fountjson
-- 查询：`partpath`（字符串，必填）。
-- 用途：获取指定 part 的 fount 原生 JSON 表示。
+- 查询：`partpath`（必填）
+- 用途：fount 原生 JSON 表示。
 
 ### POST /api/parts/shells:export/share
-- Body：JSON。`partpath`（字符串，必填）。`expiration`、`withData` 可选，由实现决定。
-- 用途：创建分享链接，返回 `{ link }`。
+- Body：`partpath`（必填）；`expiration`、`withData` 可选
+- 用途：创建分享链接 → `{ link }`。
 
 ### GET /virtual_files/parts/shells:export/download/*partpath
-- 路径：*partpath 为导出产物路径（如 part 路径或分享 ID）。查询：`withData`（可选，同 export）。
-- 用途：下载已导出的虚拟文件或分享包，返回文件流。
+- 查询：`withData`（可选）
+- 用途：下载已导出虚拟文件或分享包。

--- a/src/public/parts/shells/home/public/llms.txt
+++ b/src/public/parts/shells/home/public/llms.txt
@@ -1,22 +1,18 @@
-# home shell 支持的 Web 端点说明
+# home shell Web API
 
-本 shell 提供首页/仪表盘入口，仅有一个 API 用于获取首页注册表（按钮与 part 入口等）。
+本 shell 是 fount 主首页：聚合各 shell 功能按钮与 part 入口。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:home/
-- 用途：fount 主首页/仪表盘页面，提供所有 part（角色、世界、插件等）的浏览和管理入口。显示各 shell 的功能按钮和 part 类型界面，是用户的主要导航中心。
+- 用途：主首页 / 仪表盘。
 
 ---
 
-## 首页注册表
+## API
 
 ### GET /api/parts/shells:home/gethomeregistry
-- 用途：获取首页注册表，包含各 shell 的入口按钮与 part 界面配置，用于渲染首页。
-- 实现：服务端从各 part 的 `fount.json` → `registries.home_*` 聚合（`home_function_buttons`、`home_drag_in_handlers`、`home_drag_out_generators`、`home_interfaces`），读取各条目的 `path` JSON 后合并返回。
-
-### GET /api/registries/:name（底层）
 - 认证：需要
-- 用途：泛型 registry 聚合端点；home 相关 name 见上。条目为 `{ id, level, path }`（`path` 为前端 URL）。
+- 用途：首页注册表（`home_function_buttons`、`home_drag_in_handlers`、`home_drag_out_generators`、`home_interfaces` 等聚合结果），用于渲染首页。底层泛型聚合见 `GET /api/registries/:name`。

--- a/src/public/parts/shells/ideIntegration/public/llms.txt
+++ b/src/public/parts/shells/ideIntegration/public/llms.txt
@@ -1,13 +1,18 @@
-# ideIntegration shell 支持的 Web 端点说明
+# ideIntegration shell Web API
 
-本 shell 提供 IDE 集成相关的前端界面，无独立对外文档的 HTTP 或 WebSocket API 端点。
-通过 /parts/shells:ideIntegration/ 访问前端；与 IDE 的交互由该 shell 内部或 IPC 处理。
+本 shell 提供 IDE 集成前端，以及与 Agent Client Protocol（ACP）通信的 WebSocket。无额外 REST HTTP API。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:ideIntegration/
-- 用途：IDE 集成页面，用于配置和管理与 IDE（集成开发环境）的集成功能。支持设置 IDE 连接、查看集成状态、管理集成配置等功能。
+- 用途：IDE 集成配置与状态页。
 
 ---
+
+## WebSocket
+
+### GET /ws/parts/shells:ideIntegration/acp
+- 认证：需要
+- 用途：ACP 会话通道，供 IDE / 客户端与 fount 交换 agent 协议消息。

--- a/src/public/parts/shells/install/public/llms.txt
+++ b/src/public/parts/shells/install/public/llms.txt
@@ -1,29 +1,32 @@
-# install shell 支持的 Web 端点说明
+# install shell Web API
 
-本 shell 提供 part 安装、从文件/文本导入以及卸载功能。
+从文件或文本安装 / 导入 part，以及卸载。
+
+路径前缀：`/api/parts/shells:install`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:install/
-- 用途：part 安装页面，用于通过文件上传或文本粘贴的方式安装/导入 part（角色、世界、插件等）。支持多种格式（角色卡、Risu、SillyTavern 等）。
+- 用途：安装 / 导入页（文件上传或文本粘贴）。
 
 ### GET /parts/shells:install/uninstall
-- 用途：part 卸载页面，用于卸载指定的 part。可通过 URL 参数指定 partpath（`?partpath=${path}`）。
+- 查询：`partpath`（可选）
+- 用途：卸载页。
 
 ---
 
-## 安装与导入
+## API
 
 ### POST /api/parts/shells:install/file
-- Body：multipart 表单，包含要导入的文件（如角色卡、压缩包等）。服务端从 req.files 读取文件数据。
-- 用途：通过上传文件安装或导入 part（支持 chars、Risu/SillyTavern 等格式）。
+- Body：multipart 文件（角色卡、压缩包等）
+- 用途：按文件安装 / 导入。
 
 ### POST /api/parts/shells:install/text
-- Body：JSON。`text`（字符串，必填），粘贴的文本内容。类型/目标 part 由服务端根据内容解析。
-- 用途：通过粘贴文本安装或导入 part。
+- Body：`text`（必填）
+- 用途：按文本内容安装 / 导入（类型由服务端解析）。
 
 ### POST /api/parts/shells:install/uninstall
-- Body：JSON。`partpath`（字符串，必填），如 `chars/my-char`。路径中冒号会规范化为斜杠。
+- Body：`partpath`（必填；冒号规范化为 `/`）
 - 用途：卸载指定 part。

--- a/src/public/parts/shells/languageSettings/public/llms.txt
+++ b/src/public/parts/shells/languageSettings/public/llms.txt
@@ -2,7 +2,5 @@
 
 界面语言设置前端页，无独立 shell HTTP / WebSocket API。语言数据用基础 API `/api/getlocaledata`、`/api/getavailablelocales`。
 
-**指引**：切换界面语言在前端执行 `/scripts/i18n/index.mjs` 的 `setLanguage(['ja-JP'])`（写入 preferredLangs 并重载文案）。只读某语种 JSON 用 `loadLocaleData(['zh-CN'])`。
-
 ### GET /parts/shells:languageSettings/
 - 用途：语言偏好设置页。

--- a/src/public/parts/shells/languageSettings/public/llms.txt
+++ b/src/public/parts/shells/languageSettings/public/llms.txt
@@ -1,15 +1,8 @@
-# languageSettings shell 支持的 Web 端点说明
+# languageSettings shell
 
-本 shell 仅提供语言/国际化设置的前端页面，无独立 HTTP 或 WebSocket API 端点。
-语言数据通过基础 API /api/getlocaledata、/api/getavailablelocales 等获取；本 shell 通过 /parts/shells:languageSettings/ 提供设置界面。
+界面语言设置前端页，无独立 shell HTTP / WebSocket API。语言数据用基础 API `/api/getlocaledata`、`/api/getavailablelocales`。
 
-若用户希望 AI 协助「切换界面语言」：语言偏好由前端保存与应用，无专用服务端 API。在前端执行 `/scripts/i18n/index.mjs` 的 `setLanguage(['ja-JP'])`（写 preferredLangs 并立刻重载文案）。只读某语种 JSON 用 `loadLocaleData(['zh-CN'])`。
-
----
-
-## 提供的页面
+**指引**：切换界面语言在前端执行 `/scripts/i18n/index.mjs` 的 `setLanguage(['ja-JP'])`（写入 preferredLangs 并重载文案）。只读某语种 JSON 用 `loadLocaleData(['zh-CN'])`。
 
 ### GET /parts/shells:languageSettings/
-- 用途：语言设置页面，用于设置界面语言偏好。支持选择首选语言列表、查看可用语言、预览语言效果等功能。
-
----
+- 用途：语言偏好设置页。

--- a/src/public/parts/shells/proxy/public/llms.txt
+++ b/src/public/parts/shells/proxy/public/llms.txt
@@ -1,34 +1,33 @@
-# proxy shell 支持的 Web 端点说明
+# proxy shell Web API
 
-本 shell 提供兼容 OpenAI API 的代理，供外部客户端调用 fount 的 AI 模型（serviceSources/AI）。
-基础路径：/api/parts/shells:proxy/calling/openai。
+OpenAI 兼容代理，供外部客户端调用本机 `serviceSources/AI`。
+
+基础路径：`/api/parts/shells:proxy/calling/openai`。均需登录（或按代理约定的鉴权）。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:proxy/
-- 用途：代理服务管理页面，用于查看和管理 OpenAI 兼容 API 代理服务。显示可用的 AI 模型列表、API 密钥管理、代理配置等信息，便于外部客户端通过标准 OpenAI API 调用 fount 的 AI 模型。
+- 用途：代理说明与管理页。
 
 ---
 
-## 模型与补全
+## API
 
 ### GET /api/parts/shells:proxy/calling/openai/v1/models
-- 用途：获取可用模型列表（对应当前用户已加载的 serviceSources/AI）。
+- 用途：可用模型列表。
 
 ### POST /api/parts/shells:proxy/calling/openai/v1/completions
-- Body：OpenAI 兼容的 completions 请求（model、prompt 等）
+- Body：OpenAI completions（`model`、`prompt` 等）
 - 用途：文本补全。
 
 ### POST /api/parts/shells:proxy/calling/openai/models/:modelname/v1/completions
-- Body：同上，model 可由路径参数指定
-- 用途：文本补全（路径指定模型）。
+- 用途：同上，模型由路径指定。
 
 ### POST /api/parts/shells:proxy/calling/openai/v1/chat/completions
-- Body：OpenAI 兼容的 chat completions 请求（model、messages 等）
+- Body：OpenAI chat completions（`model`、`messages` 等）
 - 用途：聊天补全。
 
 ### POST /api/parts/shells:proxy/calling/openai/models/:modelname/v1/chat/completions
-- Body：同上，model 可由路径参数指定
-- 用途：聊天补全（路径指定模型）。
+- 用途：同上，模型由路径指定。

--- a/src/public/parts/shells/serviceSourceManage/public/llms.txt
+++ b/src/public/parts/shells/serviceSourceManage/public/llms.txt
@@ -1,50 +1,48 @@
-# serviceSourceManage shell 支持的 Web 端点说明
+# serviceSourceManage shell Web API
 
-本 shell 管理 服务源（serviceSources）类型的 part：列表、详情、增删改、默认设置及模板/展示。
-路径中的 :type 为 part 类型（如 serviceSources/AI），:name 为 part 名称。
+管理 `serviceSources` 类 part：列表、增删改、默认项、模板与展示。
+
+路径中 `:type` 为子类型（如 `AI`），`:name` 为 part 名。前缀：`/api/parts/shells:serviceSourceManage`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:serviceSourceManage/
-- 用途：服务源管理页面，用于管理 服务源（serviceSources）等类型的 part。支持查看列表、创建/编辑/删除服务源、设置默认服务源、查看模板和展示信息等功能。
+- 用途：服务源管理页。
 
 ---
 
 ## 列表与单资源
 
 ### GET /api/parts/shells:serviceSourceManage/:type
-- 路径：type 如 AI
-- 用途：获取该类型下所有 part 名称列表。
+- 用途：该类型下全部 part 名称列表。
 
 ### GET /api/parts/shells:serviceSourceManage/:type/:name
-- 路径：type, name
-- 用途：获取指定 part 的配置或详情。
+- 用途：指定 part 配置 / 详情。
 
 ### POST /api/parts/shells:serviceSourceManage/:type/:name
 - Body：配置内容
-- 用途：创建或更新指定 part 的配置。
+- 用途：创建或更新。
 
 ### DELETE /api/parts/shells:serviceSourceManage/:type/:name
-- 用途：删除指定 part 配置。
+- 用途：删除。
 
 ### PUT /api/parts/shells:serviceSourceManage/:type/:name/default
-- 用途：将指定 part 设为该类型下的默认项。
+- 用途：设为该类型默认项。
 
 ---
 
 ## 模板与展示
 
 ### GET /api/parts/shells:serviceSourceManage/:type/generators/:generator/template
-- 路径：type, generator（生成器名）
-- 用途：获取该生成器的配置模板。
+- 用途：生成器配置模板。
 
 ### GET /api/parts/shells:serviceSourceManage/:type/generators/:generator/display
-- 用途：获取该生成器的展示信息。
+- 用途：生成器展示信息。
 
 ### GET /api/parts/shells:serviceSourceManage/:type/:name/template
-- 用途：获取指定 part 对应生成器的配置模板。
+- 用途：该 part 对应生成器模板。
 
 ### GET /api/parts/shells:serviceSourceManage/:type/:name/display
-- 用途：获取指定 part 的展示信息（用于 UI 显示）。
+- 用途：该 part 展示信息。

--- a/src/public/parts/shells/shellassist/public/llms.txt
+++ b/src/public/parts/shells/shellassist/public/llms.txt
@@ -1,17 +1,18 @@
-# shellassist shell 支持的 Web 端点说明
+# shellassist shell Web API
 
-本 shell 提供基于终端的辅助界面，主要通过 WebSocket 与后端交互。以下为已注册的 WebSocket 端点。
+终端辅助界面，主要通过 WebSocket 交互。无 REST HTTP API。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:shellassist/
-- 用途：终端辅助界面页面，提供基于 Web 终端的交互式命令行界面。通过 WebSocket 与后端通信，支持执行命令、查看输出、交互式操作等功能，是 fount 的命令行管理工具。
+- 用途：基于 Web 终端的交互式命令行界面。
 
 ---
 
 ## WebSocket
 
 ### GET /ws/parts/shells:shellassist/terminal
-- 用途：连接 shellassist 的终端 WebSocket，用于交互式命令行会话。
+- 认证：需要
+- 用途：交互式终端会话。

--- a/src/public/parts/shells/social/public/llms.txt
+++ b/src/public/parts/shells/social/public/llms.txt
@@ -1,289 +1,182 @@
 # social shell Web API
 
-HTTP 前缀：`/api/parts/shells:social/`。账号与 Chat 联邦 P2P 实体相同（identity/profile 见 `/api/parts/shells:chat/{viewer,entities…}`；网络级仍 `/api/p2p/{network,denylist,federation}`），无需单独注册；后端可 import chat `src/entity/`，前端**不** `loadPart('shells/chat')`。
+social shell 提供信息流（feed）、帖文、社交关系、直播与探索发现。
 
-**统一实体模型**：HTTP 路由恒为 operator 实体 → `getSocialClient(username)`。本机 agent 经进程内 `getSocialClient(username, agentEntityHash)` 自签操作；**无** `actingEntityHash` 参数、无前端身份切换。收藏夹等私有状态存 `shells/social/entities/{entityHash}/…`，人类与 agent 互不可见。
+路径简写：`S` = `/api/parts/shells:social`。所有 HTTP 与 WS 路由都需要登录（`authenticate`）；成功 = 2xx JSON（无 `success` 包装），失败抛 `httpError(code, message)`。
 
-WebSocket：`/ws/parts/shells:social/feed`（推送 feed 更新，客户端收到后刷新首页）。
+---
 
-联邦传输：经用户级 P2P 房间 `fount-node-{nodeHash}` action `part_timeline_put`、`part_invoke` / `part_invoke_response`（npm `@steve02081504/fount-p2p` 的 `transport/user_room`、`trust_graph/*`）。Social RPC 请求/响应 `type` 字符串分离（`SOCIAL_RPC_REQUEST_TYPES` / `SOCIAL_RPC_RESPONSE_TYPES`）。**不**依赖 Chat shell Load 即可 fanout；群 Chat 仍用 `fount-fed-{groupId}` DAG。
+## 重要结论
 
-用户级拉黑/网络：`GET|POST /api/p2p/denylist`、`GET|PUT /api/p2p/network`（`settings/denylist.json`、`settings/network.json`）。
+- **账号与 chat 是同一个联邦实体**，social 不单独注册身份：观看者、实体搜索、翻译偏好、拉黑 / 隐藏名单都调 chat shell 的 API（见「跨 shell」）。
+- HTTP 恒为 operator 实体，没有换身份参数；本机 agent 自签发帖 / 互动走进程内客户端，不经本文件所列 HTTP。
+- 私有状态（收藏夹、草稿）存 `shells/social/entities/{entityHash}/`，人类与 agent 互不可见；HTTP 面固定为 operator。
+- 主人（`ownerEntityHash` 指向自己的实体）改 / 删被管实体的帖：`POST S/posts/:entityHash/:postId/edit` 或 `DELETE S/posts` 带被管实体的 `entityHash`，签名归主人，事件落在被管实体的时间线。
+- 可见性有两层且互不等价：`socialMeta.hideFromDiscovery` 控制探索 / 联邦是否隐藏账号；帖子 `content.visibility` 控制单帖加密与投递范围。
 
 ---
 
 ## 页面
 
+| 路径 / hash | 说明 |
+|------|------|
+| `GET /parts/shells:social/` | 主壳：Feed / 探索 / 通知 / 收藏 / 偏好 / 资料 |
+| `#feed` · `#explore` | 主导航 |
+| `#profile;<entityHash>[;<postId>]` | 资料页 |
+| `#post;<entityHash>;<postId>` | 帖子详情 |
+| `#topic:<tag>` | 话题页 |
+| `#search;<query>` | 搜索（`?q=` 查询参数亦可） |
+| `#live:<entityHash>;<liveId>` | 直播间 |
+
+深链：`fount://run/shells:social/post;<entityHash>;<postId>[;<sharerNodeHash>]`、`…/profile;<entityHash>`、`…/search;<query>`。从 social 跳 chat DM：`/parts/shells:chat/hub/?contact=<entityHash>`。
+
+---
+
+## WebSocket
+
 | 路径 | 说明 |
 |------|------|
-| `GET /parts/shells:social/` | 主壳：Feed / 探索 / 通知 / 收藏 / **偏好** / 资料 |
-| Hash | `#feed` / `#explore` / … 主导航；`#profile;<entityHash>[;<postId>]` 资料；`#post;<entityHash>;<postId>` 帖子详情；`#topic:` / `#search;`·`#search:` / `#live:` 深链（搜索进 `#searchView`） |
+| `/ws/parts/shells:social/feed` | feed 更新与通知推送（`type: 'notification'`） |
+| `/ws/parts/shells:social/live/:entityHash/:liveId` | 弹幕 / 点赞：客户端发 `{ type: 'danmaku', text }` 或 `{ type: 'like' }`；服务端广播 `danmaku`、`like`、`viewer_count`、`like_count`、`link_*`。联邦观看可带 `?proxy=1&bridgeOrigin=&watchSecret=` |
+| `/ws/parts/shells:social/live-av/:entityHash/:liveId` | 音视频帧（复用 chat avRelay，WebCodecs 二进制帧），同样支持 proxy 查询串 |
+| `/ws/parts/shells:social/live-bridge/:entityHash/:liveId?token=` | 节点间连线 / 公开观看代理；`token` = HMAC(`linkSecret` 或 `publicWatchSecret`) |
 
 ---
 
-## Feed 与探索
-
-### `GET /api/parts/shells:social/posts/:entityHash/:postId`
-单帖 feed item。响应：`{ item }`；不可见或不存在 → 404。
-
-### `GET /api/parts/shells:social/feed`
-Query：`limit`（默认 50，最大 200）、`cursor`（分页游标）、`ranking`（`latest` 默认｜`for_you` 本地启发式，含关注者 like/repost 挖出的二度公开帖）。
-
-响应：`{ items[], nextCursor }`。repost 条目外层 `postId` 为 repost 事件 id；`targetEntityHash`/`targetPostId` 指向原帖。解密失败时 `post.content` 为 null 且 `post.decryptView: { failed: true }`。`for_you` 条目可带 `score`。
-
-### `POST /api/parts/shells:social/feed/sync`
-显式同步关注时间线（联邦 mailbox / pull）。响应：`{ synced: true }`。
-
-### `GET /api/parts/shells:social/hashtags/trending`
-Query：`limit`（默认 12，最大 32）、`scope`（`local` 默认｜`nearby` 经 `part_query` kind `trending_hashtags` 聚合邻居公开话题计数）。响应：`{ tags: [{ tag, count }], scope }`。
-
-### `GET|PUT /api/parts/shells:social/profile/muted-keywords`
-本地关键词/标签屏蔽表（不联邦）。`PUT` body：`{ entries: [{ pattern, matchTags?, expiresAt? }] }`。命中正文、contentWarning 或 tags 的帖从 feed/explore/search/通知中隐藏。
-
-### `POST /api/parts/shells:social/signals/dwell`
-本地隐私停留信号（不联邦）。Body：`{ entries: [{ author, postId, tags?, dwellMs, at? }] }`（`dwellMs ≥ 3s`）。用于 `for_you` 作者亲和弱加权（每条 +0.25）与 taste 标签弱证据（每条 tag +0.15）。
-
-### `GET|POST /api/parts/shells:social/posts/:entityHash/:postId/notes`
-社区补充（Community Notes）：`POST` body `{ text }` → 调用者时间线 `post_note` 事件；`GET` 返回 `{ notes[], topNote }`（净 helpful 分 > 0 的最高分附在 feed `communityNote.topNote`）。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/notes/:noteEventId/vote`
-Body：`{ helpful: boolean }` → `note_vote`。通知类型含 `post_note`。
-
-### `GET /api/parts/shells:social/search`
-Query：`q`（≥2 或配合过滤器）、`limit`、`cursor?`、`author?`、`media=image|video`、`tag?`、`sort=latest|top`、`scope=local|nearby`、`before?`/`after?`（毫秒）。
-
-本地：观看者已知时间线倒排 + 扫描回退。`scope=nearby`：`part_query` kind `post_search` 聚合邻居公开帖摘录（入站清洗）。响应：`{ query, items[], nextCursor?, filters?, scope }`。
-
-### `POST /api/parts/shells:social/topics/follow`
-Body：`{ tag, follow?: boolean }` → 时间线 `tag_follow`/`tag_unfollow`。响应：`{ tag, isFollowing, tags[] }`。
-
-### `GET /api/parts/shells:social/topics/followed`
-响应：`{ tags[] }`。
-
-### `GET /api/parts/shells:social/topics/:tag/posts`
-话题帖流（cursor 分页）。响应：`{ tag, items[], nextCursor }`。首页 feed 也会把订阅话题公开帖并入 merge（`via: topic`）。
-
-### `GET /api/parts/shells:social/videos/feed`
-短视频竖屏流（含 video mediaRef 的公开帖，for_you 启发式）。响应：`{ items[], nextCursor }`。
-
-### `POST /api/parts/shells:social/live/start`
-Body：`{ title?, visibility?, groupId?, channelId?, bridgeOrigin? }`。无 group 时 social 原生 `avRoomId=social:{entityHash}:{liveId}`；有则挂载 chat streaming。写 `live_start`，**同步发 `post`（`content.liveRef`）**，通知关注者 `live_started`。公开场生成 `publicWatchSecret` 供大厅多跳观看代理。
-
-### `POST /api/parts/shells:social/live/stop`
-Body：`{ liveId }` → `live_end` + 对开播帖 `post_edit` 附 `liveStats`（时长 / 观看 / 点赞）。
-
-### `GET /api/parts/shells:social/live/feed`
-Query：`limit`、`cursor?`、`scope=local|nearby`。在播列表；`nearby` 经 `part_query` kind=`live_feed` 多跳。条目可含 `bridgeOrigin`、`watchSecret`（公开）。
-
-### `POST /api/parts/shells:social/live/:liveId/link/invite`
-Body：`{ peerEntityHash, peerLiveId, bridgeOrigin? }`。双方均在播时经 `live_link_invite` RPC 互连；同节点桥接 AV+弹幕/点赞，跨节点走 `live-bridge` WS。
-
-### `POST /api/parts/shells:social/live/:liveId/link/stop`
-断开连线。
-
-### WS `/ws/parts/shells:social/live/:entityHash/:liveId`
-弹幕/点赞信令：客户端发 `{ type:'danmaku', text }` / `{ type:'like' }`；服务端广播 `danmaku` / `like` / `viewer_count` / `like_count` / `link_*`。联邦直播可加 `?proxy=1&bridgeOrigin=&watchSecret=`。
-
-### WS `/ws/parts/shells:social/live-av/:entityHash/:liveId`
-复用 chat `avRelay`（WebCodecs 二进制帧）。联邦可同样带 proxy 查询串；本节点代理连主播 `live-bridge`。
-
-### WS `/ws/parts/shells:social/live-bridge/:entityHash/:liveId?token=`
-节点间连线 / 公开观看代理；`token` = HMAC(`linkSecret`|`publicWatchSecret`)。
-
-### `GET /api/parts/shells:social/posts/scheduled` / `DELETE …/posts/scheduled/:scheduledId`
-定时发帖队列。`POST /posts` 带未来 `publishAt`（毫秒）则入队而非即时 commit。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/feature-reply`
-Body：`{ replierEntityHash, replyPostId, feature?: boolean }` → `reply_feature`/`reply_unfeature`。
-
-发帖 body 扩展：`replyPolicy`（`everyone`|`followers_7d`|`author_follows`）、`replyDisplay`（`all`|`featured_only`）、`publishAt`。
-
-### `GET /api/parts/shells:chat/entities/search`
-Query：`q`（≥2）、`limit`（默认 20）。经 chat `part_query`（`kind=entity_search`）多跳搜实体。Social 前端搜索页用户段改调此路由。
-
-### `GET /api/parts/shells:social/explore`
-Query：`limit`。账户发现（本地 + 邻居 RPC 合并）。
-
-### `GET /api/parts/shells:social/explore/posts`
-Query：`limit`、`mediaOnly=true`。帖子发现。
-
-### `GET /api/parts/shells:social/notifications`
-Query：`limit`（默认 30，最大 100）、`cursor`（分页游标）、`types`（可选，逗号分隔）。
-
-响应：`{ notifications[], nextCursor, unreadCount, viewerEntityHash }`。读取层按目标聚合高频互动（like/repost 按目标帖、follow 按 24h 窗口）；`unreadCount` 为聚合卡片未读数。
-
-每条字段：`{ type, actorEntityHash, postId, targetPostId, at }` 必填；可选 `targetEntityHash`, `snippet`, `actors[]`, `actorCount`, `latestActorEntityHash`, `aggregateKey`。类型：`reply` | `mention` | `like` | `repost` | `follow` | `care_post` | `poll_closed` | `post_note` | `live_started`。
-
-### `POST /api/parts/shells:social/translate`
-Body：`{ text, targetLang }` — 帖子翻译（缓存于用户侧）。
-
-### `GET/PUT /api/parts/shells:chat/translation-prefs`
-`{ prefs: { autoTranslate, targetLocale?, excludeLocales? } }`。存 `shells/chat/entities/{hash}/translationPreferences.json`；Social 偏好页改调此路由。
-
-### `GET /api/parts/shells:social/mentions/suggest`
-Query：`q`、`limit`。返回 `{ suggestions: [{ entityHash, displayName, kind }] }`（self / following / agent）。
-
----
-
-## 资料（只读）
-
-### `GET /api/parts/shells:chat/viewer`
-当前观看者 `viewerEntityHash` 与 `profile` 摘要。Social 前端 bootstrap 改调此路由。
-
-### `POST /api/parts/shells:social/profile/meta`
-Body：`hideFromDiscovery?` — 追加 `social_meta` 事件更新探索可见性。
-
-### `GET /api/parts/shells:social/profile/:entityHash`
-资料、`postCount`、`followingCount`、`followerCount`（本 replica 已知粉丝投影）、`isFollowing`、`socialMeta`（不含拉黑名单）。
-
-### `GET /api/parts/shells:social/profile/:entityHash/posts`
-物化帖子列表（与首页 feed 同构的 `items[]`）。
-
-### `GET /api/parts/shells:social/profile/:entityHash/likes`
-该 entity 点赞过的帖子列表。
-
-### `GET /api/parts/shells:social/profile/:entityHash/following`
-关注列表。响应：`{ following: [{ entityHash, profile }] }`（不含隐式自关注；`profile` 为作者摘要）。
-
-### `GET /api/parts/shells:social/profile/:entityHash/followers`
-已知粉丝列表（本地关注 + 已同步远程时间线投影）。响应：`{ followers: [{ entityHash, profile }] }`。
-
-### `GET /api/parts/shells:social/profile/:entityHash/replies/:postId`
-帖下回复。响应：`{ replies[] }`，每条为完整 feed item（含 `authorProfile`、互动计数、`featured`）。
-
-### `GET /api/parts/shells:social/profile/:entityHash/replies/:postId`
-跨已知时间线的回复聚合。
-
-### `GET /api/parts/shells:chat/personal-lists`
-返回 `{ entries: [{ scope, value, kind: 'block'|'hide' }] }`。Social 拉黑/隐藏列表 UI 改调此路由。
-
----
-
-## 帖文写操作
-
-### `POST /api/parts/shells:social/posts`
-Body：`text`、`visibility`（`public`|`unlisted`|`followers`|`followers_7d`|`followers_30d`|`followers_since`|`selected`|`private`）、`minFollowMs?`、`allow?`、`except?`、`albumIds?`、`locale`、`mediaRefs[]`、`replyTo`、`quoteRef`、`groupRef`、`contentWarning?`、`sensitiveMedia?`、`poll?`、`tags?`、`replyPolicy?`、`replyDisplay?`、`publishAt?`（未来毫秒 → 定时队列）、`entityHash?`、`charPartName?`。
-定时成功响应：`{ scheduled: true, scheduledId, publishAt }`；即时发布：`{ event }`。
-可见性：`followers*`=GSH；`selected`/`private`=pkw 按接收者包裹；`unlisted`明文可读但不进发现面；`except`仅过滤层。入册时帖密级派生为所选相册最公开档位。
-
-### 相册（帖子链接合集）
-
-- `GET /albums` / `GET /albums/:entityHash` → `{ albums }`（含虚拟 `default`）
-- `GET /albums/:entityHash/:albumId` → `{ album, items }`（成员帖 feed item）
-- `POST /albums` Body：`name`、`description?`、可见性字段
-- `POST /albums/:albumId/update`、`DELETE /albums/:albumId?deletePosts=0|1`
-- `POST /albums/:albumId/posts` Body：`postId`；`DELETE /albums/:albumId/posts/:postId`
-- `POST /albums/move-post` Body：`postId`、`fromAlbumId?`、`toAlbumId`
-
-### `DELETE /api/parts/shells:social/posts`
-Body：`postId`、`entityHash?`（缺省 = operator；可删自有帖或 `ownerEntityHash` 为自己的 agent 帖）。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/edit`
-Body：`text?`、`mediaRefs?`、`locale?`、`contentWarning?` — 追加 `post_edit`；物化 `revisions[]`。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/poll-vote`
-Body：`choices`（选项下标数组） — 追加 `poll_vote`。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/like`
-Body：`like?`（默认 true）。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/dislike`
-Body：`dislike?`（默认 true）。与 like 互斥；reducer 写入时清对立反应。
-
-### `POST /api/parts/shells:social/posts/:entityHash/:postId/repost`
-Body：`comment?`。响应：成功物化可渲染 feed 条目时为 `{ event, item }`（并 `pushFeedUpdate`）；物化失败时仅 `{ event }`。
-
----
-
-## 口味偏好（taste）
-
-### `GET /api/parts/shells:social/taste`
-Query：`locale?`（默认 `zh-CN`）。响应：`{ privacy, clusteredAt, aliases, tags: [{ tagHash, weight, label }] }`。
-
-### `PUT /api/parts/shells:social/taste`
-Body：`privacy?`（`{ publishPreferences, publishReactions }`，默认皆 true）、`tags?`（`Record<tagHash, weight>` 写入 **manual** 覆盖，0 删除）。响应：`{ privacy, computed, manual, aliases, tagCount? }`。
-关闭 `publishPreferences`：不共享标签命名与合并声明。关闭 `publishReactions`：like/dislike 不 fanout、不进 `reaction_index`、联邦 pull 不导出。
-
-### `POST /api/parts/shells:social/taste/rebuild`
-从 like/dislike 反应图重建本地 `computed` 权重（manual 不动），顺带懒验证合并收件箱与本地发现 gossip。响应：`{ clusteredAt, tagCount }`。
-
-### `POST /api/parts/shells:social/taste/names`
-Body：`{ tagHash, label, locale? }` — 写入签名时间线事件 `tag_name`（受 `publishPreferences` 控制 fanout）。响应：`{ event }`。
-
-### `DELETE /api/parts/shells:social/taste/aliases/:fromTag`
-撤销软别名。响应：`{ aliases }`。
-
-SocialClient：`client.taste.get|update|rebuild|setName|revokeAlias`（与上同构）。
-
-联邦 RPC：`social_reaction_pull_request` → `{ type: 'social_reaction_pull_response', targetEntityHash, postId, events[] }`（签名 like/dislike 事件分页，`afterReactor` 游标；`postId`/`targetEntityHash` 须合法 hex）；`social_tag_merge_claim`（声明入有界收件箱，本地验证后软别名）。标签命名走时间线 `tag_name`，无独立命名 RPC。
-
----
-
-## 关系写操作
-
-### `POST /api/parts/shells:social/relationships/follow`
-Body：`entityHash`、`follow?`（默认 true）。响应：`{ entityHash, isFollowing }`。
-
-### `POST /api/parts/shells:social/relationships/block`
-Body：`entityHash`、`block?`。写入公开联邦 `block`/`unblock` 时间线事件。
-
-### `POST /api/parts/shells:social/relationships/hide`
-Body：`entityHash`、`hide?`。纯本地 `personal_hide.json`，不联邦。
-
-### `POST /api/parts/shells:social/relationships/mute`
-Body：`entityHash`、`mute?`。纯本地 `personal_mute.json`，不联邦；过滤 feed 并压制来自该作者的通知。
-
-### `POST /api/parts/shells:social/relationships/follow-approve`
-Body：`followerPubKeyHex` — 为关注者签发 GSH vault H（解密 followers 帖；**不是** locked-account 审批关注队列）。
-
----
-
-## 收藏 / 文件
+## Feed、探索与搜索
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
-| GET | `/saved-posts` | operator 收藏 `{ folders, unfiled }`；含 `preview`、`authorName`（`entities/{entityHash}/savedPosts.json`） |
-| GET | `/saved-posts/search?q=&limit=` | 在收藏夹内搜索正文/作者；`{ query, posts[] }` |
-| POST | `/saved-posts/add` | body: `{ entityHash, postId, folderId? }`（帖作者 entityHash，非换身份） |
-| POST | `/saved-posts/remove` | body: `{ entityHash, postId, folderId? }` |
-| POST | `/saved-posts/folders` | body: `{ name }` |
-| POST | `/saved-posts/folders/rename` | body: `{ folderId, name }` |
-| POST | `/saved-posts/folders/delete` | body: `{ folderId }` |
-| GET | `/drafts` | operator 草稿箱 `{ drafts[] }`（`entities/{entityHash}/drafts.json`；含 `preview`） |
-| GET | `/drafts/:draftId` | 单条草稿（完整 `body`） |
-| POST | `/drafts` | 创建/更新草稿；body 同发帖字段，可选 `draftId` 更新 |
-| DELETE | `/drafts/:draftId` | 删除草稿，返回更新后列表 |
-| POST | `/files` | 注册 vault 文件并写入 `file_share` 事件 |
-| GET | `/files/:shareId?owner=` | 文件元数据 |
+| GET | `S/feed?limit=&cursor=&ranking=` | `limit` 默认 50 / 上限 200；`ranking` = `latest`（默认）或 `for_you`。响应 `{ items[], nextCursor }`。repost 条目外层 `postId` 是 repost 事件 id，`targetEntityHash` / `targetPostId` 指原帖；解密失败时 `post.content` 为 null 且 `post.decryptView.failed` |
+| POST | `S/feed/sync` | 显式同步关注时间线（联邦 mailbox / pull） |
+| GET | `S/explore?limit=` | 账户发现（本地 + 邻居 RPC 合并） |
+| GET | `S/explore/posts?limit=&mediaOnly=` | 帖子发现 |
+| GET | `S/search?q=&limit=&cursor=&author=&media=&tag=&sort=&scope=&before=&after=` | `q` ≥2 或配合过滤器；`media` = `image｜video`，`sort` = `latest｜top`，`scope` = `local｜nearby`（nearby 聚合邻居公开帖，入站清洗）。响应 `{ query, items[], nextCursor?, filters?, scope }` |
+| GET | `S/hashtags/trending?limit=&scope=` | `limit` 默认 12 / 上限 32；`scope` = `local`（默认）或 `nearby` → `{ tags: [{ tag, count }], scope }` |
+| GET | `S/mentions/suggest?q=&limit=` | `{ suggestions: [{ entityHash, displayName, kind }] }`（self / following / agent） |
+| POST | `S/signals/dwell` | 本地停留信号（不联邦），body `{ entries: [{ author, postId, tags?, dwellMs, at? }] }`（`dwellMs` ≥ 3000） |
+| GET / PUT | `S/profile/muted-keywords` | 本地关键词 / 标签屏蔽（不联邦）；PUT body `{ entries: [{ pattern, matchTags?, expiresAt? }] }` |
+| GET | `S/videos/feed?limit=&cursor=` | 短视频竖屏流（含 video 媒体的公开帖） |
+| GET | `S/topics/followed` | 已订阅话题 `{ tags[] }` |
+| POST | `S/topics/follow` | body `{ tag, follow?: boolean }` → `{ tag, isFollowing, tags[] }` |
+| GET | `S/topics/:tag/posts?cursor=` | 话题帖流 `{ tag, items[], nextCursor }` |
 
 ---
 
-## 时间线事件类型
+## 帖文
 
-写入 `shells/social/timelines/<entityHash>/events.jsonl`：`social_meta`、`state_summary`、`post`、`post_edit`、`post_delete`、`poll_vote`、`like`、`unlike`、`dislike`、`undislike`、`repost`、`follow`、`unfollow`、`follow_approve`、`block`、`unblock`、`file_share`、`entity_key_rotate`、`entity_key_revoke`。`poll_closed` 为 inbox 通知类型（非 timeline 事件）。`suspect`/`unsuspect` 为**保留类型名**（无 reducer、无写入 API、不可物化）。
-
-逐帖反应投影：`shells/social/reaction_index/<author>/<postId>.json`（reactor → 签名 like/dislike 事件；联邦 `social_reaction_pull_request` 分页拉取）。
-
-时间线事件使用 `charPartName`（本地 agent 目录名）。`social_meta.hideFromDiscovery` 控制探索/联邦隐藏；`content.visibility` 见上文（GSH / pkw）。相册为帖链接合集；feed item 可带 `albums[]`。Feed 解密失败时 `post.content` 为 null 且 `post.decryptView: { failed: true }`。
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `S/posts/:entityHash/:postId` | 单帖 `{ item }`；不可见或不存在 → 404 |
+| POST | `S/posts` | body：`text`、`visibility`（`public｜unlisted｜followers｜followers_7d｜followers_30d｜followers_since｜selected｜private`）、`minFollowMs?`、`allow?`、`except?`、`albumIds?`、`locale`、`mediaRefs[]`、`replyTo`、`quoteRef`、`groupRef`、`contentWarning?`、`sensitiveMedia?`、`poll?`、`tags?`、`replyPolicy?`（`everyone｜followers_7d｜author_follows`）、`replyDisplay?`（`all｜featured_only`）、`publishAt?`、`entityHash?`、`charPartName?`。即时发布 → `{ event }`；`publishAt` 在未来 → `{ scheduled: true, scheduledId, publishAt }` |
+| DELETE | `S/posts` | body `{ postId, entityHash? }`（缺省 operator；可删自有帖或所属 agent 的帖） |
+| POST | `S/posts/:entityHash/:postId/edit` | body `text?`、`mediaRefs?`、`locale?`、`contentWarning?` → 追加 `post_edit`，物化 `revisions[]` |
+| POST | `S/posts/:entityHash/:postId/like` · `…/dislike` | body `{ like? }` / `{ dislike? }`（默认 true，传 false 撤销）。两者互斥 |
+| POST | `S/posts/:entityHash/:postId/repost` | body `{ comment? }`；能物化出可渲染条目时返回 `{ event, item }`，否则仅 `{ event }` |
+| POST | `S/posts/:entityHash/:postId/poll-vote` | body `{ choices }`（选项下标数组） |
+| POST | `S/posts/:entityHash/:postId/feature-reply` | body `{ replierEntityHash, replyPostId, feature?: boolean }` |
+| GET / POST | `S/posts/:entityHash/:postId/notes` | 社区补充：POST body `{ text }` 写入调用者时间线；GET → `{ notes[], topNote }` |
+| POST | `S/posts/:entityHash/:postId/notes/:noteEventId/vote` | body `{ helpful: boolean }` |
+| GET | `S/posts/scheduled` | 定时发帖队列 |
+| DELETE | `S/posts/scheduled/:scheduledId` | 取消定时发帖 |
 
 ---
 
-## Agent 集成
+## 资料与关系
 
-新帖入账（本地 commit 或联邦 ingest）统一经 `dispatchSocialMessage`：对本机每个可见托管 agent 调 `interfaces.social.onMessage`（返回 boolean 意愿）；无 `onMessage` 时被 @ 默认意愿 true 并经 `lib/replyViaChat.mjs` → `chat.GetReply` 生成公开回复。operator 特别关心（chat `care` 模块）作者发帖写 `care_post` inbox 行 + `notifyUser`。跨节点 @ 非本机实体走 `social_post_notify` RPC。`OnFollow` 保留（被关注不是消息）。
-
-进程内操作面：`src/api/client/index.mjs` → `getSocialClient(username, entityHash?)`（发帖 / 关系 / feed / 收藏 / vault 等与 HTTP 同构）。owner 改/删所属实体帖：`POST …/edit` 或 `DELETE /posts` 带被管实体的 `entityHash`，主人自签落入 **被管实体时间线**。
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `S/profile/:entityHash` | 资料、`postCount`、`followingCount`、`followerCount`、`isFollowing`、`socialMeta` |
+| POST | `S/profile/meta` | body `{ hideFromDiscovery? }` → 追加 `social_meta` |
+| GET | `S/profile/:entityHash/posts` | 该实体的帖子（与 feed 同构 `items[]`） |
+| GET | `S/profile/:entityHash/likes` | 该实体点赞过的帖子 |
+| GET | `S/profile/:entityHash/following` | `{ following: [{ entityHash, profile }] }`（不含隐式自关注） |
+| GET | `S/profile/:entityHash/followers` | `{ followers: [{ entityHash, profile }] }`（本 replica 已知投影） |
+| GET | `S/profile/:entityHash/replies/:postId` | 帖下回复 `{ replies[] }`，每条是完整 feed item |
+| POST | `S/timeline/:entityHash/maintain` | 时间线维护（压实 / 重建物化） |
+| POST | `S/relationships/follow` | body `{ entityHash, follow? }` → `{ entityHash, isFollowing }` |
+| POST | `S/relationships/block` | body `{ entityHash, block? }`：写公开联邦 `block` / `unblock` 事件 |
+| POST | `S/relationships/hide` | body `{ entityHash, hide? }`：纯本地，不联邦 |
+| POST | `S/relationships/mute` | body `{ entityHash, mute? }`：纯本地，过滤 feed 并压制该作者通知 |
+| POST | `S/relationships/follow-approve` | body `{ followerPubKeyHex }`：为关注者签发解密凭据（不是待审关注队列） |
 
 ---
 
-## 深链
+## 通知与口味偏好
 
-- `fount://run/shells:social/post;<entityHash>;<postId>[;<sharerNodeHash>]`（外部分享优先 `fount://page/parts/shells:social/#post;…`）
-- `fount://run/shells:social/profile;<entityHash>`
-- `fount://run/shells:social/post;<entityHash>;<postId>[;<sharerNodeHash>]`
-- `fount://run/shells:social/search;<query>`（浏览器：`/parts/shells:social/#search;<query>`；`?q=` 查询参数亦可）
-- 分享链可选第 4 段 `sharerNodeHash`：接收方打开帖子时对分享者与作者节点 `POST /api/p2p/federation/connect-node`
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `S/notifications?limit=&cursor=&types=` | `limit` 默认 30 / 上限 100，`types` 逗号分隔。响应 `{ notifications[], nextCursor, unreadCount, viewerEntityHash }`；读取层按目标聚合高频互动（`actors[]`、`actorCount`、`aggregateKey`） |
+| GET / PUT | `S/notifications/seen` | 已读水位 |
+| GET | `S/taste?locale=` | `{ privacy, clusteredAt, aliases, tags: [{ tagHash, weight, label }] }` |
+| PUT | `S/taste` | body `privacy?`（`{ publishPreferences, publishReactions }`，默认皆 true）、`tags?`（`Record<tagHash, weight>` 写 manual 覆盖，0 删除） |
+| POST | `S/taste/rebuild` | 从 like / dislike 反应图重建本地 computed 权重（manual 不动） |
+| POST | `S/taste/names` | body `{ tagHash, label, locale? }` → 签名时间线事件 `tag_name` |
+| DELETE | `S/taste/aliases/:fromTag` | 撤销软别名 → `{ aliases }` |
+| POST | `S/translate` | body `{ text, targetLang }`：帖子翻译（结果缓存在用户侧） |
 
-帖子 Markdown 中 `#话题` 渲染为话题页深链 `#topic:…`（不作用于 Chat `#[group/channel]` 标记）。见 `public/shared/runUri.mjs`、`markdown_ext/index.mjs`。
+关掉 `publishPreferences` 就不共享标签命名与合并声明；关掉 `publishReactions` 则 like / dislike 不 fanout、不进反应索引、联邦 pull 也不导出。
 
-从 Social 跳转 Chat DM：`/parts/shells:chat/hub/?contact=<entityHash>`。
+---
+
+## 收藏、草稿、相册与文件
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `S/saved-posts` | `{ folders, unfiled }`，条目含 `preview`、`authorName` |
+| GET | `S/saved-posts/search?q=&limit=` | 收藏夹内搜正文 / 作者 → `{ query, posts[] }` |
+| POST | `S/saved-posts/add` · `S/saved-posts/remove` | body `{ entityHash, postId, folderId? }`（`entityHash` 是帖作者） |
+| POST | `S/saved-posts/folders` · `…/folders/rename` · `…/folders/delete` | body `{ name }` / `{ folderId, name }` / `{ folderId }` |
+| GET | `S/drafts` · `S/drafts/:draftId` | 草稿列表（含 `preview`）/ 单条完整 body |
+| POST | `S/drafts` | 创建或更新草稿（body 同发帖字段，带 `draftId` 则更新） |
+| DELETE | `S/drafts/:draftId` | 删除草稿并返回更新后列表 |
+| GET | `S/albums` · `S/albums/:entityHash` | 相册列表 `{ albums }`（含虚拟 `default`） |
+| GET | `S/albums/:entityHash/:albumId` | `{ album, items }`（成员帖 feed item） |
+| POST | `S/albums` · `S/albums/:albumId/update` | 创建（`name`、`description?` + 可见性字段）/ 更新 |
+| DELETE | `S/albums/:albumId?deletePosts=0｜1` | 删相册（可选连帖删除） |
+| POST / DELETE | `S/albums/:albumId/posts` · `…/posts/:postId` | 加 / 移出成员帖，body `{ postId }` |
+| POST | `S/albums/move-post` | body `{ postId, fromAlbumId?, toAlbumId }` |
+| POST | `S/files` | 注册 vault 文件并写入 `file_share` 事件 |
+| GET | `S/files/:shareId?owner=` | 文件元数据 |
+
+---
+
+## 直播
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| POST | `S/live/start` | body `{ title?, visibility?, groupId?, channelId?, bridgeOrigin? }`。无 group 时用 social 原生房间 `social:{entityHash}:{liveId}`，有则挂 chat streaming；写 `live_start` 并同步发帖（`content.liveRef`），通知关注者。公开场生成 `publicWatchSecret` 供多跳观看代理 |
+| POST | `S/live/stop` | body `{ liveId }` → `live_end` + 对开播帖追加 `post_edit`（附时长 / 观看 / 点赞统计） |
+| GET | `S/live/feed?limit=&cursor=&scope=` | 在播列表；`scope=nearby` 多跳聚合。条目可含 `bridgeOrigin`、`watchSecret` |
+| GET | `S/live/:entityHash/:liveId` | 单场直播详情 |
+| POST / DELETE | `S/live/:liveId/whip` | WHIP 推流建立 / 断开 |
+| POST | `S/live/:liveId/link/invite` | body `{ peerEntityHash, peerLiveId, bridgeOrigin? }`：双方在播时连线（同节点直接桥接 AV + 弹幕，跨节点走 `live-bridge`） |
+| POST | `S/live/:liveId/link/stop` | 断开连线 |
+
+---
+
+## 表情包（作者包）
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `S/emoji-packs?entityHash=` | 指定实体（缺省 operator）的作者包列表 |
+| GET | `S/emoji-packs/available` | 当前观看者可用的全部包 |
+| GET | `S/emoji-packs/discover?limit=` | 附近作者包报价 |
+| GET | `S/emoji-packs/:entityHash/:packId` | 单个包 manifest |
+| POST | `S/emoji-packs` | 创建包 `{ packId?, localized? }` |
+| PUT / DELETE | `S/emoji-packs/:packId` | 更新 / 删除包 |
+| POST | `S/emoji-packs/:packId/emojis` | 上传表情（multipart 字段 `emoji`） |
+| DELETE | `S/emoji-packs/:packId/emojis/:emojiId` | 删除表情 |
+
+---
+
+## 跨 shell（chat API）
+
+| 方法 | 路径 | 用途 |
+|------|------|------|
+| GET | `/api/parts/shells:chat/viewer` | bootstrap：当前 `viewerEntityHash` 与 profile 摘要 |
+| GET | `/api/parts/shells:chat/entities/search?q=&limit=` | 搜索页用户段：`q` ≥2，多跳搜实体 |
+| GET / PUT | `/api/parts/shells:chat/translation-prefs` | 偏好页翻译设置 `{ prefs: { autoTranslate, targetLocale?, excludeLocales? } }` |
+| GET | `/api/parts/shells:chat/personal-lists` | 拉黑 / 隐藏名单 `{ entries: [{ scope, value, kind }] }` |
+
+用户级网络与拉黑仍在 `/api/p2p/*`（`network`、`denylist`、`federation`）。

--- a/src/public/parts/shells/subfounts/public/llms.txt
+++ b/src/public/parts/shells/subfounts/public/llms.txt
@@ -1,52 +1,56 @@
-# subfounts shell 支持的 Web 端点说明
+# subfounts shell Web API
 
-本 shell 提供子 fount 连接码、连接列表、远程执行与描述管理。
+子 fount 连接码、连接列表、远程执行与 infra 策略。
+
+**指引**：独立客户端未挂主机时默认跑网络 infra；挂上主机后听从「网络基建」开关（开启时优先帮扶本机）。
+
+路径前缀：`/api/parts/shells:subfounts`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:subfounts/
-- 用途：子 fount 管理页面，用于管理子 fount 连接。包括查看连接码、管理连接列表、远程执行脚本/命令、设置连接描述、统一开关下属是否参与网络 infra（开启时优先帮扶本机）等。独立客户端未挂主机时默认跑 infra；挂上主机后听从网页端「网络基建」开关。
+- 用途：子 fount 管理页。
 
 ---
 
 ## 连接码与列表
 
 ### GET /api/parts/shells:subfounts/connection-code
-- 用途：获取当前实例的连接码，供子 fount 或客户端连接。响应 `{ peerId, password, nodeHash }`；`nodeHash` 可传给客户端以直连并优先帮扶主机。
+- 用途：`{ peerId, password, nodeHash }`；`nodeHash` 可供客户端直连并优先帮扶主机。
 
 ### POST /api/parts/shells:subfounts/regenerate-code
-- 用途：重新生成连接码。响应同 connection-code。
+- 用途：重新生成连接码（响应同 connection-code）。
 
 ### GET /api/parts/shells:subfounts/list
-- 用途：获取已配置的子 fount 或连接列表。
+- 用途：已配置连接列表。
 
 ### GET /api/parts/shells:subfounts/connected
-- 用途：获取当前已连接的子 fount/客户端状态。
+- 用途：当前已连接状态。
 
 ### GET /api/parts/shells:subfounts/info
-- 用途：获取 subfounts 相关元信息（含 shell 可用性等）。
+- 用途：元信息（含 shell 可用性等）。
 
 ### GET /api/parts/shells:subfounts/settings
-- 用途：读取下属 infra 策略。响应 `{ infra: boolean }`，默认 `true`。
+- 用途：`{ infra: boolean }`（默认 `true`）。
 
 ### PUT /api/parts/shells:subfounts/settings
-- Body：`{ infra: boolean }`。
-- 用途：统一开关已连接子 fount 是否参与网络 infra（overlay 转发、Mailbox）；开启时优先帮扶本机。立即推送给在线分机。
+- Body：`{ infra: boolean }`
+- 用途：统一开关下属是否参与网络 infra；立即推送给在线分机。
 
 ### POST /api/parts/shells:subfounts/set-description
-- Body：JSON。`deviceId`（字符串，必填），连接的设备 ID（来自 list/connected 等）。`description`（字符串，可选），要设置的描述。
-- 用途：设置某连接的描述信息。
+- Body：`deviceId`（必填）、`description`（可选）
+- 用途：设置连接描述。
 
 ---
 
 ## 远程执行
 
 ### POST /api/parts/shells:subfounts/execute
-- Body：JSON。`subfountId`（必填，子 fount 标识，与 list/connected 中一致）。`script`（字符串，必填），要在子 fount 上执行的 JavaScript 代码。`callbackInfo`（可选），回调信息。
-- 用途：在指定子 fount 上执行脚本，返回 `{ result }`。
+- Body：`subfountId`、`script`（必填）；`callbackInfo`（可选）
+- 用途：在子 fount 执行 JS → `{ result }`。
 
 ### POST /api/parts/shells:subfounts/execute-shell
-- Body：JSON。`subfountId`（必填）。`command`（字符串，必填），要执行的 shell 命令。`shell`（可选），shell 类型。`options`（可选，对象）。
-- 用途：在指定子 fount 上执行 shell 命令（如 runpart），返回 `{ result }`。
+- Body：`subfountId`、`command`（必填）；`shell`、`options`（可选）
+- 用途：在子 fount 执行 shell 命令 → `{ result }`。

--- a/src/public/parts/shells/telegrambot/public/llms.txt
+++ b/src/public/parts/shells/telegrambot/public/llms.txt
@@ -38,8 +38,8 @@
 - 用途：读取指定配置。
 
 ### GET /api/parts/shells:telegrambot/getbotConfigTemplate
-- 查询：`charname`（可选）
-- 用途：配置模板；可按角色预填。
+- 查询：`charname`（必填）
+- 用途：配置模板；按角色预填。
 
 ### POST /api/parts/shells:telegrambot/setbotconfig
 - Body：`botname`、`config`

--- a/src/public/parts/shells/telegrambot/public/llms.txt
+++ b/src/public/parts/shells/telegrambot/public/llms.txt
@@ -1,52 +1,54 @@
-# telegrambot shell 支持的 Web 端点说明
+# telegrambot shell Web API
 
-本 shell 提供 Telegram 机器人的启动、停止与配置管理。
+本 shell 管理 Telegram 机器人：配置 CRUD 与启停。绑定角色后走 `char.interfaces.chat.GetReply`；会话为虚拟桥接群，不建真实 Hub 群。
+
+路径前缀：`/api/parts/shells:telegrambot`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:telegrambot/
-- 用途：Telegram 机器人管理页面，用于创建、配置、启动和停止 Telegram 机器人。支持管理多个机器人配置、查看运行状态、编辑机器人设置等功能。
+- 用途：Telegram 机器人管理页。
 
 ---
 
-## 机器人生命周期
+## 生命周期
 
 ### POST /api/parts/shells:telegrambot/start
-- Body：botname
-- 用途：启动指定 Telegram 机器人。
+- Body：`botname`
+- 用途：启动指定机器人。
 
 ### POST /api/parts/shells:telegrambot/stop
-- Body：botname
-- 用途：停止指定 Telegram 机器人。
+- Body：`botname`
+- 用途：停止指定机器人。
 
 ### GET /api/parts/shells:telegrambot/getbotlist
-- 用途：获取当前用户所有 Telegram 机器人配置名称列表。
+- 用途：全部机器人配置名列表。
 
 ### GET /api/parts/shells:telegrambot/getrunningbotlist
-- 用途：获取当前正在运行的 Telegram 机器人名称列表。
+- 用途：正在运行的机器人名列表。
 
 ---
 
 ## 配置
 
 ### GET /api/parts/shells:telegrambot/getbotconfig
-- 查询：botname
-- 用途：获取指定机器人的配置。
+- 查询：`botname`
+- 用途：读取指定配置。
 
 ### GET /api/parts/shells:telegrambot/getbotConfigTemplate
-- 查询：charname（可选，用于基于角色的模板）
-- 用途：获取机器人配置模板。
+- 查询：`charname`（可选）
+- 用途：配置模板；可按角色预填。
 
 ### POST /api/parts/shells:telegrambot/setbotconfig
-- Body：botname, config
-- 用途：保存指定机器人的配置。
+- Body：`botname`、`config`
+- 用途：保存配置。
 
 ### POST /api/parts/shells:telegrambot/deletebotconfig
-- Body：botname
-- 用途：删除指定机器人配置（若在运行会先停止）。
+- Body：`botname`
+- 用途：删除配置（若在运行会先停止）。
 
 ### POST /api/parts/shells:telegrambot/newbotconfig
-- Body：JSON。`botname`（字符串，必填），新机器人配置名称。
-- 用途：创建新的空机器人配置。
+- Body：`botname`（必填）
+- 用途：新建空配置。

--- a/src/public/parts/shells/themeManage/public/llms.txt
+++ b/src/public/parts/shells/themeManage/public/llms.txt
@@ -1,40 +1,31 @@
-# themeManage shell 支持的 Web 端点说明
+# themeManage shell Web API
 
-本 shell 提供主题的列出、获取、保存与删除。
+本 shell 提供主题的列出、获取、保存与删除。主题数据存服务端，可跨设备同步。
+
+**指引**：切换「当前页面正在用的主题」没有对应 HTTP API，须在前端调用 `/scripts/theme.mjs` 的 `setTheme(theme)`（`'light'` / `'dark'` / `'auto'` 或已保存主题的 `id`/`name`）或 `applyTheme()`。
+
+路径前缀：`/api/parts/shells:themeManage`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:themeManage/
-- 用途：主题管理页面，用于创建、编辑、删除和应用自定义主题。支持预览主题效果、管理主题列表、切换当前页面主题等功能。
+- 用途：主题管理页。
 
 ---
 
-## 原理说明
-
-- **API 能做什么**：主题的列出、获取、保存、删除均通过下述 HTTP 接口完成；主题数据存储在服务端，可跨设备同步。
-- **API 不能做什么**：当前页面的「应用/切换主题」由前端负责，没有对应 API。即：用户希望「把当前看到的界面换成某个主题」时，仅靠调用 themeManage 的 API 无法生效。
-- **若用户希望设置/切换当前页面的主题**：必须在**前端**执行 JavaScript。方式：在已加载 fount 前端的页面中，从共享脚本 `/scripts/theme.mjs` 调用：
-  - `setTheme(theme)`：切换并应用主题。参数 `theme` 为字符串，可为内置值 `'light'`、`'dark'`、`'auto'`，或 themeManage 中保存的自定义主题 ID/名称（与 GET theme/:id 返回的 `id` 或 `name` 一致）。需先通过 themeManage API 或 localStorage 确保该主题已存在。
-  - `applyTheme()`：根据当前存储的 theme 重新应用主题（例如页面加载时或跨标签同步后）。
-  因此，若 AI Agent 需要帮用户「切换当前看到的主题」，应引导用户在前端执行上述 JS（例如通过支持执行前端脚本的 shell，如 browserIntegration 的 runJsOnPage），或让用户打开 themeManage 页面手动选择主题。
-
----
-
-## 主题管理
+## API
 
 ### GET /api/parts/shells:themeManage/list
-- 用途：获取当前用户主题列表。返回主题数组，每项至少含 id、name 等，用于展示或作为 theme/:id 的 id。
+- 用途：主题列表（含 `id`、`name` 等）。
 
 ### GET /api/parts/shells:themeManage/theme/:id
-- 路径：id 为主题 ID（字符串，与 list 中项的 id 一致）。
-- 用途：获取指定主题的完整内容（含 id、name、lastModified 及主题配置等）。保存时可将此结构略作修改后 POST 到 save。
+- 用途：指定主题完整内容（含配置与 `lastModified`）。
 
 ### POST /api/parts/shells:themeManage/save
-- Body：JSON。可选字段 `id`（不传则自动生成）；建议含 `name` 及与 GET theme/:id 返回结构一致的配置对象（如 daisyUI 相关变量等）。服务端会写入 `lastModified`。
-- 用途：保存（新建或更新）主题。返回 `{ id }`。
+- Body：可选 `id`（缺省自动生成）；建议含 `name` 及与 GET 同构的配置。服务端写入 `lastModified`。
+- 用途：新建或更新。返回 `{ id }`。
 
 ### DELETE /api/parts/shells:themeManage/theme/:id
-- 路径：id 为主题 ID。
 - 用途：删除指定主题。

--- a/src/public/parts/shells/tutorial/public/llms.txt
+++ b/src/public/parts/shells/tutorial/public/llms.txt
@@ -1,13 +1,6 @@
-# tutorial shell 支持的 Web 端点说明
+# tutorial shell
 
-本 shell 仅提供静态教程页面，无独立 HTTP 或 WebSocket API 端点。
-通过 /parts/shells:tutorial/ 访问前端界面即可。
-
----
-
-## 提供的页面
+静态教程页，无独立 HTTP 或 WebSocket API。
 
 ### GET /parts/shells:tutorial/
-- 用途：教程页面，提供 fount 系统的使用教程和帮助文档。包含入门指南、功能介绍、使用技巧等内容，帮助用户快速了解和使用 fount。
-
----
+- 用途：使用教程与帮助文档。

--- a/src/public/parts/shells/userSettings/public/llms.txt
+++ b/src/public/parts/shells/userSettings/public/llms.txt
@@ -1,36 +1,72 @@
-# userSettings shell 支持的 Web 端点说明
+# userSettings shell Web API
 
-本 shell 提供用户账户设置：统计、改密、重命名、设备管理、注销账户等。
+本 shell 提供账户设置：统计、改密、重命名、设备与通行密钥、注销，以及本机编辑器命令配置。
+
+路径前缀：`/api/parts/shells:userSettings`。均需登录。
 
 ---
 
-## 提供的页面
+## 页面
 
 ### GET /parts/shells:userSettings/
-- 用途：用户设置页面，用于管理用户账户信息。包括查看统计信息、修改密码、重命名账户、管理已登录设备、注销账户等功能。
+- 用途：用户账户设置页。
 
 ---
 
-## 用户与账户
+## 账户
 
 ### GET /api/parts/shells:userSettings/stats
-- 用途：获取当前用户统计信息。
+- 用途：当前用户统计信息。
 
 ### POST /api/parts/shells:userSettings/change_password
-- Body：JSON。`currentPassword`（字符串，必填）、`newPassword`（字符串，必填）。
-- 用途：修改当前用户密码。
+- Body：`currentPassword`、`newPassword`（均必填）
+- 用途：修改密码。
 
 ### POST /api/parts/shells:userSettings/rename_user
-- Body：JSON。`newUsername`（字符串，必填）、`password`（字符串，必填）。
+- Body：`newUsername`、`password`（均必填）
 - 用途：重命名当前用户。
 
 ### POST /api/parts/shells:userSettings/delete_account
-- Body：JSON。`password`（字符串，必填）。
-- 用途：注销当前用户账户。
+- Body：`password`（必填）
+- 用途：注销账户。
 
 ### GET /api/parts/shells:userSettings/devices
-- 用途：获取当前用户已登录设备列表。返回 `{ devices: [...] }`，每项含 `deviceId`、`jti`、`expiry`、`lastSeen`、`ipAddress`、`userAgent` 等。撤销设备时使用其中的 `jti` 作为 tokenJti。
+- 用途：已登录设备列表 `{ devices: [...] }`（含 `deviceId`、`jti`、`expiry`、`lastSeen`、`ipAddress`、`userAgent` 等）。撤销时用 `jti` 作 `tokenJti`。
 
 ### POST /api/parts/shells:userSettings/revoke_device
-- Body：JSON。`tokenJti`（字符串，必填，来自 GET devices 返回的某设备的 `jti` 字段）、`password`（字符串，必填）。
-- 用途：撤销指定设备的登录会话。
+- Body：`tokenJti`、`password`（均必填）
+- 用途：撤销指定设备会话。
+
+---
+
+## 通行密钥（WebAuthn）
+
+### GET /api/parts/shells:userSettings/webauthn_credentials
+- 用途：已注册通行密钥列表 `{ credentials }`。
+
+### POST /api/parts/shells:userSettings/webauthn_register_begin
+- Body：`password`（必填）
+- 用途：开始注册；返回浏览器 `navigator.credentials.create` 所需选项。
+
+### POST /api/parts/shells:userSettings/webauthn_register_complete
+- Body：`credential`、`password`（必填），`nickname`（可选）
+- 用途：完成注册并保存凭证。
+
+### POST /api/parts/shells:userSettings/webauthn_remove
+- Body：`credentialId`、`password`（均必填）
+- 用途：删除通行密钥。
+
+---
+
+## 本机编辑器
+
+### GET /api/parts/shells:userSettings/editor_command
+- 用途：当前编辑器命令配置 `{ config }`。
+
+### POST /api/parts/shells:userSettings/editor_command
+- Body：`editorId`、`command`、`argsTemplate` 等
+- 用途：保存打开本地文件所用的编辑器命令。
+
+### POST /api/parts/shells:userSettings/open_editor
+- Body：`filePath`（必填），`line`、`column`（可选）
+- 用途：用已配置命令在本机打开文件。

--- a/src/public/parts/shells/wechatbot/public/llms.txt
+++ b/src/public/parts/shells/wechatbot/public/llms.txt
@@ -1,7 +1,68 @@
-# WeChat Bot shell (fount)
+# wechatbot shell Web API
 
-- Part path: `parts/shells:wechatbot`
-- Backend routes: `/api/parts/shells:wechatbot/*` (start, stop, getbotlist, setbotconfig, …)
-- Binds a **fount character** via `char.interfaces.chat.GetReply` (same pattern as `discordbot`).
-- **QR login** (recommended): `POST .../qrcode/start` then poll `GET .../qrcode/poll?sessionKey=` — talks to `https://ilinkai.weixin.qq.com` (no separate gateway process required).
-- Transport: iLink HTTP (`ilink/bot/getupdates`, `ilink/bot/sendmessage`). Default base URL `https://ilinkai.weixin.qq.com` if apiBaseUrl is empty.
+本 shell 管理微信机器人：配置 CRUD、启停，以及 iLink QR 登录。绑定角色后走 `char.interfaces.chat.GetReply`（与 discordbot / telegrambot 同构）；会话为虚拟桥接群 `bridge:wechat:{platformChatId}`，不建真实 Hub 群。
+
+默认传输基址 `https://ilinkai.weixin.qq.com`（配置 `apiBaseUrl` 为空时）；协议为 iLink HTTP（`ilink/bot/getupdates`、`ilink/bot/sendmessage`）。
+
+路径前缀：`/api/parts/shells:wechatbot`。均需登录。
+
+---
+
+## 页面
+
+### GET /parts/shells:wechatbot/
+- 用途：微信机器人管理页（配置、启停、扫码登录）。
+
+---
+
+## 生命周期
+
+### POST /api/parts/shells:wechatbot/start
+- Body：`botname`
+- 用途：启动指定机器人。
+
+### POST /api/parts/shells:wechatbot/stop
+- Body：`botname`
+- 用途：停止指定机器人。
+
+### GET /api/parts/shells:wechatbot/getbotlist
+- 用途：当前用户全部机器人配置名列表。
+
+### GET /api/parts/shells:wechatbot/getrunningbotlist
+- 用途：正在运行的机器人名列表。
+
+---
+
+## 配置
+
+### GET /api/parts/shells:wechatbot/getbotconfig
+- 查询：`botname`
+- 用途：读取指定配置。
+
+### GET /api/parts/shells:wechatbot/getbotConfigTemplate
+- 查询：`charname`（可选）
+- 用途：配置模板；可按角色预填。
+
+### POST /api/parts/shells:wechatbot/setbotconfig
+- Body：`botname`、`config`
+- 用途：保存配置。
+
+### POST /api/parts/shells:wechatbot/deletebotconfig
+- Body：`botname`
+- 用途：删除配置（若在运行会先停止）。
+
+### POST /api/parts/shells:wechatbot/newbotconfig
+- Body：`botname`（必填）
+- 用途：新建空配置。
+
+---
+
+## QR 登录（推荐）
+
+### POST /api/parts/shells:wechatbot/qrcode/start
+- Body：`botname`（可选；成功后凭证写回该配置）
+- 用途：向 iLink 申请登录二维码会话，返回 `sessionKey` 与二维码信息。
+
+### GET /api/parts/shells:wechatbot/qrcode/poll
+- 查询：`sessionKey`（必填）
+- 用途：轮询扫码状态。成功且带 `token`/`botname` 时服务端写回配置（token、apiBaseUrl；必要时更新 OwnerWeChatId 并绑定桥接身份）。


### PR DESCRIPTION
## Summary

- 按 shells AGENTS.md 新约定重写/精简各 shell 及 pages/llms.txt：中文、操作结论与 HTTP/WS API，去掉设计文档 § 引用、wire-protocol 堆砌与进程内客户端 API。
- 重点整理 chat / social 等大 shell 的 llms.txt（路径简写、重要结论、路由表结构）。
- 在 shells/AGENTS.md 中明确 public/llms.txt 的定位与边界（与 AGENTS.md / decl/ 分工）。

## Test plan

- [ ] 无需运行时变更；确认各 llms.txt 在 IDE 中可读、链接与路径前缀正确
- [ ] 可选：对照 chat/social 实际 ndpoints.mjs 抽查几条路由是否与文档一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
本 PR 重整 shell 与 `pages/llms.txt` 文档，统一中文、路径前缀、认证要求及 HTTP/WebSocket API 说明。`chat` 与 `social` 改为按主题组织的路由参考，并移除设计笔记、协议细节、存储实现和进程内客户端 API。

同时，实体和文件端点改用 `httpError` 抛出错误，由中间件统一处理。

目标是提升 IDE、AI 和 API 使用者的阅读效率，减少实现噪声。无明显架构风险。主要审美风险是部分文档压缩过度，历史背景和内部 API 可见性降低。整体结构更清晰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->