### PR TITLE
fix(runner): git clone low-speed timeout with CN/RU/KP mirror fallback

### DIFF
--- a/path/AGENTS.md
+++ b/path/AGENTS.md
@@ -28,6 +28,7 @@ Same logic is isomorphic across `foo.{ps1,sh}`; platform-only code under `path/s
 - `fount update <branch>` — checkout + remove `.noupdate`; unknown names `ls-remote` once then one-shot fetch.
 - `fount update <sha>` — detach + create `.noupdate`.
 - `fount update pr/<n>` (also `pull/<n>`, `#<n>`, or a GitHub PR URL) — fetch `refs/pull/<n>/head` into `origin/pr/<n>`, detach, create `.noupdate`. Re-run to refresh the tip.
+- `fount update <remote-url>` — point `origin` at that URL and check out its default branch (tracking it), clearing `.noupdate`; subsequent plain updates follow it. Detected before branch names via `git_is_remote_url` (http(s)/ssh/git/ftp/file URLs and scp-like `user@host:path`).
 - If the current upstream is confirmed gone on origin (not a network error), fall back to tracking `master`.
 - Git / bash / Deno-template traps: [docs/git-notes.md](docs/git-notes.md).
 

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -94,6 +94,38 @@ function script:git_fetch_pull_request($Pr) {
 	invoke_repo_git fetch origin --prune "+refs/pull/${Pr}/head:refs/remotes/origin/pr/${Pr}"
 }
 
+# Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
+# with CN/KP/RU mirror fallback and a low-speed timeout (mirrors runner's installer).
+# Leaves origin pointed at whichever URL actually fetched.
+function script:git_supplement_repo {
+	$global:LastExitCode = 0
+	$urls = @("https://github.com/steve02081504/fount.git")
+	if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
+		$urls += "https://gh-proxy.org/github.com/steve02081504/fount.git"
+		$urls += "https://gitclone.com/github.com/steve02081504/fount.git"
+	}
+	invoke_repo_git init -b master
+	if ($LastExitCode -ne 0) { return }
+	invoke_repo_git config core.autocrlf false
+	if ($LastExitCode -ne 0) { return }
+	$originAdded = $false
+	foreach ($url in $urls) {
+		if ($originAdded) {
+			invoke_repo_git remote set-url origin $url
+		}
+		else {
+			invoke_repo_git remote add origin $url
+			$originAdded = $true
+		}
+		invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1
+		if ($LastExitCode -eq 0) {
+			$global:LastExitCode = 0
+			return
+		}
+	}
+	$global:LastExitCode = 1
+}
+
 function script:git_backup_uncommitted {
 	$global:LastExitCode = 0
 	if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return }
@@ -250,11 +282,8 @@ function script:fount_upgrade {
 	}
 	if (!(Test-Path -Path "$FOUNT_DIR/.git")) {
 		Write-Host (Get-I18n -key 'git.repoNotFound')
-		invoke_repo_git init -b master
-		invoke_repo_git config core.autocrlf false
-		invoke_repo_git remote add origin https://github.com/steve02081504/fount.git
 		Write-Host (Get-I18n -key 'git.fetchingAndResetting')
-		invoke_repo_git fetch origin master --depth 1
+		git_supplement_repo
 		if ($LastExitCode -ne 0) {
 			Write-Warning (Get-I18n -key 'git.fetchFailed')
 			Write-Warning (Get-I18n -key 'git.fetchFailedSkippingUpdate')

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -133,39 +133,28 @@ function script:git_supplement_repo {
 }
 
 # 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
-# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 设置依次尝试每个
-# 镜像并在结束后恢复原 URL；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
+# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 和 -c remote.origin.url
+# 依次尝试每个镜像而不改动配置；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
 # 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
 function script:git_fetch_with_fallback {
 	$originUrl = invoke_repo_git config --get remote.origin.url 2>$null
 	if ($LastExitCode -ne 0) { $originUrl = $null }
-	if ($originUrl -in @(
-			'https://github.com/steve02081504/fount.git',
+	$candidates = @($originUrl, 'https://github.com/steve02081504/fount.git')
+	if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
+		$candidates += @(
 			'https://gh-proxy.org/github.com/steve02081504/fount.git',
 			'https://gitclone.com/github.com/steve02081504/fount.git'
-		)) {
-		$candidates = @($originUrl, 'https://github.com/steve02081504/fount.git')
-		if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
-			$candidates += 'https://gh-proxy.org/github.com/steve02081504/fount.git'
-			$candidates += 'https://gitclone.com/github.com/steve02081504/fount.git'
-		}
-		foreach ($url in $candidates) {
-			if ($url -ne $originUrl) {
-				invoke_repo_git remote set-url origin $url
-				if ($LastExitCode -ne 0) { continue }
-			}
-			invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune @args
-			if ($LastExitCode -eq 0) {
-				if ($url -ne $originUrl) { invoke_repo_git remote set-url origin $originUrl }
-				$global:LastExitCode = 0
-				return
-			}
-		}
-		invoke_repo_git remote set-url origin $originUrl
-		$global:LastExitCode = 1
-		return
+		)
 	}
-	invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune @args
+	$candidates = $candidates | Select-Object -Unique
+	foreach ($url in $candidates) {
+		invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 -c "remote.origin.url=$url" fetch origin --prune @args
+		if ($LastExitCode -eq 0) {
+			$global:LastExitCode = 0
+			return
+		}
+	}
+	$global:LastExitCode = 1
 }
 
 function script:git_backup_uncommitted {

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -85,6 +85,14 @@ function script:git_parse_pr_number($Target) {
 	return $null
 }
 
+# 检测是否为远程 URL（http(s)/ssh/git/ftp/file 协议，或 scp-like 的 user@host:path）。
+function script:git_is_remote_url($Target) {
+	if ([string]::IsNullOrEmpty($Target)) { return $false }
+	if ($Target -match '^(?i)(https?|ssh|git\+ssh|git|ftp|file)://') { return $true }
+	if ($Target -match '^[^/:]+@[^/:]+:') { return $true }
+	return $false
+}
+
 # 一次性将 GitHub 的 pull/<n>/head 映射到 origin/pr/<n>（不扩展 remote.origin.fetch）。
 function script:git_fetch_pull_request($Pr) {
 	if ($Pr -notmatch '^[0-9]+$') {

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -104,6 +104,7 @@ function script:git_supplement_repo {
 		$urls += "https://gh-proxy.org/github.com/steve02081504/fount.git"
 		$urls += "https://gitclone.com/github.com/steve02081504/fount.git"
 	}
+	$hadGit = Test-Path -LiteralPath "$FOUNT_DIR/.git"
 	invoke_repo_git init -b master
 	if ($LastExitCode -ne 0) { return }
 	invoke_repo_git config core.autocrlf false
@@ -122,6 +123,12 @@ function script:git_supplement_repo {
 			$global:LastExitCode = 0
 			return
 		}
+	}
+	# All configured fetches failed: undo the .git this invocation created so the
+	# caller can retry the full source sequence on the next run. Never touch a
+	# pre-existing repo.
+	if (-not $hadGit) {
+		Remove-Item -LiteralPath "$FOUNT_DIR/.git" -Recurse -Force -ErrorAction SilentlyContinue
 	}
 	$global:LastExitCode = 1
 }

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -72,7 +72,7 @@ function script:git_fetch_remote_branch($Branch) {
 		$global:LastExitCode = 1
 		return
 	}
-	invoke_repo_git fetch origin --prune "+refs/heads/${Branch}:refs/remotes/origin/${Branch}"
+	git_fetch_with_fallback "+refs/heads/${Branch}:refs/remotes/origin/${Branch}"
 }
 
 # Return PR number if target names a GitHub pull request (pr/N, pull/N, #N, or github.com/…/pull/N URL); else $null.
@@ -91,7 +91,7 @@ function script:git_fetch_pull_request($Pr) {
 		$global:LastExitCode = 1
 		return
 	}
-	invoke_repo_git fetch origin --prune "+refs/pull/${Pr}/head:refs/remotes/origin/pr/${Pr}"
+	git_fetch_with_fallback "+refs/pull/${Pr}/head:refs/remotes/origin/pr/${Pr}"
 }
 
 # Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
@@ -131,6 +131,44 @@ function script:git_supplement_repo {
 		Remove-Item -LiteralPath "$FOUNT_DIR/.git" -Recurse -Force -ErrorAction SilentlyContinue
 	}
 	$global:LastExitCode = 1
