### PR TITLE
fix 404 of server-status.php

### DIFF
--- a/src/public/pages/server-status.php.html
+++ b/src/public/pages/server-status.php.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Apache Status</title>
+	<style>
+		body {
+			font-family: "Courier New", Courier, monospace;
+			background-color: #ffffff;
+			color: #000000;
+		}
+
+		h1 {
+			font-size: 1.5em;
+			border-bottom: 1px solid #000;
+		}
+
+		table {
+			border-collapse: collapse;
+			margin-top: 15px;
+			width: 100%;
+		}
+
+		th,
+		td {
+			text-align: left;
+			padding: 2px 5px;
+			font-size: 0.9em;
+		}
+
+		th {
+			background-color: #cccccc;
+		}
+
+		.scoreboard {
+			font-weight: bold;
+			padding: 10px 0;
+			letter-spacing: 2px;
+		}
+
+		hr {
+			border: 0;
+			border-top: 1px solid #000;
+			margin: 15px 0;
+		}
+	</style>
+</head>
+
+<body>
+
+	<h1>Apache Server Status for localhost</h1>
+
+	<dl>
+		<dt>Server Version: Apache/1.3.26 (Unix) RedHat/Linux PHP/4.2.0</dt>
+		<dt>Server Built: May 15 2002 10:22:15</dt>
+	</dl>
+	<hr>
+
+	<dl>
+		<dt>Current Time: <span id="current-time">Saturday, 26-Oct-2002 14:32:11 GMT</span></dt>
+		<dt>Restart Time: <span id="restart-time">Wednesday, 23-Oct-2002 09:12:45 GMT</span></dt>
+		<dt>Parent Server Generation: 1</dt>
+		<dt>Server uptime: 201 days 14 hours 22 minutes</dt>
+		<dt>Total accesses: 8943210 - Total Traffic: 12.4 GB</dt>
+		<dt>CPU Usage: u14.2 s3.1 cu0 cs0 - .001% CPU load</dt>
+		<dt>0.51 requests/sec - 731 B/second - 1433 B/request</dt>
+		<dt>4 requests currently being processed, 6 idle servers</dt>
+	</dl>
+
+	<div class="scoreboard">
+		_W__R_K_C_......................................
+	</div>
+
+	<p>Scoreboard Key:<br>
+		"<b><code>_</code></b>" Waiting for Connection, "<b><code>S</code></b>" Starting up, "<b><code>R</code></b>" Reading Request,<br>
+		"<b><code>W</code></b>" Sending Reply, "<b><code>K</code></b>" Keepalive (read), "<b><code>D</code></b>" DNS Lookup,<br>
+		"<b><code>C</code></b>" Closing connection, "<b><code>L</code></b>" Logging, "<b><code>G</code></b>" Gracefully finishing,<br>
+		"<b><code>.</code></b>" Open slot with no current process</p>
+
+	<table border="0">
+		<tr>
+			<th>Srv</th>
+			<th>PID</th>
+			<th>Acc</th>
+			<th>M</th>
+			<th>CPU</th>
+			<th>SS</th>
+			<th>Req</th>
+			<th>Conn</th>
+			<th>Child</th>
+			<th>Slot</th>
+			<th>Client</th>
+			<th>VHost</th>
+			<th>Request</th>
+		</tr>
+
+		<tr>
+			<td>0-0</td>
+			<td>2301</td>
+			<td>0/15/234</td>
+			<td><b>W</b></td>
+			<td>0.12</td>
+			<td>2</td>
+			<td>0</td>
+			<td>0.0</td>
+			<td>0.12</td>
+			<td>0.00</td>
+			<td>218.10.4.2</td>
+			<td>localhost</td>
+			<td>GET /cgi-bin/formmail.pl HTTP/1.0</td>
+		</tr>
+
+		<tr>
+			<td>1-0</td>
+			<td>2302</td>
+			<td>0/8/120</td>
+			<td><b>K</b></td>
+			<td>0.05</td>
+			<td>15</td>
+			<td>0</td>
+			<td>0.0</td>
+			<td>0.05</td>
+			<td>0.00</td>
+			<td>192.168.0.50</td>
+			<td>localhost</td>
+			<td>GET /index.php?page=../../../../etc/passwd HTTP/1.0</td>
+		</tr>
+
+		<tr>
+			<td>2-0</td>
+			<td>2305</td>
+			<td>0/2/15</td>
+			<td><b>C</b></td>
+			<td>0.01</td>
+			<td>1</td>
+			<td>0</td>
+			<td>0.0</td>
+			<td>0.01</td>
+			<td>0.00</td>
+			<td>64.233.160.0</td>
+			<td>localhost</td>
+			<td>GET /c99.php?act=cmd HTTP/1.0</td>
+		</tr>
+
+		<!-- 当前页面请求 -->
+		<tr>
+			<td>3-0</td>
+			<td>2310</td>
+			<td>0/1/1</td>
+			<td><b>R</b></td>
+			<td>0.00</td>
+			<td>0</td>
+			<td>0</td>
+			<td>0.0</td>
+			<td>0.00</td>
+			<td>0.00</td>
+			<td>127.0.0.1</td>
+			<td>localhost</td>
+			<td>GET /server-status.php HTTP/1.1</td>
+		</tr>
+	</table>
+
+	<hr>
+	<!--
+	<br />
+	<b>Warning</b>:  Cannot add header information - headers already sent by (output started at /usr/local/apache/htdocs/server-status.php:2) in <b>/usr/local/apache/htdocs/server-status.php</b> on line <b>55</b><br />
+	-->
+
+	<script>
+		const now = new Date()
+		const restart = new Date(now.getTime() - (201 * 24 * 60 * 60 * 1000) - (14 * 60 * 60 * 1000))
+		document.getElementById('current-time').innerText = now.toUTCString().replace('UTC', 'GMT')
+		document.getElementById('restart-time').innerText = restart.toUTCString().replace('UTC', 'GMT')
+	</script>
+</body>
+
+</html>

--- a/src/server/test/live/php_decoy.test.mjs
+++ b/src/server/test/live/php_decoy.test.mjs
@@ -1,0 +1,33 @@
+/**
+ * PHP 诱饵页：X-Powered-By 触发扫描后由 *.php.html / *.php.mjs 响应。
+ */
+/* global Deno */
+import { assertEquals, assertMatch } from 'jsr:@std/assert'
+
+import { launchNode, stopNode } from '../../../scripts/test/node/launch.mjs'
+
+Deno.test({
+	name: 'php decoy serves server-status.php.html',
+	sanitizeOps: false,
+	sanitizeResources: false,
+}, async () => {
+	const node = await launchNode({
+		username: 'php-decoy-user',
+		apiKey: `fount-php-decoy-${Date.now().toString(36)}`,
+	})
+	const { baseUrl, apiKey } = node
+	try {
+		const res = await fetch(`${baseUrl}/server-status.php?fount-apikey=${encodeURIComponent(apiKey)}`)
+		assertEquals(res.status, 200)
+		assertEquals(res.headers.get('x-powered-by'), 'PHP/4.2.0')
+		const body = await res.text()
+		assertMatch(body, /Apache Server Status for localhost/)
+		assertMatch(body, /GET \/server-status\.php HTTP/)
+		const setCookie = res.headers.getSetCookie?.() ?? []
+		const sessionCookie = setCookie.find(c => c.startsWith('PHPSESSID='))
+		assertEquals(sessionCookie != null, true, 'first visit should set PHPSESSID')
+	}
+	finally {
+		await stopNode(node)
+	}
+})

--- a/src/server/web_server/index.mjs
+++ b/src/server/web_server/index.mjs
@@ -9,6 +9,7 @@ import { __dirname } from '../base.mjs'
 import { registerEndpoints } from './endpoints.mjs'
 import { diff_if_auth, registerMiddleware } from './middleware.mjs'
 import { PartsRouter } from './parts_router.mjs'
+import { registerPhpDecoy } from './php_decoy.mjs'
 import { betterSendFile, registerResources } from './resources.mjs'
 import { registerWellKnowns } from './well-knowns.mjs'
 