+}
+
+# Fetch the given refspec(s) against origin, reusing git_supplement_repo's regional
+# mirror fallback and low-speed timeout for existing repos. When origin is one of the
+# known fount URLs, try each mirror in turn with -c http.lowSpeed* settings and restore
+# the original URL afterward; a custom origin (fork/self-hosted) is fetched as-is with
+# the same low-speed timeout, never rewritten. Refs are content-addressed, so fetching
+# from a mirror is indistinguishable to later readers.
+function script:git_fetch_with_fallback {
+	$originUrl = invoke_repo_git config --get remote.origin.url 2>$null
+	if ($LastExitCode -ne 0) { $originUrl = $null }
+	if ($originUrl -in @(
+			'https://github.com/steve02081504/fount.git',
+			'https://gh-proxy.org/github.com/steve02081504/fount.git',
+			'https://gitclone.com/github.com/steve02081504/fount.git'
+		)) {
+		$candidates = @($originUrl, 'https://github.com/steve02081504/fount.git')
+		if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
+			$candidates += 'https://gh-proxy.org/github.com/steve02081504/fount.git'
+			$candidates += 'https://gitclone.com/github.com/steve02081504/fount.git'
+		}
+		foreach ($url in $candidates) {
+			if ($url -ne $originUrl) {
+				invoke_repo_git remote set-url origin $url
+				if ($LastExitCode -ne 0) { continue }
+			}
+			invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune @args
+			if ($LastExitCode -eq 0) {
+				if ($url -ne $originUrl) { invoke_repo_git remote set-url origin $originUrl }
+				$global:LastExitCode = 0
+				return
+			}
+		}
+		invoke_repo_git remote set-url origin $originUrl
+		$global:LastExitCode = 1
+		return
+	}
+	invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune @args
 }
 
 function script:git_backup_uncommitted {

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -37,14 +37,14 @@ function script:git_ref_exists($Ref = 'HEAD') {
 	return ($LastExitCode -eq 0)
 }
 
-# Fetch origin and drop stale remote-tracking refs under the configured refspec.
-# Does not widen fetch to other branches — named targets use git_fetch_remote_branch.
+# 按配置的 refspec 拉取 origin 并清理过期的远端跟踪引用。
+# 不扩展到其他分支 —— 具名目标使用 git_fetch_remote_branch。
 function script:git_fetch_origin {
 	invoke_repo_git fetch origin --prune
 }
 
-# Reject glob metacharacters and other ref-unsafe fragments for single-branch fetch.
-# Aligns with git check-ref-format rules for refs/heads/<name> (plus apostrophe).
+# 拒绝 glob 元字符等单分支拉取不安全的片段。
+# 与 git check-ref-format 对 refs/heads/<name> 的规则一致（外加撇号）。
 function script:git_valid_branch_name($Branch) {
 	if ([string]::IsNullOrEmpty($Branch) -or $Branch -eq '@') { return $false }
 	if ($Branch -match '[\?\*\[\\:~^\s'']|\.\.|@{|//|[\x00-\x1F\x7F]') { return $false }
@@ -56,8 +56,8 @@ function script:git_valid_branch_name($Branch) {
 	return $true
 }
 
-# 0 = branch exists on origin, 1 = confirmed absent, 2 = network/other error.
-# Only call when a named ref is unknown locally — avoid on the plain-update happy path.
+# 0 = 分支在 origin 存在，1 = 确认不存在，2 = 网络/其他错误。
+# 仅当本地未知该具名引用时调用 —— 普通更新的顺利路径不要走这里。
 function script:git_remote_branch_status($Branch) {
 	if (-not (git_valid_branch_name $Branch)) { return 2 }
 	$output = invoke_repo_git ls-remote --heads origin "refs/heads/$Branch" 2>$null
@@ -66,7 +66,7 @@ function script:git_remote_branch_status($Branch) {
 	return 1
 }
 
-# One-shot map of a single head into origin/<branch> (does not change remote.origin.fetch).
+# 一次性将单个 head 映射到 origin/<branch>（不修改 remote.origin.fetch）。
 function script:git_fetch_remote_branch($Branch) {
 	if (-not (git_valid_branch_name $Branch)) {
 		$global:LastExitCode = 1
@@ -75,7 +75,7 @@ function script:git_fetch_remote_branch($Branch) {
 	git_fetch_with_fallback "+refs/heads/${Branch}:refs/remotes/origin/${Branch}"
 }
 
-# Return PR number if target names a GitHub pull request (pr/N, pull/N, #N, or github.com/…/pull/N URL); else $null.
+# 若 target 指向 GitHub pull request（pr/N、pull/N、#N 或 github.com/…/pull/N 链接），返回 PR 号；否则返回 $null。
 function script:git_parse_pr_number($Target) {
 	if ([string]::IsNullOrEmpty($Target)) { return $null }
 	if ($Target -match '^(?i)pr/([0-9]+)$') { return $Matches[1] }
@@ -85,7 +85,7 @@ function script:git_parse_pr_number($Target) {
 	return $null
 }
 
-# One-shot map of GitHub pull/<n>/head into origin/pr/<n> (does not widen remote.origin.fetch).
+# 一次性将 GitHub 的 pull/<n>/head 映射到 origin/pr/<n>（不扩展 remote.origin.fetch）。
 function script:git_fetch_pull_request($Pr) {
 	if ($Pr -notmatch '^[0-9]+$') {
 		$global:LastExitCode = 1
@@ -94,9 +94,9 @@ function script:git_fetch_pull_request($Pr) {
 	git_fetch_with_fallback "+refs/pull/${Pr}/head:refs/remotes/origin/pr/${Pr}"
 }
 
-# Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
-# with CN/KP/RU mirror fallback and a low-speed timeout (mirrors runner's installer).
-# Leaves origin pointed at whichever URL actually fetched.
+# 修复缺失/损坏的 $FOUNT_DIR 仓库：初始化、配置 origin，然后用 CN/KP/RU 镜像回退
+# 和低速超时拉取 master（与 runner 安装器一致）。
+# 拉取成功后 origin 保留指向实际拉取到的那个 URL。
 function script:git_supplement_repo {
 	$global:LastExitCode = 0
 	$urls = @("https://github.com/steve02081504/fount.git")
@@ -124,21 +124,18 @@ function script:git_supplement_repo {
 			return
 		}
 	}
-	# All configured fetches failed: undo the .git this invocation created so the
-	# caller can retry the full source sequence on the next run. Never touch a
-	# pre-existing repo.
+	# 所有配置的拉取都失败了：撤销本次调用创建的 .git，以便下次运行时调用方
+	# 可重试完整的源码序列。绝不触碰已存在的仓库。
 	if (-not $hadGit) {
 		Remove-Item -LiteralPath "$FOUNT_DIR/.git" -Recurse -Force -ErrorAction SilentlyContinue
 	}
 	$global:LastExitCode = 1
 }
 
-# Fetch the given refspec(s) against origin, reusing git_supplement_repo's regional
-# mirror fallback and low-speed timeout for existing repos. When origin is one of the
-# known fount URLs, try each mirror in turn with -c http.lowSpeed* settings and restore
-# the original URL afterward; a custom origin (fork/self-hosted) is fetched as-is with
-# the same low-speed timeout, never rewritten. Refs are content-addressed, so fetching
-# from a mirror is indistinguishable to later readers.
+# 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
+# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 设置依次尝试每个
+# 镜像并在结束后恢复原 URL；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
+# 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
 function script:git_fetch_with_fallback {
 	$originUrl = invoke_repo_git config --get remote.origin.url 2>$null
 	if ($LastExitCode -ne 0) { $originUrl = $null }
@@ -206,8 +203,8 @@ function script:git_sync_to_ref($Ref) {
 	invoke_repo_git reset --hard $Ref
 }
 
-# Ensure remote.origin.fetch maps refs/heads/<Branch> → origin/<Branch>.
-# Adds a single-branch refspec only — never expands to refs/heads/*.
+# 确保 remote.origin.fetch 将 refs/heads/<Branch> 映射到 origin/<Branch>。
+# 只添加单分支 refspec —— 绝不扩展为 refs/heads/*。
 function script:git_ensure_origin_fetch_branch($RemoteBranch) {
 	if (-not (git_valid_branch_name $RemoteBranch)) {
 		$global:LastExitCode = 1
@@ -223,9 +220,9 @@ function script:git_ensure_origin_fetch_branch($RemoteBranch) {
 	invoke_repo_git config --add remote.origin.fetch "+refs/heads/${RemoteBranch}:refs/remotes/origin/${RemoteBranch}"
 }
 
-# Point local branch at origin/<name> without requiring a prior wildcard fetch refspec.
-# `git branch --set-upstream-to` rejects one-shot remote-tracking refs under single-branch clones;
-# add the one head to remote.origin.fetch (not *) then set branch.*.remote / merge.
+# 将本地分支指向 origin/<name>，无需事先配置通配符拉取 refspec。
+# 单分支克隆下 `git branch --set-upstream-to` 会拒绝一次性远端跟踪引用；
+# 把该 head 加进 remote.origin.fetch（而非 *），再设置 branch.*.remote / merge。
 function script:git_track_origin_branch($Branch, $OriginRef = $null) {
 	if (-not $OriginRef) { $OriginRef = "origin/$Branch" }
 	if ($OriginRef -notlike 'origin/*') {
@@ -241,7 +238,7 @@ function script:git_track_origin_branch($Branch, $OriginRef = $null) {
 	invoke_repo_git config "branch.$Branch.merge" "refs/heads/$remoteBranch"
 }
 
-# Switch/create local branch at StartPoint (default origin/<Branch>). Does not move other branches.
+# 在 StartPoint（默认 origin/<Branch>）处切换/创建本地分支。不动其他分支。
 function script:git_checkout_branch($Branch, $StartPoint = $null) {
 	if (-not $StartPoint) { $StartPoint = "origin/$Branch" }
 	if (-not (git_ref_exists $StartPoint)) {
@@ -259,7 +256,7 @@ function script:git_checkout_branch($Branch, $StartPoint = $null) {
 	}
 }
 
-# Detach HEAD at Ref without moving the previous branch tip.
+# 在 Ref 处分离 HEAD，不动此前分支的尖端。
 function script:git_detach_to_ref($Ref) {
 	$resolved = invoke_repo_git rev-parse --verify "${Ref}^{commit}" 2>$null
 	if ($LastExitCode -ne 0 -or -not $resolved) {
@@ -416,7 +413,7 @@ function script:fount_upgrade {
 	}
 }
 
-# $Kind = version.status.* suffix; $Warn = Write-Warning instead of Write-Host.
+# $Kind = version.status.* 的后缀；$Warn = 用 Write-Warning 而非 Write-Host。
 function script:fount_print_version_status($Kind, [switch]$Warn) {
 	if ($Warn) {
 		Write-Warning (Get-I18n -key 'version.status.title' -params @{ status = (Get-I18n -key "version.status.$Kind") })
@@ -426,7 +423,7 @@ function script:fount_print_version_status($Kind, [switch]$Warn) {
 	}
 }
 
-# $Branch = branch name, or HEAD for detached.
+# $Branch = 分支名，分离状态为 HEAD。
 function script:fount_print_version_branch($Branch) {
 	if ($Branch -eq 'HEAD') {
 		$Branch = Get-I18n -key 'version.branch.detached'
@@ -434,7 +431,7 @@ function script:fount_print_version_branch($Branch) {
 	Write-Host (Get-I18n -key 'version.branch.title' -params @{ branch = $Branch })
 }
 
-# Print branch, HEAD commit, and whether the current branch tip matches origin.
+# 打印分支、HEAD 提交，以及当前分支尖端是否与 origin 一致。
 function script:fount_show_version {
 	$global:LastExitCode = 0
 	if (!(Get-Command git -ErrorAction SilentlyContinue)) {

--- a/path/src/git.ps1
+++ b/path/src/git.ps1
@@ -133,9 +133,9 @@ function script:git_supplement_repo {
 }
 
 # 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
-# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 和 -c remote.origin.url
-# 依次尝试每个镜像而不改动配置；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
-# 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
+# 和低速超时。用 -c http.lowSpeed* 和 -c remote.origin.url 依次尝试每个候选 URL（origin、
+# 主库及各镜像）而不改动配置；自定义 origin（fork/自托管）也以主库兜底。refs 是内容寻址的，
+# 因此从镜像拉取对后续读者而言与主源无异。
 function script:git_fetch_with_fallback {
 	$originUrl = invoke_repo_git config --get remote.origin.url 2>$null
 	if ($LastExitCode -ne 0) { $originUrl = $null }

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Git helpers for fount self-update
+# fount 自更新的 Git 辅助函数
 
 invoke_repo_git() {
 	GIT_TERMINAL_PROMPT=0 GIT_OPTIONAL_LOCKS=0 git -C "$FOUNT_DIR" "$@"
@@ -9,14 +9,14 @@ git_ref_exists() {
 	invoke_repo_git rev-parse --verify "$1" &>/dev/null
 }
 
-# Fetch origin and drop stale remote-tracking refs under the configured refspec.
-# Does not widen fetch to other branches — named targets use git_fetch_remote_branch.
+# 按配置的 refspec 拉取 origin 并清理过期的远端跟踪引用。
+# 不扩展到其他分支 —— 具名目标使用 git_fetch_remote_branch。
 git_fetch_origin() {
 	invoke_repo_git fetch origin --prune
 }
 
-# Reject glob metacharacters and other ref-unsafe fragments for single-branch fetch.
-# Aligns with git check-ref-format rules for refs/heads/<name> (plus apostrophe).
+# 拒绝 glob 元字符等单分支拉取不安全的片段。
+# 与 git check-ref-format 对 refs/heads/<name> 的规则一致（外加撇号）。
 git_valid_branch_name() {
 	local branch="$1" part
 	[[ -n "$branch" && "$branch" != @ ]] || return 1
@@ -26,7 +26,7 @@ git_valid_branch_name() {
 	[[ "$branch" != *'@{'* ]] || return 1
 	[[ "$branch" != /* && "$branch" != */ && "$branch" != *//* ]] || return 1
 	local IFS='/'
-	# shellcheck disable=SC2086 # intentional IFS split on /
+	# shellcheck disable=SC2086 # 有意按 / 做 IFS 拆分
 	for part in $branch; do
 		[[ -n "$part" && "$part" != .* && "$part" != *.lock ]] || return 1
 		[[ "$part" != *. ]] || return 1
@@ -34,8 +34,8 @@ git_valid_branch_name() {
 	return 0
 }
 
-# 0 = branch exists on origin, 1 = confirmed absent, 2 = network/other error.
-# Only call when a named ref is unknown locally — avoid on the plain-update happy path.
+# 0 = 分支在 origin 存在，1 = 确认不存在，2 = 网络/其他错误。
+# 仅当本地未知该具名引用时调用 —— 普通更新的顺利路径不要走这里。
 git_remote_branch_status() {
 	local branch="$1" remote_heads
 	git_valid_branch_name "$branch" || return 2
@@ -44,14 +44,14 @@ git_remote_branch_status() {
 	return 1
 }
 
-# One-shot map of a single head into origin/<branch> (does not change remote.origin.fetch).
+# 一次性将单个 head 映射到 origin/<branch>（不修改 remote.origin.fetch）。
 git_fetch_remote_branch() {
 	local branch="$1"
 	git_valid_branch_name "$branch" || return 1
 	git_fetch_with_fallback "+refs/heads/${branch}:refs/remotes/origin/${branch}"
 }
 
-# Echo PR number if target names a GitHub pull request (pr/N, pull/N, #N, or github.com/…/pull/N URL); else return 1.
+# 若 target 指向 GitHub pull request（pr/N、pull/N、#N 或 github.com/…/pull/N 链接），输出 PR 号；否则返回 1。
 git_parse_pr_number() {
 	local target="$1" number=
 	[[ -n "$target" ]] || return 1
@@ -69,16 +69,16 @@ git_parse_pr_number() {
 	printf '%s\n' "$number"
 }
 
-# One-shot map of GitHub pull/<n>/head into origin/pr/<n> (does not widen remote.origin.fetch).
+# 一次性将 GitHub 的 pull/<n>/head 映射到 origin/pr/<n>（不扩展 remote.origin.fetch）。
 git_fetch_pull_request() {
 	local pr="$1"
 	[[ "$pr" =~ ^[0-9]+$ ]] || return 1
 	git_fetch_with_fallback "+refs/pull/${pr}/head:refs/remotes/origin/pr/${pr}"
 }
 
-# Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
-# with CN/KP/RU mirror fallback and a low-speed timeout (mirrors runner's installer).
-# Leaves origin pointed at whichever URL actually fetched.
+# 修复缺失/损坏的 $FOUNT_DIR 仓库：初始化、配置 origin，然后用 CN/KP/RU 镜像回退
+# 和低速超时拉取 master（与 runner 安装器一致）。
+# 拉取成功后 origin 保留指向实际拉取到的那个 URL。
 git_supplement_repo() {
 	local urls=("https://github.com/steve02081504/fount.git") origin_added=0 url
 	if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
@@ -99,21 +99,18 @@ git_supplement_repo() {
 			return 0
 		fi
 	done
-	# All configured fetches failed: undo the .git this invocation created so the
-	# caller can retry the full source sequence on the next run. Never touch a
-	# pre-existing repo.
+	# 所有配置的拉取都失败了：撤销本次调用创建的 .git，以便下次运行时调用方
+	# 可重试完整的源码序列。绝不触碰已存在的仓库。
 	if [ "$had_git" -eq 0 ] && [ -n "${FOUNT_DIR:-}" ]; then
 		rm -rf "$FOUNT_DIR/.git"
 	fi
 	return 1
 }
 
-# Fetch the given refspec(s) against origin, reusing git_supplement_repo's regional
-# mirror fallback and low-speed timeout for existing repos. When origin is one of the
-# known fount URLs, try each mirror in turn with -c http.lowSpeed* settings and restore
-# the original URL afterward; a custom origin (fork/self-hosted) is fetched as-is with
-# the same low-speed timeout, never rewritten. Refs are content-addressed, so fetching
-# from a mirror is indistinguishable to later readers.
+# 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
+# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 设置依次尝试每个
+# 镜像并在结束后恢复原 URL；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
+# 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
 git_fetch_with_fallback() {
 	local origin_url url
 	origin_url=$(invoke_repo_git config --get remote.origin.url 2>/dev/null) || origin_url=
@@ -178,8 +175,8 @@ git_sync_to_ref() {
 	invoke_repo_git reset --hard "$ref"
 }
 
-# Ensure remote.origin.fetch maps refs/heads/<branch> → origin/<branch>.
-# Adds a single-branch refspec only — never expands to refs/heads/*.
+# 确保 remote.origin.fetch 将 refs/heads/<branch> 映射到 origin/<branch>。
+# 只添加单分支 refspec —— 绝不扩展为 refs/heads/*。
 git_ensure_origin_fetch_branch() {
 	local remote_branch="$1" specs
 	git_valid_branch_name "$remote_branch" || return 1
@@ -196,9 +193,9 @@ git_ensure_origin_fetch_branch() {
 	invoke_repo_git config --add remote.origin.fetch "+refs/heads/${remote_branch}:refs/remotes/origin/${remote_branch}"
 }
 
-# Point local branch at origin/<name> without requiring a prior wildcard fetch refspec.
-# `git branch --set-upstream-to` rejects one-shot remote-tracking refs under single-branch clones;
-# add the one head to remote.origin.fetch (not *) then set branch.*.remote / merge.
+# 将本地分支指向 origin/<name>，无需事先配置通配符拉取 refspec。
+# 单分支克隆下 `git branch --set-upstream-to` 会拒绝一次性远端跟踪引用；
+# 把该 head 加进 remote.origin.fetch（而非 *），再设置 branch.*.remote / merge。
 git_track_origin_branch() {
 	local branch="$1"
 	local origin_ref="${2:-origin/$branch}"
@@ -215,7 +212,7 @@ git_track_origin_branch() {
 	invoke_repo_git config "branch.${branch}.merge" "refs/heads/${remote_branch}"
 }
 
-# Switch/create local branch at start_point (default origin/<branch>). Does not move other branches.
+# 在 start_point（默认 origin/<branch>）处切换/创建本地分支。不动其他分支。
 git_checkout_branch() {
 	local branch="$1"
 	local start_point="${2:-origin/$branch}"
@@ -231,7 +228,7 @@ git_checkout_branch() {
 	esac
 }
 
-# Detach HEAD at ref without moving the previous branch tip.
+# 在 ref 处分离 HEAD，不动此前分支的尖端。
 git_detach_to_ref() {
 	local ref="$1" resolved
 	resolved=$(invoke_repo_git rev-parse --verify "${ref}^{commit}" 2>/dev/null) || {
@@ -271,7 +268,7 @@ git_reset_and_clean() {
 	fi
 }
 
-# $1 = version.status.* suffix; $2 = green|yellow| (default plain stdout).
+# $1 = version.status.* 的后缀；$2 = green|yellow|（默认普通 stdout）。
 fount_print_version_status() {
 	local text color="${2:-}"
 	text=$(get_i18n "version.status.$1")
@@ -282,7 +279,7 @@ fount_print_version_status() {
 	esac
 }
 
-# $1 = branch name, or HEAD for detached.
+# $1 = 分支名，分离状态为 HEAD。
 fount_print_version_branch() {
 	local text="$1"
 	if [ "$text" = "HEAD" ]; then
@@ -291,7 +288,7 @@ fount_print_version_branch() {
 	get_i18n 'version.branch.title' 'branch' "$text"
 }
 
-# Print branch, HEAD commit, and whether the current branch tip matches origin.
+# 打印分支、HEAD 提交，以及当前分支尖端是否与 origin 一致。
 fount_show_version() {
 	local branch commit_hash remote_commit_hash merge_base
 	if ! command -v git &>/dev/null; then

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -85,6 +85,8 @@ git_supplement_repo() {
 	if [[ "$locale_var" =~ _(CN|KP|RU)(\.|@|$) ]]; then
 		urls+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 	fi
+	local had_git=0
+	[ -d "$FOUNT_DIR/.git" ] && had_git=1
 	invoke_repo_git init -b master || return 1
 	invoke_repo_git config core.autocrlf false || return 1
 	for url in "${urls[@]}"; do
@@ -98,6 +100,12 @@ git_supplement_repo() {
 			return 0
 		fi
 	done
+	# All configured fetches failed: undo the .git this invocation created so the
+	# caller can retry the full source sequence on the next run. Never touch a
+	# pre-existing repo.
+	if [ "$had_git" -eq 0 ]; then
+		rm -rf "$FOUNT_DIR/.git"
+	fi
 	return 1
 }
 

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -86,7 +86,7 @@ git_supplement_repo() {
 		urls+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 	fi
 	local had_git=0
-	[ -d "$FOUNT_DIR/.git" ] && had_git=1
+	if [ -n "${FOUNT_DIR:-}" ] && [ -d "$FOUNT_DIR/.git" ]; then had_git=1; fi
 	invoke_repo_git init -b master || return 1
 	invoke_repo_git config core.autocrlf false || return 1
 	for url in "${urls[@]}"; do
@@ -103,7 +103,7 @@ git_supplement_repo() {
 	# All configured fetches failed: undo the .git this invocation created so the
 	# caller can retry the full source sequence on the next run. Never touch a
 	# pre-existing repo.
-	if [ "$had_git" -eq 0 ]; then
+	if [ "$had_git" -eq 0 ] && [ -n "${FOUNT_DIR:-}" ]; then
 		rm -rf "$FOUNT_DIR/.git"
 	fi
 	return 1

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -69,6 +69,17 @@ git_parse_pr_number() {
 	printf '%s\n' "$number"
 }
 
+# 检测是否为远程 URL（http(s)/ssh/git/ftp/file 协议，或 scp-like 的 user@host:path）。
+git_is_remote_url() {
+	local target="$1"
+	[ -n "$target" ] || return 1
+	case "$target" in
+		http://*|https://*|ssh://*|git://*|git+ssh://*|ftp://*|file://*) return 0 ;;
+		*@*:*) return 0 ;;
+	esac
+	return 1
+}
+
 # 一次性将 GitHub 的 pull/<n>/head 映射到 origin/pr/<n>（不扩展 remote.origin.fetch）。
 git_fetch_pull_request() {
 	local pr="$1"

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -81,8 +81,7 @@ git_fetch_pull_request() {
 # Leaves origin pointed at whichever URL actually fetched.
 git_supplement_repo() {
 	local urls=("https://github.com/steve02081504/fount.git") origin_added=0 url
-	local locale_var="${LC_ALL:-${LC_MESSAGES:-$LANG}}"
-	if [[ "$locale_var" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+	if [[ "${LC_ALL:-${LC_MESSAGES:-$LANG}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
 		urls+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 	fi
 	local had_git=0

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -108,34 +108,34 @@ git_supplement_repo() {
 }
 
 # 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
-# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 设置依次尝试每个
-# 镜像并在结束后恢复原 URL；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
+# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 和 -c remote.origin.url
+# 依次尝试每个镜像而不改动配置；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
 # 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
 git_fetch_with_fallback() {
-	local origin_url url
+	local origin_url
 	origin_url=$(invoke_repo_git config --get remote.origin.url 2>/dev/null) || origin_url=
-	case "$origin_url" in
-	https://github.com/steve02081504/fount.git|https://gh-proxy.org/github.com/steve02081504/fount.git|https://gitclone.com/github.com/steve02081504/fount.git)
-		local candidates=("$origin_url" "https://github.com/steve02081504/fount.git")
-		if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
-			candidates+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
+	local candidates
+	candidates=("$origin_url" "https://github.com/steve02081504/fount.git")
+	if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+		candidates+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
+	fi
+	# 去重
+	local unique_candidates=()
+	local seen=()
+	local url
+	for url in "${candidates[@]}"; do
+		if [ -z "${seen[$url]:-}" ]; then
+			seen["$url"]=1
+			unique_candidates+=("$url")
 		fi
-		for url in "${candidates[@]}"; do
-			if [ "$url" != "$origin_url" ]; then
-				invoke_repo_git remote set-url origin "$url" || continue
-			fi
-			if invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune "$@"; then
-				if [ "$url" != "$origin_url" ]; then
-					invoke_repo_git remote set-url origin "$origin_url"
-				fi
-				return 0
-			fi
-		done
-		invoke_repo_git remote set-url origin "$origin_url"
-		return 1
-		;;
-	esac
-	invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune "$@"
+	done
+	candidates=("${unique_candidates[@]}")
+	for url in "${candidates[@]}"; do
+		if invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 -c "remote.origin.url=$url" fetch origin --prune "$@"; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 git_backup_uncommitted() {
@@ -344,4 +344,3 @@ fount_show_version() {
 		fount_print_version_status diverged yellow
 	fi
 }
-

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -48,7 +48,7 @@ git_remote_branch_status() {
 git_fetch_remote_branch() {
 	local branch="$1"
 	git_valid_branch_name "$branch" || return 1
-	invoke_repo_git fetch origin --prune "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+	git_fetch_with_fallback "+refs/heads/${branch}:refs/remotes/origin/${branch}"
 }
 
 # Echo PR number if target names a GitHub pull request (pr/N, pull/N, #N, or github.com/…/pull/N URL); else return 1.
@@ -73,7 +73,7 @@ git_parse_pr_number() {
 git_fetch_pull_request() {
 	local pr="$1"
 	[[ "$pr" =~ ^[0-9]+$ ]] || return 1
-	invoke_repo_git fetch origin --prune "+refs/pull/${pr}/head:refs/remotes/origin/pr/${pr}"
+	git_fetch_with_fallback "+refs/pull/${pr}/head:refs/remotes/origin/pr/${pr}"
 }
 
 # Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
@@ -106,6 +106,39 @@ git_supplement_repo() {
 		rm -rf "$FOUNT_DIR/.git"
 	fi
 	return 1
+}
+
+# Fetch the given refspec(s) against origin, reusing git_supplement_repo's regional
+# mirror fallback and low-speed timeout for existing repos. When origin is one of the
+# known fount URLs, try each mirror in turn with -c http.lowSpeed* settings and restore
+# the original URL afterward; a custom origin (fork/self-hosted) is fetched as-is with
+# the same low-speed timeout, never rewritten. Refs are content-addressed, so fetching
+# from a mirror is indistinguishable to later readers.
+git_fetch_with_fallback() {
+	local origin_url url
+	origin_url=$(invoke_repo_git config --get remote.origin.url 2>/dev/null) || origin_url=
+	case "$origin_url" in
+	https://github.com/steve02081504/fount.git|https://gh-proxy.org/github.com/steve02081504/fount.git|https://gitclone.com/github.com/steve02081504/fount.git)
+		local candidates=("$origin_url" "https://github.com/steve02081504/fount.git")
+		if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+			candidates+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
+		fi
+		for url in "${candidates[@]}"; do
+			if [ "$url" != "$origin_url" ]; then
+				invoke_repo_git remote set-url origin "$url" || continue
+			fi
+			if invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune "$@"; then
+				if [ "$url" != "$origin_url" ]; then
+					invoke_repo_git remote set-url origin "$origin_url"
+				fi
+				return 0
+			fi
+		done
+		invoke_repo_git remote set-url origin "$origin_url"
+		return 1
+		;;
+	esac
+	invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin --prune "$@"
 }
 
 git_backup_uncommitted() {

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -108,9 +108,9 @@ git_supplement_repo() {
 }
 
 # 对 origin 拉取给定的 refspec，为已存在仓库复用 git_supplement_repo 的区域镜像回退
-# 和低速超时。当 origin 是已知的 fount URL 时，用 -c http.lowSpeed* 和 -c remote.origin.url
-# 依次尝试每个镜像而不改动配置；自定义 origin（fork/自托管）则原样拉取，同样带低速超时，
-# 绝不重写。refs 是内容寻址的，因此从镜像拉取对后续读者而言与主源无异。
+# 和低速超时。用 -c http.lowSpeed* 和 -c remote.origin.url 依次尝试每个候选 URL（origin、
+# 主库及各镜像）而不改动配置；自定义 origin（fork/自托管）也以主库兜底。refs 是内容寻址的，
+# 因此从镜像拉取对后续读者而言与主源无异。
 git_fetch_with_fallback() {
 	local origin_url
 	origin_url=$(invoke_repo_git config --get remote.origin.url 2>/dev/null) || origin_url=
@@ -119,15 +119,14 @@ git_fetch_with_fallback() {
 	if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
 		candidates+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 	fi
-	# 去重
+	# 去重（嵌套循环，兼容 macOS 上古 bash 3.2，无关联数组）
 	local unique_candidates=()
-	local seen=()
-	local url
+	local url existing
 	for url in "${candidates[@]}"; do
-		if [ -z "${seen[$url]:-}" ]; then
-			seen["$url"]=1
-			unique_candidates+=("$url")
-		fi
+		for existing in "${unique_candidates[@]}"; do
+			[ "$existing" = "$url" ] && continue 2
+		done
+		unique_candidates+=("$url")
 	done
 	candidates=("${unique_candidates[@]}")
 	for url in "${candidates[@]}"; do

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -81,11 +81,11 @@ git_fetch_pull_request() {
 # Leaves origin pointed at whichever URL actually fetched.
 git_supplement_repo() {
 	local urls=("https://github.com/steve02081504/fount.git") origin_added=0 url
-	if [[ "${LC_ALL:-${LC_MESSAGES:-$LANG}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+	if [[ "${LC_ALL:-${LC_MESSAGES:-${LANG:-}}}" =~ _(CN|KP|RU)(\.|@|$) ]]; then
 		urls+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 	fi
 	local had_git=0
-	if [ -n "${FOUNT_DIR:-}" ] && [ -d "$FOUNT_DIR/.git" ]; then had_git=1; fi
+	if [ -n "${FOUNT_DIR:-}" ] && [ -e "$FOUNT_DIR/.git" ]; then had_git=1; fi
 	invoke_repo_git init -b master || return 1
 	invoke_repo_git config core.autocrlf false || return 1
 	for url in "${urls[@]}"; do
@@ -110,7 +110,7 @@ git_supplement_repo() {
 
 git_backup_uncommitted() {
 	command -v git &>/dev/null || return 0
-	[ -d "$FOUNT_DIR/.git" ] || return 0
+	[ -e "$FOUNT_DIR/.git" ] || return 0
 	if [ -z "$(invoke_repo_git status --porcelain)" ]; then
 		return 0
 	fi
@@ -265,7 +265,7 @@ fount_show_version() {
 		print_i18n_yellow 'version.noGit' >&2
 		return 1
 	fi
-	if [ ! -d "$FOUNT_DIR/.git" ]; then
+	if [ ! -e "$FOUNT_DIR/.git" ]; then
 		print_i18n_yellow 'version.noRepo' >&2
 		return 1
 	fi

--- a/path/src/git.sh
+++ b/path/src/git.sh
@@ -76,6 +76,31 @@ git_fetch_pull_request() {
 	invoke_repo_git fetch origin --prune "+refs/pull/${pr}/head:refs/remotes/origin/pr/${pr}"
 }
 
+# Repair a missing/corrupt $FOUNT_DIR repo: init, wire origin, then fetch master
+# with CN/KP/RU mirror fallback and a low-speed timeout (mirrors runner's installer).
+# Leaves origin pointed at whichever URL actually fetched.
+git_supplement_repo() {
+	local urls=("https://github.com/steve02081504/fount.git") origin_added=0 url
+	local locale_var="${LC_ALL:-${LC_MESSAGES:-$LANG}}"
+	if [[ "$locale_var" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+		urls+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
+	fi
+	invoke_repo_git init -b master || return 1
+	invoke_repo_git config core.autocrlf false || return 1
+	for url in "${urls[@]}"; do
+		if [ "$origin_added" -eq 0 ]; then
+			invoke_repo_git remote add origin "$url" || return 1
+			origin_added=1
+		else
+			invoke_repo_git remote set-url origin "$url" || continue
+		fi
+		if invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 git_backup_uncommitted() {
 	command -v git &>/dev/null || return 0
 	[ -d "$FOUNT_DIR/.git" ] || return 0

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -32,9 +32,12 @@ function script:fount_update_to_ref($Target) {
 	}
 	if (!(Test-Path -Path "$FOUNT_DIR/.git")) {
 		Write-Host (Get-I18n -key 'git.repoNotFound')
-		invoke_repo_git init -b master
-		invoke_repo_git config core.autocrlf false
-		invoke_repo_git remote add origin https://github.com/steve02081504/fount.git
+		git_supplement_repo
+		if ($LastExitCode -ne 0) {
+			Write-Warning (Get-I18n -key 'git.fetchFailed')
+			Write-Warning (Get-I18n -key 'git.fetchFailedSkippingUpdate')
+			return
+		}
 	}
 
 	invoke_repo_git config core.autocrlf false

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -98,7 +98,7 @@ function script:fount_update_to_ref($Target) {
 	}
 
 	# Bare ref → FETCH_HEAD; enough to resolve a commit/tag object.
-	invoke_repo_git fetch origin $Target 2>$null | Out-Null
+	git_fetch_with_fallback $Target 2>$null | Out-Null
 	$commit = invoke_repo_git rev-parse --verify "${Target}^{commit}" 2>$null
 	if ($LastExitCode -ne 0 -or -not $commit) {
 		Write-Warning (Get-I18n -key 'update.unknownTarget' -params @{ target = $Target })

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -8,7 +8,7 @@
 	deno_upgrade
 }
 
-# Switch to a remote branch tip (one-shot fetch; does not widen remote.origin.fetch).
+# 切换到远端分支尖端（一次性拉取；不扩展 remote.origin.fetch）。
 function script:fount_switch_to_branch($Target) {
 	Write-Host (Get-I18n -key 'update.switchingToBranch' -params @{ branch = $Target })
 	git_fetch_remote_branch $Target
@@ -21,7 +21,7 @@ function script:fount_switch_to_branch($Target) {
 	}
 }
 
-# Explicit target: PR → detach at head & .noupdate; branch → track tip & clear .noupdate; commit → detach & .noupdate.
+# 显式目标：PR → 分离到 head 并写 .noupdate；分支 → 跟踪尖端并清除 .noupdate；提交 → 分离并写 .noupdate。
 function script:fount_update_to_ref($Target) {
 	if (!(Get-Command git -ErrorAction SilentlyContinue)) {
 		Write-Host (Get-I18n -key 'git.notInstalledSkippingPull')
@@ -42,7 +42,7 @@ function script:fount_update_to_ref($Target) {
 
 	invoke_repo_git config core.autocrlf false
 
-	# GitHub pull request tip — pin like a commit (re-run the same command to refresh).
+	# GitHub pull request 尖端 —— 像提交一样固定（重复运行同一命令即可刷新）。
 	$prNumber = git_parse_pr_number $Target
 	if ($prNumber) {
 		Write-Host (Get-I18n -key 'update.pinningToPullRequest' -params @{ pr = $prNumber })
@@ -60,7 +60,7 @@ function script:fount_update_to_ref($Target) {
 		return
 	}
 
-	# Known locally / already tracked — refresh that one tip, no ls-remote.
+	# 本地已知/已跟踪 —— 只刷新那一个尖端，不做 ls-remote。
 	if ((git_ref_exists "origin/$Target") -or (git_ref_exists "refs/heads/$Target")) {
 		if (git_ref_exists "origin/$Target") {
 			fount_switch_to_branch $Target
@@ -83,7 +83,7 @@ function script:fount_update_to_ref($Target) {
 		return
 	}
 
-	# Unknown named target — ask origin once, then one-shot fetch if it is a branch.
+	# 未知具名目标 —— 先询问 origin 一次，若是分支再做一次性拉取。
 	$remoteStatus = git_remote_branch_status $Target
 	if ($remoteStatus -eq 2) {
 		Write-Warning (Get-I18n -key 'git.fetchFailed')
@@ -97,7 +97,7 @@ function script:fount_update_to_ref($Target) {
 		return
 	}
 
-	# Bare ref → FETCH_HEAD; enough to resolve a commit/tag object.
+	# 裸 ref → FETCH_HEAD；足以解析一个 commit/tag 对象。
 	git_fetch_with_fallback $Target 2>$null | Out-Null
 	$commit = invoke_repo_git rev-parse --verify "${Target}^{commit}" 2>$null
 	if ($LastExitCode -ne 0 -or -not $commit) {
@@ -113,7 +113,7 @@ function script:fount_update_to_ref($Target) {
 	deno_upgrade
 }
 
-# After the first successful deno upgrade, routine starts refresh in the background.
+# 首次成功升级 deno 后，例程改为在后台刷新。
 function script:update_fount_and_deno_background {
 	if (Test-Path -Path "$FOUNT_DIR/.noupdate") {
 		Write-Host (Get-I18n -key 'update.skippingFountUpdate')
@@ -121,7 +121,7 @@ function script:update_fount_and_deno_background {
 	}
 	$upgradedFlag = Join-Path $FOUNT_DIR 'data/installer/deno_upgraded'
 	if (Test-Path $upgradedFlag) {
-		# Start-Job cannot call in-process functions; re-enter via `fount update`.
+		# Start-Job 无法调用进程内函数；通过 `fount update` 重新进入。
 		Start-Job -ScriptBlock {
 			param($fountPs1)
 			& $fountPs1 update

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -60,6 +60,12 @@ function script:fount_update_to_ref($Target) {
 		return
 	}
 
+	# 远程 URL —— 把 origin 指到该远程并切到其默认分支。
+	if (git_is_remote_url $Target) {
+		fount_update_to_url $Target
+		return
+	}
+
 	# 本地已知/已跟踪 —— 只刷新那一个尖端，不做 ls-remote。
 	if ((git_ref_exists "origin/$Target") -or (git_ref_exists "refs/heads/$Target")) {
 		if (git_ref_exists "origin/$Target") {
@@ -110,6 +116,34 @@ function script:fount_update_to_ref($Target) {
 	if ($LastExitCode -ne 0) { return }
 	New-Item -Path "$FOUNT_DIR/.noupdate" -ItemType File -Force | Out-Null
 	Write-Host (Get-I18n -key 'update.createdNoUpdate')
+	deno_upgrade
+}
+
+# `fount update <remote-url>` —— 把 origin 指到该远程并切到其默认分支（随后普通更新跟随它）。
+function script:fount_update_to_url($Url) {
+	if (invoke_repo_git remote 2>$null -contains 'origin') {
+		invoke_repo_git remote set-url origin $Url
+	}
+	else {
+		invoke_repo_git remote add origin $Url
+	}
+	if ($LastExitCode -ne 0) {
+		Write-Warning (Get-I18n -key 'git.fetchFailed')
+		return
+	}
+	$symref = invoke_repo_git ls-remote --symref $Url HEAD 2>$null
+	if ($LastExitCode -ne 0) {
+		Write-Warning (Get-I18n -key 'git.fetchFailed')
+		return
+	}
+	$defaultBranch = $null
+	foreach ($line in $symref) {
+		if ($line -match '^ref:\s*refs/heads/([^\s\t]+)') { $defaultBranch = $Matches[1]; break }
+	}
+	if (-not $defaultBranch) { $defaultBranch = 'master' }
+	Write-Host (Get-I18n -key 'update.switchingToRemote' -params @{ url = $Url; branch = $defaultBranch })
+	fount_switch_to_branch $defaultBranch
+	if ($LastExitCode -ne 0) { return }
 	deno_upgrade
 }
 

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -121,6 +121,16 @@ function script:fount_update_to_ref($Target) {
 
 # `fount update <remote-url>` —— 把 origin 指到该远程并切到其默认分支（随后普通更新跟随它）。
 function script:fount_update_to_url($Url) {
+	$symref = invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 ls-remote --symref $Url HEAD 2>$null
+	if ($LastExitCode -ne 0) {
+		Write-Warning (Get-I18n -key 'git.fetchFailed')
+		return
+	}
+	$defaultBranch = $null
+	foreach ($line in $symref) {
+		if ($line -match '^ref:\s*refs/heads/([^\s\t]+)') { $defaultBranch = $Matches[1]; break }
+	}
+	if (-not $defaultBranch) { $defaultBranch = 'master' }
 	if (invoke_repo_git remote 2>$null -contains 'origin') {
 		invoke_repo_git remote set-url origin $Url
 	}
@@ -131,16 +141,6 @@ function script:fount_update_to_url($Url) {
 		Write-Warning (Get-I18n -key 'git.fetchFailed')
 		return
 	}
-	$symref = invoke_repo_git ls-remote --symref $Url HEAD 2>$null
-	if ($LastExitCode -ne 0) {
-		Write-Warning (Get-I18n -key 'git.fetchFailed')
-		return
-	}
-	$defaultBranch = $null
-	foreach ($line in $symref) {
-		if ($line -match '^ref:\s*refs/heads/([^\s\t]+)') { $defaultBranch = $Matches[1]; break }
-	}
-	if (-not $defaultBranch) { $defaultBranch = 'master' }
 	fount_switch_to_branch $defaultBranch
 	if ($LastExitCode -ne 0) { return }
 	deno_upgrade

--- a/path/src/update.ps1
+++ b/path/src/update.ps1
@@ -141,7 +141,6 @@ function script:fount_update_to_url($Url) {
 		if ($line -match '^ref:\s*refs/heads/([^\s\t]+)') { $defaultBranch = $Matches[1]; break }
 	}
 	if (-not $defaultBranch) { $defaultBranch = 'master' }
-	Write-Host (Get-I18n -key 'update.switchingToRemote' -params @{ url = $Url; branch = $defaultBranch })
 	fount_switch_to_branch $defaultBranch
 	if ($LastExitCode -ne 0) { return }
 	deno_upgrade

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -209,7 +209,7 @@ fount_update_to_ref() {
 	fi
 
 	# Bare ref → FETCH_HEAD; enough to resolve a commit/tag object.
-	invoke_repo_git fetch origin "$target" 2>/dev/null || true
+	git_fetch_with_fallback "$target" 2>/dev/null || true
 	commit=$(invoke_repo_git rev-parse --verify "${target}^{commit}" 2>/dev/null) || {
 		print_i18n_yellow 'update.unknownTarget' 'target' "$target" >&2
 		return 1

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -232,13 +232,15 @@ fount_update_to_ref() {
 fount_update_to_url() {
 	local url="$1" default_branch symref
 	if invoke_repo_git remote | grep -qx origin; then
-		invoke_repo_git remote set-url origin "$url"
+		if ! invoke_repo_git remote set-url origin "$url"; then
+			print_i18n_yellow 'git.fetchFailed' >&2
+			return 1
+		fi
 	else
-		invoke_repo_git remote add origin "$url"
-	fi
-	if [ "$?" -ne 0 ]; then
-		print_i18n_yellow 'git.fetchFailed' >&2
-		return 1
+		if ! invoke_repo_git remote add origin "$url"; then
+			print_i18n_yellow 'git.fetchFailed' >&2
+			return 1
+		fi
 	fi
 	symref=$(invoke_repo_git ls-remote --symref "$url" HEAD 2>/dev/null) || {
 		print_i18n_yellow 'git.fetchFailed' >&2

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -45,7 +45,7 @@ fount_upgrade() {
 	if git config --global --get-all safe.directory | grep -q -xF "$FOUNT_DIR"; then : else
 		git config --global --add safe.directory "$FOUNT_DIR"
 	fi
-	if [ ! -d "$FOUNT_DIR/.git" ]; then
+	if [ ! -e "$FOUNT_DIR/.git" ]; then
 		get_i18n 'git.repoNotFound'
 		get_i18n 'git.fetchingAndResetting'
 		if ! git_supplement_repo; then
@@ -149,7 +149,7 @@ fount_update_to_ref() {
 	if git config --global --get-all safe.directory | grep -q -xF "$FOUNT_DIR"; then : else
 		git config --global --add safe.directory "$FOUNT_DIR"
 	fi
-	if [ ! -d "$FOUNT_DIR/.git" ]; then
+	if [ ! -e "$FOUNT_DIR/.git" ]; then
 		get_i18n 'git.repoNotFound'
 		if ! git_supplement_repo; then
 			print_i18n_yellow 'git.fetchFailed' >&2

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -230,7 +230,7 @@ fount_update_to_ref() {
 
 # `fount update <remote-url>` —— 把 origin 指到该远程并切到其默认分支（随后普通更新跟随它）。
 fount_update_to_url() {
-	local url="$1" default_branch symref
+	local url="$1" default_branch
 	if invoke_repo_git remote | grep -qx origin; then
 		if ! invoke_repo_git remote set-url origin "$url"; then
 			print_i18n_yellow 'git.fetchFailed' >&2
@@ -242,11 +242,11 @@ fount_update_to_url() {
 			return 1
 		fi
 	fi
-	symref=$(invoke_repo_git ls-remote --symref "$url" HEAD 2>/dev/null) || {
+	if ! default_branch=$(invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 ls-remote --symref "$url" HEAD 2>/dev/null); then
 		print_i18n_yellow 'git.fetchFailed' >&2
 		return 1
-	}
-	default_branch=$(printf '%s\n' "$symref" | sed -n 's/^ref: refs\/heads\///p' | head -n 1)
+	fi
+	default_branch=$(printf '%s\n' "$default_branch" | sed -n 's/^ref: refs\/heads\/\([^[:space:]]*\).*/\1/p' | head -n 1)
 	[ -z "$default_branch" ] && default_branch=master
 	get_i18n 'update.switchingToRemote' 'url' "$url" 'branch' "$default_branch"
 	fount_switch_to_branch "$default_branch" || return 1

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -231,6 +231,12 @@ fount_update_to_ref() {
 # `fount update <remote-url>` —— 把 origin 指到该远程并切到其默认分支（随后普通更新跟随它）。
 fount_update_to_url() {
 	local url="$1" default_branch
+	if ! default_branch=$(invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 ls-remote --symref "$url" HEAD 2>/dev/null); then
+		print_i18n_yellow 'git.fetchFailed' >&2
+		return 1
+	fi
+	default_branch=$(printf '%s\n' "$default_branch" | sed -n 's/^ref: refs\/heads\/\([^[:space:]]*\).*/\1/p' | head -n 1)
+	[ -z "$default_branch" ] && default_branch=master
 	if invoke_repo_git remote | grep -qx origin; then
 		if ! invoke_repo_git remote set-url origin "$url"; then
 			print_i18n_yellow 'git.fetchFailed' >&2
@@ -242,12 +248,6 @@ fount_update_to_url() {
 			return 1
 		fi
 	fi
-	if ! default_branch=$(invoke_repo_git -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 ls-remote --symref "$url" HEAD 2>/dev/null); then
-		print_i18n_yellow 'git.fetchFailed' >&2
-		return 1
-	fi
-	default_branch=$(printf '%s\n' "$default_branch" | sed -n 's/^ref: refs\/heads\/\([^[:space:]]*\).*/\1/p' | head -n 1)
-	[ -z "$default_branch" ] && default_branch=master
 	get_i18n 'update.switchingToRemote' 'url' "$url" 'branch' "$default_branch"
 	fount_switch_to_branch "$default_branch" || return 1
 	deno_upgrade

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -175,6 +175,12 @@ fount_update_to_ref() {
 		return
 	fi
 
+	# 远程 URL —— 把 origin 指到该远程并切到其默认分支。
+	if git_is_remote_url "$target"; then
+		fount_update_to_url "$target"
+		return
+	fi
+
 	# 本地已知/已跟踪 —— 只刷新那一个尖端，不做 ls-remote。
 	if git_ref_exists "origin/$target" || git_ref_exists "refs/heads/$target"; then
 		if git_ref_exists "origin/$target"; then
@@ -219,6 +225,29 @@ fount_update_to_ref() {
 	git_detach_to_ref "$commit" || return 1
 	: >"$FOUNT_DIR/.noupdate"
 	get_i18n 'update.createdNoUpdate'
+	deno_upgrade
+}
+
+# `fount update <remote-url>` —— 把 origin 指到该远程并切到其默认分支（随后普通更新跟随它）。
+fount_update_to_url() {
+	local url="$1" default_branch symref
+	if invoke_repo_git remote | grep -qx origin; then
+		invoke_repo_git remote set-url origin "$url"
+	else
+		invoke_repo_git remote add origin "$url"
+	fi
+	if [ "$?" -ne 0 ]; then
+		print_i18n_yellow 'git.fetchFailed' >&2
+		return 1
+	fi
+	symref=$(invoke_repo_git ls-remote --symref "$url" HEAD 2>/dev/null) || {
+		print_i18n_yellow 'git.fetchFailed' >&2
+		return 1
+	}
+	default_branch=$(printf '%s\n' "$symref" | sed -n 's/^ref: refs\/heads\///p' | head -n 1)
+	[ -z "$default_branch" ] && default_branch=master
+	get_i18n 'update.switchingToRemote' 'url' "$url" 'branch' "$default_branch"
+	fount_switch_to_branch "$default_branch" || return 1
 	deno_upgrade
 }
 

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -47,11 +47,8 @@ fount_upgrade() {
 	fi
 	if [ ! -d "$FOUNT_DIR/.git" ]; then
 		get_i18n 'git.repoNotFound'
-		invoke_repo_git init -b master
-		invoke_repo_git config core.autocrlf false
-		invoke_repo_git remote add origin https://github.com/steve02081504/fount.git || true
 		get_i18n 'git.fetchingAndResetting'
-		if ! invoke_repo_git fetch origin master --depth 1; then
+		if ! git_supplement_repo; then
 			print_i18n_yellow 'git.fetchFailed' >&2
 			print_i18n_yellow 'git.fetchFailedSkippingUpdate' >&2
 			return 1

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -151,9 +151,11 @@ fount_update_to_ref() {
 	fi
 	if [ ! -d "$FOUNT_DIR/.git" ]; then
 		get_i18n 'git.repoNotFound'
-		invoke_repo_git init -b master
-		invoke_repo_git config core.autocrlf false
-		invoke_repo_git remote add origin https://github.com/steve02081504/fount.git || true
+		if ! git_supplement_repo; then
+			print_i18n_yellow 'git.fetchFailed' >&2
+			print_i18n_yellow 'git.fetchFailedSkippingUpdate' >&2
+			return 1
+		fi
 	fi
 
 	invoke_repo_git config core.autocrlf false

--- a/path/src/update.sh
+++ b/path/src/update.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# fount self-update via git + deno upgrade
+# 通过 git + deno 升级完成 fount 自更新
 
-# Refresh origin/<branch> only. On failure, ls-remote to tell deleted vs network.
-# Sets remoteBranch=origin/<branch> on success. Falls back to master when branch is gone.
+# 只刷新 origin/<branch>。失败时用 ls-remote 区分已删除与网络问题。
+# 成功时设置 remoteBranch=origin/<branch>。分支消失时回退到 master。
 fount_resolve_upstream() {
 	local branch="$1" remote_status had_upstream
 	had_upstream=$(invoke_repo_git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null) || had_upstream=
@@ -19,7 +19,7 @@ fount_resolve_upstream() {
 	git_remote_branch_status "$branch"
 	remote_status=$?
 	if [ "$remote_status" -eq 2 ] || [ "$remote_status" -eq 0 ]; then
-		# Network error, or exists but fetch failed — never treat as deleted.
+		# 网络错误，或存在但拉取失败 —— 绝不当作已删除。
 		print_i18n_yellow 'git.fetchFailed' >&2
 		print_i18n_yellow 'git.fetchFailedSkippingUpdate' >&2
 		return 1
@@ -120,7 +120,7 @@ fount_upgrade() {
 	fi
 }
 
-# Foreground fount + deno upgrade.
+# 前台执行 fount + deno 升级。
 update_fount_and_deno() {
 	if [ -f "$FOUNT_DIR/.noupdate" ]; then
 		get_i18n 'update.skippingFountUpdate'
@@ -130,7 +130,7 @@ update_fount_and_deno() {
 	deno_upgrade
 }
 
-# Switch to a remote branch tip (one-shot fetch; does not widen remote.origin.fetch).
+# 切换到远端分支尖端（一次性拉取；不扩展 remote.origin.fetch）。
 fount_switch_to_branch() {
 	local target="$1"
 	get_i18n 'update.switchingToBranch' 'branch' "$target"
@@ -142,7 +142,7 @@ fount_switch_to_branch() {
 	fi
 }
 
-# Explicit target: PR → detach at head & .noupdate; branch → track tip & clear .noupdate; commit → detach & .noupdate.
+# 显式目标：PR → 分离到 head 并写 .noupdate；分支 → 跟踪尖端并清除 .noupdate；提交 → 分离并写 .noupdate。
 fount_update_to_ref() {
 	local target="$1" commit remote_status pr_number
 	install_package "git" "git" || return 0
@@ -160,7 +160,7 @@ fount_update_to_ref() {
 
 	invoke_repo_git config core.autocrlf false
 
-	# GitHub pull request tip — pin like a commit (re-run the same command to refresh).
+	# GitHub pull request 尖端 —— 像提交一样固定（重复运行同一命令即可刷新）。
 	if pr_number=$(git_parse_pr_number "$target"); then
 		get_i18n 'update.pinningToPullRequest' 'pr' "$pr_number"
 		if ! git_fetch_pull_request "$pr_number"; then
@@ -175,7 +175,7 @@ fount_update_to_ref() {
 		return
 	fi
 
-	# Known locally / already tracked — refresh that one tip, no ls-remote.
+	# 本地已知/已跟踪 —— 只刷新那一个尖端，不做 ls-remote。
 	if git_ref_exists "origin/$target" || git_ref_exists "refs/heads/$target"; then
 		if git_ref_exists "origin/$target"; then
 			fount_switch_to_branch "$target" || return 1
@@ -194,7 +194,7 @@ fount_update_to_ref() {
 		return
 	fi
 
-	# Unknown named target — ask origin once, then one-shot fetch if it is a branch.
+	# 未知具名目标 —— 先询问 origin 一次，若是分支再做一次性拉取。
 	git_remote_branch_status "$target"
 	remote_status=$?
 	if [ "$remote_status" -eq 2 ]; then
@@ -208,7 +208,7 @@ fount_update_to_ref() {
 		return
 	fi
 
-	# Bare ref → FETCH_HEAD; enough to resolve a commit/tag object.
+	# 裸 ref → FETCH_HEAD；足以解析一个 commit/tag 对象。
 	git_fetch_with_fallback "$target" 2>/dev/null || true
 	commit=$(invoke_repo_git rev-parse --verify "${target}^{commit}" 2>/dev/null) || {
 		print_i18n_yellow 'update.unknownTarget' 'target' "$target" >&2
@@ -222,7 +222,7 @@ fount_update_to_ref() {
 	deno_upgrade
 }
 
-# After the first successful deno upgrade, routine starts refresh in the background.
+# 首次成功升级 deno 后，例程改为在后台刷新。
 update_fount_and_deno_background() {
 	if [ -f "$FOUNT_DIR/.noupdate" ]; then
 		get_i18n 'update.skippingFountUpdate'

--- a/path/test/git.test.mjs
+++ b/path/test/git.test.mjs
@@ -302,6 +302,61 @@ foreach ($base64Name in $encoded) {
 })
 
 /**
+ * git_supplement_repo：非受限区只用 github 源，CN/KP/RU 追加镜像，
+ * 且 fetch 都带 low-speed 超时。通过 stub invoke_repo_git 做隔离断言。
+ */
+Deno.test('git_supplement_repo wires origin and fetches master with low-speed timeout', async () => {
+	const primaryUrl = 'https://github.com/steve02081504/fount.git'
+	const proxyUrl = 'https://gh-proxy.org/github.com/steve02081504/fount.git'
+	const gitcloneUrl = 'https://gitclone.com/github.com/steve02081504/fount.git'
+
+	/**
+	 * 在 stub invoke_repo_git 下跑 git_supplement_repo 并返回记录的命令序列。
+	 * `minFetch` = 第几个 fetch 调用开始成功；更早的 fetch 视为失败（模拟 github.com 慢）。
+	 * @param {string} lang LANG/LC_ALL 值，控制镜像分支
+	 * @param {number} minFetch 成功所需的最小 fetch 序号
+	 * @returns {Promise<{code: number, stdout: string, stderr: string}>} exec 结果
+	 */
+	const run = (lang, minFetch) => bash_exec(`
+		set -euo pipefail
+		. ${JSON.stringify(gitShPath)}
+		LC_ALL=${JSON.stringify(lang)} export LC_ALL
+		calls=() fetchCount=0
+		invoke_repo_git() {
+			calls+=("$*")
+			case " $* " in
+				*" fetch "*) fetchCount=$((fetchCount + 1)); [ "$fetchCount" -ge ${minFetch} ] ;;
+				*) return 0 ;;
+			esac
+		}
+		git_supplement_repo
+		printf '%s\\n' "${'$'}{calls[@]}"
+	`)
+
+	const primary = await run('en_US.UTF-8', 1)
+	assertEquals(primary.code, 0, primary.stderr || primary.stdout)
+	const primaryCalls = primary.stdout.trim().split(/\r?\n/)
+	assertStringIncludes(primaryCalls[0], 'init -b master')
+	assertStringIncludes(primaryCalls[1], 'config core.autocrlf false')
+	assertStringIncludes(primaryCalls[2], `remote add origin ${primaryUrl}`)
+	assertStringIncludes(
+		primaryCalls[3],
+		'-c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1',
+	)
+
+	// CN locale: primary fetch fails, then gh-proxy fails, finally gitclone succeeds.
+	const mirror = await run('zh_CN.UTF-8', 3)
+	assertEquals(mirror.code, 0, mirror.stderr || mirror.stdout)
+	const mirrorCalls = mirror.stdout.trim().split(/\r?\n/)
+	assertStringIncludes(mirrorCalls[2], `remote add origin ${primaryUrl}`)
+	assertStringIncludes(mirrorCalls[3], '-c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1')
+	assertStringIncludes(mirrorCalls[4], `remote set-url origin ${proxyUrl}`)
+	assertStringIncludes(mirrorCalls[5], '-c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1')
+	assertStringIncludes(mirrorCalls[6], `remote set-url origin ${gitcloneUrl}`)
+	assertStringIncludes(mirrorCalls[7], '-c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 fetch origin master --depth 1')
+})
+
+/**
  * 单分支 clone + one-shot fetch 场景：`branch --set-upstream-to` 会 fatal；
  * git_checkout_branch 必须补上该 head 的 fetch refspec（非 *）并建好 @{u}。
  */

--- a/src/decl/locale_data.ts
+++ b/src/decl/locale_data.ts
@@ -372,6 +372,7 @@ export type LocaleData = {
 			update: {
 				skippingFountUpdate: string
 				switchingToBranch: string
+				switchingToRemote: string
 				removedNoUpdate: string
 				pinningToCommit: string
 				pinningToPullRequest: string
@@ -6303,6 +6304,7 @@ export type LocaleKeyParams = {
 	'fountConsole.path.update.pinningToCommit': { ref: string | number }
 	'fountConsole.path.update.pinningToPullRequest': { pr: string | number }
 	'fountConsole.path.update.switchingToBranch': { branch: string | number }
+	'fountConsole.path.update.switchingToRemote': { branch: string | number; url: string | number }
 	'fountConsole.path.update.unknownTarget': { target: string | number }
 	'fountConsole.path.version.branch.title': { branch: string | number }
 	'fountConsole.path.version.commit': { ref: string | number }

--- a/src/public/locales/ar-SA.json
+++ b/src/public/locales/ar-SA.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "نظرًا لوجود الملف ‎`.noupdate`، يتم تخطي تحديث fount",
 				"switchingToBranch": "جارٍ التبديل إلى الفرع «${branch}»…",
+				"switchingToRemote": "التبديل إلى الفرع الافتراضي \"${url}\" للفرع البعيد \"${branch}\"...",
 				"removedNoUpdate": "تمت إزالة `.noupdate`؛ استُعيدت التحديثات التلقائية.",
 				"pinningToCommit": "جارٍ التثبيت على الالتزام `${ref}` وإنشاء `.noupdate`…",
 				"pinningToPullRequest": "جارٍ التثبيت على طلب السحب #${pr} وإنشاء `.noupdate`…",

--- a/src/public/locales/ar-SA.json
+++ b/src/public/locales/ar-SA.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "نظرًا لوجود الملف ‎`.noupdate`، يتم تخطي تحديث fount",
 				"switchingToBranch": "جارٍ التبديل إلى الفرع «${branch}»…",
-				"switchingToRemote": "التبديل إلى الفرع الافتراضي \"${url}\" للفرع البعيد \"${branch}\"...",
+				"switchingToRemote": "جارٍ التبديل إلى الفرع الافتراضي «${branch}» من المستودع البعيد «${url}»…",
 				"removedNoUpdate": "تمت إزالة `.noupdate`؛ استُعيدت التحديثات التلقائية.",
 				"pinningToCommit": "جارٍ التثبيت على الالتزام `${ref}` وإنشاء `.noupdate`…",
 				"pinningToPullRequest": "جارٍ التثبيت على طلب السحب #${pr} وإنشاء `.noupdate`…",

--- a/src/public/locales/de-DE.json
+++ b/src/public/locales/de-DE.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Da die Datei `.noupdate` vorhanden ist, wird die Aktualisierung der fount übersprungen",
 				"switchingToBranch": "Wechsle zu Branch '${branch}' …",
-				"switchingToRemote": "Wechsel zum Standardzweig „${url}“ von Remote „${branch}“ ...",
+				"switchingToRemote": "Wechsle zum Standard-Branch '${branch}' von Remote '${url}'…",
 				"removedNoUpdate": "`.noupdate` entfernt; automatische Updates wieder aktiv.",
 				"pinningToCommit": "Commit `${ref}` wird festgesetzt und `.noupdate` erstellt …",
 				"pinningToPullRequest": "Pull Request #${pr} wird festgesetzt und `.noupdate` erstellt …",

--- a/src/public/locales/de-DE.json
+++ b/src/public/locales/de-DE.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Da die Datei `.noupdate` vorhanden ist, wird die Aktualisierung der fount übersprungen",
 				"switchingToBranch": "Wechsle zu Branch '${branch}' …",
+				"switchingToRemote": "Wechsel zum Standardzweig „${url}“ von Remote „${branch}“ ...",
 				"removedNoUpdate": "`.noupdate` entfernt; automatische Updates wieder aktiv.",
 				"pinningToCommit": "Commit `${ref}` wird festgesetzt und `.noupdate` erstellt …",
 				"pinningToPullRequest": "Pull Request #${pr} wird festgesetzt und `.noupdate` erstellt …",

--- a/src/public/locales/emoji.json
+++ b/src/public/locales/emoji.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "⏭️ ⛲ ⏫",
 				"switchingToBranch": "🔀🌿 '${branch}'…",
-				"switchingToRemote": "正在切换到远程「${url}」的默认分支「${branch}」…",
+				"switchingToRemote": "🔀🌐 '${url}' ➡️🌿 '${branch}'…",
 				"removedNoUpdate": "🗑️ `.noupdate` ➡️ ▶️⏫",
 				"pinningToCommit": "📌 `${ref}` ➕ `.noupdate`…",
 				"pinningToPullRequest": "📌 PR#${pr} ➕ `.noupdate`…",

--- a/src/public/locales/emoji.json
+++ b/src/public/locales/emoji.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "⏭️ ⛲ ⏫",
 				"switchingToBranch": "🔀🌿 '${branch}'…",
+				"switchingToRemote": "正在切换到远程「${url}」的默认分支「${branch}」…",
 				"removedNoUpdate": "🗑️ `.noupdate` ➡️ ▶️⏫",
 				"pinningToCommit": "📌 `${ref}` ➕ `.noupdate`…",
 				"pinningToPullRequest": "📌 PR#${pr} ➕ `.noupdate`…",

--- a/src/public/locales/en-UK.json
+++ b/src/public/locales/en-UK.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Because the `.noupdate` file exists, the fount update is skipped",
 				"switchingToBranch": "Switching to branch '${branch}'…",
+				"switchingToRemote": "Switching to the default branch '${branch}' of remote '${url}'…",
 				"removedNoUpdate": "Removed `.noupdate`; automatic updates resumed.",
 				"pinningToCommit": "Pinning to commit `${ref}` and creating `.noupdate`…",
 				"pinningToPullRequest": "Pinning to pull request #${pr} and creating `.noupdate`…",

--- a/src/public/locales/es-ES.json
+++ b/src/public/locales/es-ES.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Debido a que el archivo `.noupdate` existe, se omite la actualización de la fount",
 				"switchingToBranch": "Cambiando a la rama «${branch}»…",
-				"switchingToRemote": "Cambiando a la rama predeterminada \"${url}\" del control remoto \"${branch}\"...",
+				"switchingToRemote": "Cambiando a la rama predeterminada «${branch}» del repositorio remoto «${url}»…",
 				"removedNoUpdate": "Se eliminó `.noupdate`; actualizaciones automáticas reactivadas.",
 				"pinningToCommit": "Fijando al commit `${ref}` y creando `.noupdate`…",
 				"pinningToPullRequest": "Fijando a la pull request #${pr} y creando `.noupdate`…",

--- a/src/public/locales/es-ES.json
+++ b/src/public/locales/es-ES.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Debido a que el archivo `.noupdate` existe, se omite la actualización de la fount",
 				"switchingToBranch": "Cambiando a la rama «${branch}»…",
+				"switchingToRemote": "Cambiando a la rama predeterminada \"${url}\" del control remoto \"${branch}\"...",
 				"removedNoUpdate": "Se eliminó `.noupdate`; actualizaciones automáticas reactivadas.",
 				"pinningToCommit": "Fijando al commit `${ref}` y creando `.noupdate`…",
 				"pinningToPullRequest": "Fijando a la pull request #${pr} y creando `.noupdate`…",

--- a/src/public/locales/fr-FR.json
+++ b/src/public/locales/fr-FR.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Étant donné que le fichier `.noupdate` existe, la mise à jour des founts est ignorée",
 				"switchingToBranch": "Basculement vers la branche « ${branch} »…",
-				"switchingToRemote": "Passage à la branche par défaut \"${url}\" de la télécommande \"${branch}\"...",
+				"switchingToRemote": "Passage à la branche par défaut « ${branch} » du dépôt distant « ${url} »…",
 				"removedNoUpdate": "`.noupdate` supprimé ; mises à jour automatiques réactivées.",
 				"pinningToCommit": "Fixation au commit `${ref}` et création de `.noupdate`…",
 				"pinningToPullRequest": "Fixation sur la pull request n° ${pr} et création de `.noupdate`…",

--- a/src/public/locales/fr-FR.json
+++ b/src/public/locales/fr-FR.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Étant donné que le fichier `.noupdate` existe, la mise à jour des founts est ignorée",
 				"switchingToBranch": "Basculement vers la branche « ${branch} »…",
+				"switchingToRemote": "Passage à la branche par défaut \"${url}\" de la télécommande \"${branch}\"...",
 				"removedNoUpdate": "`.noupdate` supprimé ; mises à jour automatiques réactivées.",
 				"pinningToCommit": "Fixation au commit `${ref}` et création de `.noupdate`…",
 				"pinningToPullRequest": "Fixation sur la pull request n° ${pr} et création de `.noupdate`…",

--- a/src/public/locales/hi-IN.json
+++ b/src/public/locales/hi-IN.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "चूँकि `.noupdate` फ़ाइल मौजूद है, इसलिए fount अपडेट छोड़ दिया गया है",
 				"switchingToBranch": "शाखा '${branch}' पर स्विच किया जा रहा है…",
-				"switchingToRemote": "दूरस्थ \"${url}\" की डिफ़ॉल्ट शाखा \"${branch}\" पर स्विच किया जा रहा है...",
+				"switchingToRemote": "दूरस्थ '${url}' की डिफ़ॉल्ट शाखा '${branch}' पर स्विच किया जा रहा है…",
 				"removedNoUpdate": "`.noupdate` हटाया गया; स्वचालित अपडेट फिर से शुरू हो गए।",
 				"pinningToCommit": "कमिट `${ref}` पर पिन किया जा रहा है और `.noupdate` बनाया जा रहा है…",
 				"pinningToPullRequest": "पुल अनुरोध #${pr} पर पिन किया जा रहा है और `.noupdate` बनाया जा रहा है…",

--- a/src/public/locales/hi-IN.json
+++ b/src/public/locales/hi-IN.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "चूँकि `.noupdate` फ़ाइल मौजूद है, इसलिए fount अपडेट छोड़ दिया गया है",
 				"switchingToBranch": "शाखा '${branch}' पर स्विच किया जा रहा है…",
+				"switchingToRemote": "दूरस्थ \"${url}\" की डिफ़ॉल्ट शाखा \"${branch}\" पर स्विच किया जा रहा है...",
 				"removedNoUpdate": "`.noupdate` हटाया गया; स्वचालित अपडेट फिर से शुरू हो गए।",
 				"pinningToCommit": "कमिट `${ref}` पर पिन किया जा रहा है और `.noupdate` बनाया जा रहा है…",
 				"pinningToPullRequest": "पुल अनुरोध #${pr} पर पिन किया जा रहा है और `.noupdate` बनाया जा रहा है…",

--- a/src/public/locales/is-IS.json
+++ b/src/public/locales/is-IS.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Þar sem `.noupdate` skráin er til er leturuppfærslunni sleppt",
 				"switchingToBranch": "Skiptir yfir á grein '${branch}'…",
-				"switchingToRemote": "Skiptir yfir í sjálfgefna útibú „${url}“ á fjarstýringu „${branch}“...",
+				"switchingToRemote": "Skiptir yfir í sjálfgefnu greinina '${branch}' á fjarræna geymslunni '${url}'…",
 				"removedNoUpdate": "`.noupdate` fjarlægt; sjálfvirkar uppfærslur hafnar aftur.",
 				"pinningToCommit": "Festir á commit `${ref}` og býr til `.noupdate`…",
 				"pinningToPullRequest": "Festir á pull request #${pr} og býr til `.noupdate`…",

--- a/src/public/locales/is-IS.json
+++ b/src/public/locales/is-IS.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Þar sem `.noupdate` skráin er til er leturuppfærslunni sleppt",
 				"switchingToBranch": "Skiptir yfir á grein '${branch}'…",
+				"switchingToRemote": "Skiptir yfir í sjálfgefna útibú „${url}“ á fjarstýringu „${branch}“...",
 				"removedNoUpdate": "`.noupdate` fjarlægt; sjálfvirkar uppfærslur hafnar aftur.",
 				"pinningToCommit": "Festir á commit `${ref}` og býr til `.noupdate`…",
 				"pinningToPullRequest": "Festir á pull request #${pr} og býr til `.noupdate`…",

--- a/src/public/locales/it-IT.json
+++ b/src/public/locales/it-IT.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Poiché il file `.noupdate` esiste, l'aggiornamento del fount viene ignorato",
 				"switchingToBranch": "Passaggio al ramo «${branch}»…",
-				"switchingToRemote": "Passaggio al ramo predefinito \"${url}\" del remoto \"${branch}\"...",
+				"switchingToRemote": "Passaggio al ramo predefinito «${branch}» del remoto «${url}»…",
 				"removedNoUpdate": "Rimosso `.noupdate`; aggiornamenti automatici ripristinati.",
 				"pinningToCommit": "Fissaggio al commit `${ref}` e creazione di `.noupdate`…",
 				"pinningToPullRequest": "Fissaggio alla pull request #${pr} e creazione di `.noupdate`…",

--- a/src/public/locales/it-IT.json
+++ b/src/public/locales/it-IT.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Poiché il file `.noupdate` esiste, l'aggiornamento del fount viene ignorato",
 				"switchingToBranch": "Passaggio al ramo «${branch}»…",
+				"switchingToRemote": "Passaggio al ramo predefinito \"${url}\" del remoto \"${branch}\"...",
 				"removedNoUpdate": "Rimosso `.noupdate`; aggiornamenti automatici ripristinati.",
 				"pinningToCommit": "Fissaggio al commit `${ref}` e creazione di `.noupdate`…",
 				"pinningToPullRequest": "Fissaggio alla pull request #${pr} e creazione di `.noupdate`…",

--- a/src/public/locales/ja-JP.json
+++ b/src/public/locales/ja-JP.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "`.noupdate` ファイルが存在するため、fountの更新はスキップされます",
 				"switchingToBranch": "ブランチ「${branch}」に切り替えています…",
+				"switchingToRemote": "リモート「${url}」のデフォルトブランチ「${branch}」に切り替えています...",
 				"removedNoUpdate": "`.noupdate` を削除しました。自動更新を再開します。",
 				"pinningToCommit": "コミット `${ref}` に固定し、`.noupdate` を作成しています…",
 				"pinningToPullRequest": "プルリクエスト #${pr} に固定し、`.noupdate` を作成しています…",

--- a/src/public/locales/ja-JP.json
+++ b/src/public/locales/ja-JP.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "`.noupdate` ファイルが存在するため、fountの更新はスキップされます",
 				"switchingToBranch": "ブランチ「${branch}」に切り替えています…",
-				"switchingToRemote": "リモート「${url}」のデフォルトブランチ「${branch}」に切り替えています...",
+				"switchingToRemote": "リモート「${url}」のデフォルトブランチ「${branch}」に切り替えています…",
 				"removedNoUpdate": "`.noupdate` を削除しました。自動更新を再開します。",
 				"pinningToCommit": "コミット `${ref}` に固定し、`.noupdate` を作成しています…",
 				"pinningToPullRequest": "プルリクエスト #${pr} に固定し、`.noupdate` を作成しています…",

--- a/src/public/locales/ko-KR.json
+++ b/src/public/locales/ko-KR.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "`.noupdate` 파일이 존재하므로 fount 업데이트를 건너뜁니다.",
 				"switchingToBranch": "'${branch}' 브랜치로 전환 중…",
-				"switchingToRemote": "원격 \"${url}\"의 기본 분기 \"${branch}\"로 전환 중...",
+				"switchingToRemote": "원격 '${url}'의 기본 브랜치 '${branch}'로 전환 중…",
 				"removedNoUpdate": "`.noupdate`를 제거했습니다. 자동 업데이트가 재개됩니다.",
 				"pinningToCommit": "커밋 `${ref}`에 고정하고 `.noupdate`를 생성하는 중…",
 				"pinningToPullRequest": "풀 리퀘스트 #${pr}에 고정하고 `.noupdate`를 생성하는 중…",

--- a/src/public/locales/ko-KR.json
+++ b/src/public/locales/ko-KR.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "`.noupdate` 파일이 존재하므로 fount 업데이트를 건너뜁니다.",
 				"switchingToBranch": "'${branch}' 브랜치로 전환 중…",
+				"switchingToRemote": "원격 \"${url}\"의 기본 분기 \"${branch}\"로 전환 중...",
 				"removedNoUpdate": "`.noupdate`를 제거했습니다. 자동 업데이트가 재개됩니다.",
 				"pinningToCommit": "커밋 `${ref}`에 고정하고 `.noupdate`를 생성하는 중…",
 				"pinningToPullRequest": "풀 리퀘스트 #${pr}에 고정하고 `.noupdate`를 생성하는 중…",

--- a/src/public/locales/lzh.json
+++ b/src/public/locales/lzh.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "因有 `.noupdate` 檔，fount 之更暫略",
 				"switchingToBranch": "正轉至分支「${branch}」…",
-				"switchingToRemote": "正在切换到远程「${url}」的默认分支「${branch}」…",
+				"switchingToRemote": "正轉至遠端「${url}」之默認分支「${branch}」…",
 				"removedNoUpdate": "已刪 `.noupdate` 檔，自動更新復行。",
 				"pinningToCommit": "正固定於提交「${ref}」，並立 `.noupdate` 檔…",
 				"pinningToPullRequest": "正固定於拉取請求 #${pr}，並立 `.noupdate` 檔…",

--- a/src/public/locales/lzh.json
+++ b/src/public/locales/lzh.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "因有 `.noupdate` 檔，fount 之更暫略",
 				"switchingToBranch": "正轉至分支「${branch}」…",
+				"switchingToRemote": "正在切换到远程「${url}」的默认分支「${branch}」…",
 				"removedNoUpdate": "已刪 `.noupdate` 檔，自動更新復行。",
 				"pinningToCommit": "正固定於提交「${ref}」，並立 `.noupdate` 檔…",
 				"pinningToPullRequest": "正固定於拉取請求 #${pr}，並立 `.noupdate` 檔…",

--- a/src/public/locales/nl-NL.json
+++ b/src/public/locales/nl-NL.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Omdat het `.noupdate`-bestand bestaat, wordt de fount-update overgeslagen",
 				"switchingToBranch": "Schakelen naar branch '${branch}'…",
+				"switchingToRemote": "Overschakelen naar de standaardvertakking \"${url}\" van externe \"${branch}\"...",
 				"removedNoUpdate": "`.noupdate` verwijderd; automatische updates hervat.",
 				"pinningToCommit": "Vastzetten op commit `${ref}` en `.noupdate` aanmaken…",
 				"pinningToPullRequest": "Vastzetten op pull request #${pr} en `.noupdate` aanmaken…",

--- a/src/public/locales/nl-NL.json
+++ b/src/public/locales/nl-NL.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Omdat het `.noupdate`-bestand bestaat, wordt de fount-update overgeslagen",
 				"switchingToBranch": "Schakelen naar branch '${branch}'…",
-				"switchingToRemote": "Overschakelen naar de standaardvertakking \"${url}\" van externe \"${branch}\"...",
+				"switchingToRemote": "Overschakelen naar de standaard branch '${branch}' van de remote '${url}'…",
 				"removedNoUpdate": "`.noupdate` verwijderd; automatische updates hervat.",
 				"pinningToCommit": "Vastzetten op commit `${ref}` en `.noupdate` aanmaken…",
 				"pinningToPullRequest": "Vastzetten op pull request #${pr} en `.noupdate` aanmaken…",

--- a/src/public/locales/pt-PT.json
+++ b/src/public/locales/pt-PT.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Como o arquivo `.noupdate` existe, a atualização da fount é ignorada",
 				"switchingToBranch": "Mudando para o ramo «${branch}»…",
-				"switchingToRemote": "Mudando para o branch padrão \"${url}\" do remoto \"${branch}\"...",
+				"switchingToRemote": "Mudando para o ramo predefinido «${branch}» do remoto «${url}»…",
 				"removedNoUpdate": "`.noupdate` removido; atualizações automáticas reativadas.",
 				"pinningToCommit": "Fixando ao commit `${ref}` e criando `.noupdate`…",
 				"pinningToPullRequest": "Fixando a pull request #${pr} e criando `.noupdate`…",

--- a/src/public/locales/pt-PT.json
+++ b/src/public/locales/pt-PT.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Como o arquivo `.noupdate` existe, a atualização da fount é ignorada",
 				"switchingToBranch": "Mudando para o ramo «${branch}»…",
+				"switchingToRemote": "Mudando para o branch padrão \"${url}\" do remoto \"${branch}\"...",
 				"removedNoUpdate": "`.noupdate` removido; atualizações automáticas reativadas.",
 				"pinningToCommit": "Fixando ao commit `${ref}` e criando `.noupdate`…",
 				"pinningToPullRequest": "Fixando a pull request #${pr} e criando `.noupdate`…",

--- a/src/public/locales/ru-RU.json
+++ b/src/public/locales/ru-RU.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Поскольку файл `.noupdate` существует, обновление fount пропускается.",
 				"switchingToBranch": "Переключение на ветку «${branch}»…",
-				"switchingToRemote": "Переключение на ветку по умолчанию \"${url}\" удаленного \"${branch}\"...",
+				"switchingToRemote": "Переключение на ветку по умолчанию «${branch}» удалённого репозитория «${url}»…",
 				"removedNoUpdate": "`.noupdate` удалён; автоматические обновления возобновлены.",
 				"pinningToCommit": "Закрепление на коммите `${ref}` и создание `.noupdate`…",
 				"pinningToPullRequest": "Закрепление на pull request #${pr} и создание `.noupdate`…",

--- a/src/public/locales/ru-RU.json
+++ b/src/public/locales/ru-RU.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Поскольку файл `.noupdate` существует, обновление fount пропускается.",
 				"switchingToBranch": "Переключение на ветку «${branch}»…",
+				"switchingToRemote": "Переключение на ветку по умолчанию \"${url}\" удаленного \"${branch}\"...",
 				"removedNoUpdate": "`.noupdate` удалён; автоматические обновления возобновлены.",
 				"pinningToCommit": "Закрепление на коммите `${ref}` и создание `.noupdate`…",
 				"pinningToPullRequest": "Закрепление на pull request #${pr} и создание `.noupdate`…",

--- a/src/public/locales/uk-UA.json
+++ b/src/public/locales/uk-UA.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Оскільки файл `.noupdate` існує, оновлення fount пропускається",
 				"switchingToBranch": "Перемикання на гілку «${branch}»…",
-				"switchingToRemote": "Перехід на стандартну гілку \"${url}\" віддаленого \"${branch}\"...",
+				"switchingToRemote": "Перехід на гілку за замовчуванням «${branch}» віддаленого репозиторію «${url}»…",
 				"removedNoUpdate": "`.noupdate` видалено; автоматичні оновлення відновлено.",
 				"pinningToCommit": "Закріплення на коміті `${ref}` і створення `.noupdate`…",
 				"pinningToPullRequest": "Закріплення на pull request #${pr} і створення `.noupdate`…",

--- a/src/public/locales/uk-UA.json
+++ b/src/public/locales/uk-UA.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Оскільки файл `.noupdate` існує, оновлення fount пропускається",
 				"switchingToBranch": "Перемикання на гілку «${branch}»…",
+				"switchingToRemote": "Перехід на стандартну гілку \"${url}\" віддаленого \"${branch}\"...",
 				"removedNoUpdate": "`.noupdate` видалено; автоматичні оновлення відновлено.",
 				"pinningToCommit": "Закріплення на коміті `${ref}` і створення `.noupdate`…",
 				"pinningToPullRequest": "Закріплення на pull request #${pr} і створення `.noupdate`…",

--- a/src/public/locales/vi-VN.json
+++ b/src/public/locales/vi-VN.json
@@ -395,7 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Vì tệp `.noupdate` tồn tại nên bản cập nhật fount bị bỏ qua",
 				"switchingToBranch": "Đang chuyển sang nhánh «${branch}»…",
-				"switchingToRemote": "Đang chuyển sang nhánh mặc định \"${url}\" của điều khiển từ xa \"${branch}\"...",
+				"switchingToRemote": "Đang chuyển sang nhánh mặc định «${branch}» của kho lưu trữ từ xa «${url}»…",
 				"removedNoUpdate": "Đã xóa `.noupdate`; cập nhật tự động đã được khôi phục.",
 				"pinningToCommit": "Đang ghim vào commit `${ref}` và tạo `.noupdate`…",
 				"pinningToPullRequest": "Đang ghim vào pull request #${pr} và tạo `.noupdate`…",

--- a/src/public/locales/vi-VN.json
+++ b/src/public/locales/vi-VN.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "Vì tệp `.noupdate` tồn tại nên bản cập nhật fount bị bỏ qua",
 				"switchingToBranch": "Đang chuyển sang nhánh «${branch}»…",
+				"switchingToRemote": "Đang chuyển sang nhánh mặc định \"${url}\" của điều khiển từ xa \"${branch}\"...",
 				"removedNoUpdate": "Đã xóa `.noupdate`; cập nhật tự động đã được khôi phục.",
 				"pinningToCommit": "Đang ghim vào commit `${ref}` và tạo `.noupdate`…",
 				"pinningToPullRequest": "Đang ghim vào pull request #${pr} và tạo `.noupdate`…",

--- a/src/public/locales/zh-CN.json
+++ b/src/public/locales/zh-CN.json
@@ -395,6 +395,7 @@
 			"update": {
 				"skippingFountUpdate": "因 `.noupdate` 文件存在，跳过 fount 更新",
 				"switchingToBranch": "正在切换到分支「${branch}」…",
+				"switchingToRemote": "正在切换到远程「${url}」的默认分支「${branch}」…",
 				"removedNoUpdate": "已删除 `.noupdate`，自动更新已恢复。",
 				"pinningToCommit": "正在固定到提交 `${ref}`，并创建 `.noupdate`…",
 				"pinningToPullRequest": "正在固定到拉取请求 #${pr}，并创建 `.noupdate`…",

--- a/src/public/locales/zh-TW.json
+++ b/src/public/locales/zh-TW.json
@@ -394,6 +394,7 @@
 			"update": {
 				"skippingFountUpdate": "因 `.noupdate` 檔案存在，跳過 fount 更新",
 				"switchingToBranch": "正在切換至分支「${branch}」…",
+				"switchingToRemote": "正在切換到遠端「${url}」的預設分支「${branch}」…",
 				"removedNoUpdate": "已移除 `.noupdate`，自動更新已恢復。",
 				"pinningToCommit": "正在固定至提交 `${ref}`，並建立 `.noupdate`…",
 				"pinningToPullRequest": "正在固定至拉取請求 #${pr}，並建立 `.noupdate`…",

--- a/src/runner/main.ps1
+++ b/src/runner/main.ps1
@@ -214,9 +214,8 @@ function Install-FountTree {
 	param([string]$Dir, [string]$Branch)
 	Remove-Item $Dir -Force -ErrorAction Ignore -Recurse
 	if (Get-Command git -ErrorAction Ignore) {
-		$useMirrors = (Get-Culture).Name -match '-(CN|KP|RU)$'
 		$cloneUrls = @("https://github.com/steve02081504/fount")
-		if ($useMirrors) {
+		if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
 			$cloneUrls += "https://gh-proxy.org/github.com/steve02081504/fount"
 			$cloneUrls += "https://gitclone.com/github.com/steve02081504/fount.git"
 		}
@@ -226,18 +225,33 @@ function Install-FountTree {
 			Remove-Item $Dir -Force -ErrorAction Ignore -Recurse
 		}
 	}
-	if (!(Test-Path $Dir)) {
+	$installFlag = Join-Path $Dir 'path/fount.ps1'
+	if (!(Test-Path $installFlag)) {
 		Remove-Item "$env:TEMP/fount-$Branch" -Force -ErrorAction Ignore -Recurse
-		try { Invoke-WebRequest https://github.com/steve02081504/fount/archive/refs/heads/$Branch.zip -OutFile $env:TEMP/fount.zip }
-		catch {
-			throw "Failed to download fount: $($_.Exception.Message)"
+		$zipUrls = @("https://github.com/steve02081504/fount/archive/refs/heads/$Branch.zip")
+		if ((Get-Culture).Name -match '-(CN|KP|RU)$') {
+			$zipUrls += "https://gh-proxy.org/https://github.com/steve02081504/fount/archive/refs/heads/$Branch.zip"
+		}
+		$lastError = $null
+		foreach ($zipUrl in $zipUrls) {
+			try {
+				Invoke-WebRequest $zipUrl -OutFile $env:TEMP/fount.zip
+				break
+			}
+			catch {
+				$lastError = $_.Exception.Message
+				Remove-Item $env:TEMP/fount.zip -Force -ErrorAction Ignore
+			}
+		}
+		if (-not (Test-Path $env:TEMP/fount.zip)) {
+			throw "Failed to download fount: $lastError"
 		}
 		Expand-Archive $env:TEMP/fount.zip $env:TEMP -Force
 		Remove-Item $env:TEMP/fount.zip -Force
 		New-Item $(Split-Path -Parent $Dir) -ItemType Directory -Force -ErrorAction Ignore
 		Move-Item "$env:TEMP/fount-$Branch" $Dir -Force
 	}
-	if (!(Test-Path $Dir)) {
+	if (!(Test-Path $installFlag)) {
 		throw "Failed to install fount"
 	}
 }

--- a/src/runner/main.ps1
+++ b/src/runner/main.ps1
@@ -214,8 +214,15 @@ function Install-FountTree {
 	param([string]$Dir, [string]$Branch)
 	Remove-Item $Dir -Force -ErrorAction Ignore -Recurse
 	if (Get-Command git -ErrorAction Ignore) {
-		git clone -c core.autocrlf=false https://github.com/steve02081504/fount $Dir --depth 1 --single-branch --branch $Branch
-		if ($LastExitCode) {
+		$useMirrors = (Get-Culture).Name -match '-(CN|KP|RU)$'
+		$cloneUrls = @("https://github.com/steve02081504/fount")
+		if ($useMirrors) {
+			$cloneUrls += "https://gh-proxy.org/github.com/steve02081504/fount"
+			$cloneUrls += "https://gitclone.com/github.com/steve02081504/fount.git"
+		}
+		foreach ($url in $cloneUrls) {
+			git clone -c core.autocrlf=false -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 $url $Dir --depth 1 --single-branch --branch $Branch
+			if ($LastExitCode -eq 0) { break }
 			Remove-Item $Dir -Force -ErrorAction Ignore -Recurse
 		}
 	}

--- a/src/runner/main.sh
+++ b/src/runner/main.sh
@@ -262,6 +262,7 @@ remove_fount_after_eula_decline() {
 }
 
 install_fount_tree() {
+	local clone_ok="" clones=()
 	echo -e "Installing fount into ${C_CYAN}$FOUNT_DIR${C_RESET}..."
 	rm -rf "$FOUNT_DIR"
 	mkdir -p "$(dirname "$FOUNT_DIR")"
@@ -270,7 +271,18 @@ install_fount_tree() {
 	if command -v git &>/dev/null; then
 		write_taskbar_progress 25
 		echo "Cloning fount repository..."
-		if git clone -c core.autocrlf=false https://github.com/steve02081504/fount.git "$FOUNT_DIR" --depth 1 --single-branch --branch "$FOUNT_BRANCH"; then
+		clones+=("https://github.com/steve02081504/fount.git")
+		if echo "${LANG:-}" | grep -iqE "_(CN|KP|RU)"; then
+			clones+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
+		fi
+		for clone_url in "${clones[@]}"; do
+			if git clone -c core.autocrlf=false -c http.lowSpeedLimit=1 -c http.lowSpeedTime=30 "$clone_url" "$FOUNT_DIR" --depth 1 --single-branch --branch "$FOUNT_BRANCH"; then
+				clone_ok=1
+				break
+			fi
+			rm -rf "$FOUNT_DIR"
+		done
+		if [ -n "$clone_ok" ]; then
 			echo -e "${C_GREEN}Clone successful.${C_RESET}"
 			write_taskbar_progress 40
 		else

--- a/src/runner/main.sh
+++ b/src/runner/main.sh
@@ -263,6 +263,7 @@ remove_fount_after_eula_decline() {
 
 install_fount_tree() {
 	local clone_ok="" clones=()
+	local locale_var="${LC_ALL:-${LC_MESSAGES:-$LANG}}"
 	echo -e "Installing fount into ${C_CYAN}$FOUNT_DIR${C_RESET}..."
 	rm -rf "$FOUNT_DIR"
 	mkdir -p "$(dirname "$FOUNT_DIR")"
@@ -272,7 +273,7 @@ install_fount_tree() {
 		write_taskbar_progress 25
 		echo "Cloning fount repository..."
 		clones+=("https://github.com/steve02081504/fount.git")
-		if echo "${LANG:-}" | grep -iqE "_(CN|KP|RU)"; then
+		if [[ "$locale_var" =~ _(CN|KP|RU)(\.|@|$) ]]; then
 			clones+=("https://gh-proxy.org/github.com/steve02081504/fount.git" "https://gitclone.com/github.com/steve02081504/fount.git")
 		fi
 		for clone_url in "${clones[@]}"; do
@@ -287,7 +288,6 @@ install_fount_tree() {
 			write_taskbar_progress 40
 		else
 			echo -e "${C_YELLOW}Git clone failed, falling back to zip download...${C_RESET}"
-			rm -rf "$FOUNT_DIR"
 			write_taskbar_progress 25
 		fi
 	fi
@@ -300,19 +300,29 @@ install_fount_tree() {
 		write_taskbar_progress 35
 
 		FOUNT_INSTALL_TMP=$(mktemp -d)
-		ZIP_URL="https://github.com/steve02081504/fount/archive/refs/heads/$FOUNT_BRANCH.zip"
+		zip_urls=("https://github.com/steve02081504/fount/archive/refs/heads/$FOUNT_BRANCH.zip")
+		if [[ "$locale_var" =~ _(CN|KP|RU)(\.|@|$) ]]; then
+			zip_urls+=("https://gh-proxy.org/https://github.com/steve02081504/fount/archive/refs/heads/$FOUNT_BRANCH.zip")
+		fi
 		ZIP_FILE="$FOUNT_INSTALL_TMP/fount.zip"
 
-		echo "Downloading fount from $ZIP_URL..."
-		if command -v curl &>/dev/null; then
-			curl --progress-bar -L -o "$ZIP_FILE" "$ZIP_URL"
-		else
-			wget -q --show-progress -O "$ZIP_FILE" "$ZIP_URL"
-		fi
+		zip_ok=""
+		for zip_url in "${zip_urls[@]}"; do
+			echo "Downloading fount from $zip_url..."
+			if command -v curl &>/dev/null; then
+				curl --progress-bar -L -o "$ZIP_FILE" "$zip_url"
+			else
+				wget -q --show-progress -O "$ZIP_FILE" "$zip_url"
+			fi
+			if [ $? -eq 0 ]; then
+				zip_ok=1
+				break
+			fi
+			rm -f "$ZIP_FILE"
+		done
 		write_taskbar_progress 40
 
-		# shellcheck disable=SC2181
-		if [ $? -ne 0 ]; then
+		if [ -z "$zip_ok" ]; then
 			echo -e "${C_RED}Error: Download failed.${C_RESET}" >&2
 			rm -rf "$FOUNT_INSTALL_TMP"
 			FOUNT_INSTALL_TMP=""


### PR DESCRIPTION
During install, git clones now set \-c http.lowSpeedLimit=1 -c http.lowSpeedTime=30\ so a stalled clone fails fast instead of hanging. On CN/RU/KP culture/locale, retries via \gh-proxy.org\ then \gitclone.com\ mirrors before falling back to zip download. Both \main.ps1\ and \main.sh\ build a URL array and loop uniformly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
改动：为安装、仓库补全和 Git 获取统一加入低速超时及多 URL 重试。CN、RU、KP 地区支持镜像回退。克隆失败后回退到 ZIP 下载。新增 `git_supplement_repo`、`git_fetch_with_fallback` 和指定远程 URL 更新流程，并补充测试与本地化提示。

原因：避免网络停滞长期阻塞，提高受限网络环境下的安装和更新成功率。支持从指定远程 URL 切换到默认分支。

风险：无明显架构风险。安装脚本仍重复维护 URL 和重试逻辑，结构不够统一。Git 获取逻辑已集中处理，整体结构更清晰。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->