@@ -34,6 +35,9 @@ mainRouter.post('/api/sentrytunnel', diff_if_auth(
 
 // 在主路由器上设置中间件
 registerMiddleware(mainRouter)
+
+// 为php请求路由到html/mjs文件 —— 一般由 X-Powered-By: PHP/4.2.0 诱饵触发（须在 cookieParser 之后）
+registerPhpDecoy(mainRouter)
 
 // 在主路由器上设置 API、well-known 和资源端点
 registerEndpoints(mainRouter)

--- a/src/server/web_server/php_decoy.mjs
+++ b/src/server/web_server/php_decoy.mjs
@@ -1,0 +1,56 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { __dirname } from '../base.mjs'
+
+import { betterSendFile } from './resources.mjs'
+
+const DECOY_ROOT = path.join(__dirname, 'src/public/pages')
+
+/**
+ * 将 .php URL 路径规范为 decoy 目录下的相对路径。
+ * @param {string} reqPath Express `req.path`
+ * @returns {string | null} 如 `server-status.php`，无法映射时 null
+ */
+function phpDecoyRelPath(reqPath) {
+	if (!reqPath.endsWith('.php')) return null
+	const safe = path.normalize(reqPath).replace(/^(\.\.[/\\])+/, '').replace(/^\//, '')
+	if (!safe.endsWith('.php') || safe.includes('\0')) return null
+	return safe
+}
+
+/**
+ * 注册 PHP 诱饵路由：将 `*.php` 请求映射到同名的 `.php.html` 或 `.php.mjs`。
+ * @param {import('../../scripts/WsAbleRouter.mjs').WsAbleRouter} router Express 路由器（须在 cookieParser 之后注册）。
+ * @returns {void}
+ */
+export function registerPhpDecoy(router) {
+	router.use(async (req, res, next) => {
+		const rel = phpDecoyRelPath(req.path)
+		if (!rel) return next()
+
+		if (!req.cookies?.PHPSESSID) {
+			const fakeSessionId = crypto.randomBytes(16).toString('hex')
+			// 不加 HttpOnly，还原 2002 年 PHP 4 的真实 Cookie 行为
+			res.setHeader('Set-Cookie', `PHPSESSID=${fakeSessionId}; path=/`)
+		}
+
+		const targetTxt = path.join(DECOY_ROOT, `${rel}.txt`)
+		if (fs.existsSync(targetTxt))
+			return betterSendFile(res.status(200), targetTxt)
+
+		const targetHtml = path.join(DECOY_ROOT, `${rel}.html`)
+		if (fs.existsSync(targetHtml))
+			return betterSendFile(res.status(200), targetHtml)
+
+		const targetMjs = path.join(DECOY_ROOT, `${rel}.mjs`)
+		if (fs.existsSync(targetMjs)) {
+			const result = await import(pathToFileURL(targetMjs).href)
+			if (result.handle) return result.handle(req, res)
+			if (result.generateHtml) return res.status(200).send(await result.generateHtml(req))
+		}
+		next()
+	})
+}


### PR DESCRIPTION
---
name: 'default'
about: default pull request template
title: change name
assignees: steve02081504
---

**感谢你对fount做出的贡献**  
**Thank you for your contribution to fount**

如果你自信其他人能通过观察你对项目的修改得知你的意图，这里可以什么都不填。如果不能，请描述你的修改直至你认为其他人可以看懂修改的缘由  
If you are confident that others will know your intentions by observing your modifications to the project, you can fill in nothing here. If not, please describe your change until you think others can understand the reason for the modification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

新增 PHP 诱饵路由和静态 `server-status.php` 页面，解决访问 404。路由支持 `.html`、`.txt` 和动态 `.mjs` 页面，并设置 `PHPSESSID` Cookie；新增集成测试覆盖响应内容与会话行为。

架构风险较低，但通用文件映射和动态模块执行会扩大路由行为，需严格控制页面目录内容。审美风险中等：静态 Apache 状态页与 PHP 诱饵逻辑耦合，且页面脚本动态伪造时间和状态数据，维护成本偏高。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->