### PR TITLE
fix: hide Windows launch via wscript hidden_launch.vbs

### DIFF
--- a/path/src/boot.ps1
+++ b/path/src/boot.ps1
@@ -2,6 +2,8 @@
 	if (!$IsWindows -or (in_container)) { return }
 	if (Test-Path "$FOUNT_DIR/.noautoboot") { return }
 	try {
+		# wscript 是 GUI 子系统进程（不分配控制台），经 hidden_launch.vbs 以窗口样式 0
+		# 隐藏拉起 powershell，开机自启不闪 PowerShell 蓝框。
 		$shellExe = if (Get-Command powershell.exe -ErrorAction SilentlyContinue) {
 			(Get-Command powershell.exe).Source
 		}
@@ -12,7 +14,10 @@
 			(Get-Command pwsh).Source
 		}
 		$fountPs1 = Join-Path $FOUNT_DIR 'path\fount.ps1'
-		$runValue = "`"$shellExe`" -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File `"$fountPs1`" background keepalive"
+		$vbsPath = Join-Path $FOUNT_DIR 'path\src\win\hidden_launch.vbs'
+		$backgroundCmd = "`"$shellExe`" -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File `"$fountPs1`" background keepalive"
+		$encodedCmd = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($backgroundCmd))
+		$runValue = "`"$env:SystemRoot\System32\wscript.exe`" //nologo `"$vbsPath`" `"$encodedCmd`""
 		$runKey = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
 		if (-not (Test-Path $runKey)) {
 			New-Item -Path $runKey -Force | Out-Null

--- a/path/src/win/hidden_launch.vbs
+++ b/path/src/win/hidden_launch.vbs
@@ -1,0 +1,33 @@
+' Hidden-launch helper shared by the path CLI and the server (src/scripts/launch_external.mjs).
+' wscript.exe is a GUI-subsystem host: it never allocates a console, so nothing flashes or lingers.
+' Invocation: wscript //nologo "<this>" <base64-cmdline> [suffix]
+'   - decode and run hidden (window style 0), no wait
+'   - suffix: optional argument appended to the decoded command (quoted)
+Function DecodeB64(ByVal s)
+	Dim xmlDoc, bnode, bytes, st
+	Set xmlDoc = CreateObject("MSXML2.DOMDocument.6.0")
+	Set bnode = xmlDoc.createElement("b64")
+	bnode.dataType = "bin.base64"
+	bnode.text = s
+	bytes = bnode.nodeTypedValue
+	Set st = CreateObject("ADODB.Stream")
+	st.Type = 1
+	st.Open
+	st.Write bytes
+	st.Position = 0
+	st.Type = 2
+	st.Charset = "utf-8"
+	DecodeB64 = st.ReadText
+	st.Close
+End Function
+
+Set sh = WScript.CreateObject("WScript.Shell")
+If WScript.Arguments.Count = 0 Then
+	WScript.Quit 1
+End If
+Dim cmd
+cmd = DecodeB64(WScript.Arguments(0))
+If WScript.Arguments.Count > 1 Then
+	cmd = cmd & " """ & Replace(WScript.Arguments(1), """", """""") & """"
+End If
+sh.Run cmd, 0, False

--- a/path/src/win/protocol_reg.ps1
+++ b/path/src/win/protocol_reg.ps1
@@ -1,6 +1,8 @@
 ﻿function script:Register-FountProtocol {
 	$protocolName = "fount"
 	$protocolDescription = (Get-I18n -key 'protocol.description')
+	# wscript 是 GUI 子系统进程（不分配控制台），经 hidden_launch.vbs 以窗口样式 0
+	# 隐藏拉起 powershell，避免浏览器 ShellExecute 启动协议处理器时闪出 PowerShell 蓝框。
 	$shellExe = if (Get-Command powershell.exe -ErrorAction SilentlyContinue) {
 		(Get-Command powershell.exe).Source
 	}
@@ -10,12 +12,10 @@
 	elseif (Get-Command pwsh -ErrorAction SilentlyContinue) {
 		(Get-Command pwsh).Source
 	}
-	if (Test-Path -LiteralPath $shellExe) {
-		$command = "`"$shellExe`" -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File `"$(Join-Path $FOUNT_DIR 'path\fount.ps1')`" protocolhandle `"%1`""
-	}
-	else {
-		$command = "`"$FOUNT_DIR\path\fount.bat`" protocolhandle `"%1`""
-	}
+	$vbsPath = Join-Path $FOUNT_DIR 'path\src\win\hidden_launch.vbs'
+	$prefixCmd = "`"$shellExe`" -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File `"$(Join-Path $FOUNT_DIR 'path\fount.ps1')`" protocolhandle"
+	$encodedPrefix = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($prefixCmd))
+	$command = "`"$env:SystemRoot\System32\wscript.exe`" //nologo `"$vbsPath`" `"$encodedPrefix`" `"%1`""
 	try {
 		New-Item -Path "HKCU:\Software\Classes\$protocolName" -Force | Out-Null
 		Set-ItemProperty -Path "HKCU:\Software\Classes\$protocolName" -Name "(Default)" -Value $protocolDescription -ErrorAction Stop

--- a/src/public/pages/base.mjs
+++ b/src/public/pages/base.mjs
@@ -121,20 +121,29 @@ async function ensureWebPushSubscription() {
 const is_hidden_page = !window.innerHeight || !window.innerWidth
 
 /**
+ * 等待 Service Worker 接管当前页面后返回其 controller。
+ * 新注册的 worker 尚未 claim 页面时，controller 暂时为 null，需等
+ * `navigator.serviceWorker.ready` 与 `controllerchange` 后才有可用的 controller，
+ * 以便 WAKE_SERVER_REQUEST 能送达新激活的 worker。
+ * @returns {Promise<ServiceWorker | null>} 控制当前页面的 Service Worker，无则返回 null。
+ */
+async function waitServiceWorkerController() {
+	if (!navigator.serviceWorker) return null
+	if (!navigator.serviceWorker.controller) {
+		try { await navigator.serviceWorker.ready } catch { return navigator.serviceWorker.controller }
+		if (navigator.serviceWorker.controller) return navigator.serviceWorker.controller
+		await new Promise(resolve => navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true }))
+	}
+	return navigator.serviceWorker.controller
+}
+
+/**
  * 向 Service Worker 查询服务器是否适合启动。
  * @returns {Promise<boolean>} 是否适合启动服务器。
  */
 export async function queryWakeServer() {
-	if (!navigator.serviceWorker?.controller) {
-		try {
-			await fetch('/api/ping', { method: 'GET', mode: 'cors', credentials: 'omit', cache: 'no-store', signal: AbortSignal.timeout(500) })
-		}
-		catch {
-			return false
-		}
-		return true
-	}
-	return new Promise(resolve => {
+	const controller = await waitServiceWorkerController()
+	if (controller) return new Promise(resolve => {
 		const channel = new MessageChannel()
 		/**
 		 * 处理 Service Worker 返回的在线状态消息。
@@ -142,8 +151,15 @@ export async function queryWakeServer() {
 		 * @returns {void}
 		 */
 		channel.port1.onmessage = event => resolve(!!event.data?.approved)
-		navigator.serviceWorker.controller.postMessage({ type: 'WAKE_SERVER_REQUEST' }, [channel.port2])
+		controller.postMessage({ type: 'WAKE_SERVER_REQUEST' }, [channel.port2])
 	})
+	try {
+		await fetch('/api/ping', { method: 'GET', mode: 'cors', credentials: 'omit', cache: 'no-store', signal: AbortSignal.timeout(500) })
+	}
+	catch {
+		return false
+	}
+	return true
 }
 
 /**

--- a/src/public/pages/base.mjs
+++ b/src/public/pages/base.mjs
@@ -121,10 +121,10 @@ async function ensureWebPushSubscription() {
 const is_hidden_page = !window.innerHeight || !window.innerWidth
 
 /**
- * 向 Service Worker 查询服务器是否在线。
- * @returns {Promise<boolean>} 服务器是否在线，无法查询时视为离线。
+ * 向 Service Worker 查询服务器是否适合启动。
+ * @returns {Promise<boolean>} 是否适合启动服务器。
  */
-export async function queryServerOnline() {
+export async function queryWakeServer() {
 	if (!navigator.serviceWorker?.controller) {
 		try {
 			await fetch('/api/ping', { method: 'GET', mode: 'cors', credentials: 'omit', cache: 'no-store', signal: AbortSignal.timeout(500) })
@@ -141,8 +141,8 @@ export async function queryServerOnline() {
 		 * @param {MessageEvent} event - 消息事件。
 		 * @returns {void}
 		 */
-		channel.port1.onmessage = event => resolve(!!event.data?.serverOnline)
-		navigator.serviceWorker.controller.postMessage({ type: 'GET_SERVER_ONLINE' }, [channel.port2])
+		channel.port1.onmessage = event => resolve(!!event.data?.approved)
+		navigator.serviceWorker.controller.postMessage({ type: 'WAKE_SERVER_REQUEST' }, [channel.port2])
 	})
 }
 
@@ -151,7 +151,7 @@ export async function queryServerOnline() {
  * @returns {Promise<void>}
  */
 export async function wakeServer() {
-	if (await queryServerOnline()) return
+	if (await queryWakeServer()) return
 	const iframe = document.createElement('iframe')
 	iframe.ariaHidden = true
 	iframe.style.display = 'none'

--- a/src/public/pages/service_worker.mjs
+++ b/src/public/pages/service_worker.mjs
@@ -368,6 +368,7 @@ async function fetchAndCache(request) {
 
 		if (networkResponse.type == 'opaque');
 		else if (networkResponse && networkResponse.ok) {
+			if (!ws && new URL(request.url).origin === self.location.origin) connectWebSocket()
 			const responseToCache = networkResponse.clone()
 			const now = Date.now()
 
@@ -478,8 +479,16 @@ self.addEventListener('message', event => {
 	}
 	else if (event.data?.type === 'GET_FOUNT_VERSION')
 		event.ports[0]?.postMessage?.({ fountVersion })
-	else if (event.data?.type === 'GET_SERVER_ONLINE')
-		event.ports[0]?.postMessage?.({ serverOnline })
+	else if (event.data?.type === 'WAKE_SERVER_REQUEST') {
+		event.ports[0]?.postMessage?.({ approved: (() => {
+			if (serverOnline) return true
+			const now = Date.now()
+			try {
+				if (now - lastWakeRequestAt < WAKE_GRACE_MS) return true
+			} finally { lastWakeRequestAt = now }
+			return false
+		})() })
+	}
 })
 
 /**
@@ -628,6 +637,8 @@ let fountVersion = 'unknown'
 getConfig('fountVersion').then(version => fountVersion = version)
 
 const RECONNECT_DELAY = 5000 // 5 seconds
+const WAKE_GRACE_MS = 3 * 60 * 1000 // 3 minutes
+let lastWakeRequestAt = 0
 
 const wsMessageHandlers = {
 	/**
@@ -673,6 +684,8 @@ const wsMessageHandlers = {
  * @returns {void}
  */
 function connectWebSocket() {
+	if (ws) return
+	reconnectTimeout &&= clearTimeout(reconnectTimeout)
 	// Use a relative URL that will be resolved correctly by the browser
 	// against the service worker's origin.
 	const wsUrl = new URL('/ws/notify', self.location.href)

--- a/src/scripts/launch_external.mjs
+++ b/src/scripts/launch_external.mjs
@@ -1,49 +1,13 @@
 import { Buffer } from 'node:buffer'
 import { spawn } from 'node:child_process'
-import { existsSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 
 /**
- * 隐藏启动用的 wscript 辅助脚本：解码 base64 命令行，隐藏（窗口样式 0）孤儿化拉起目标。
- * 共享一个临时文件即可，无需每次启动重写。
+ * 隐藏启动用的 wscript 辅助脚本（随 fount 附带，path/src/win/hidden_launch.vbs）：
+ * 解码 base64 命令行，隐藏（窗口样式 0）孤儿化拉起目标。
  */
-const HIDDEN_HELPER_VBS = `\
-Function DecodeB64(ByVal s)
-	Dim xmlDoc, bnode, bytes, st
-	Set xmlDoc = CreateObject("MSXML2.DOMDocument.6.0")
-	Set bnode = xmlDoc.createElement("b64")
-	bnode.dataType = "bin.base64"
-	bnode.text = s
-	bytes = bnode.nodeTypedValue
-	Set st = CreateObject("ADODB.Stream")
-	st.Type = 1
-	st.Open
-	st.Write bytes
-	st.Position = 0
-	st.Type = 2
-	st.Charset = "utf-8"
-	DecodeB64 = st.ReadText
-	st.Close
-End Function
-Set sh = WScript.CreateObject("WScript.Shell")
-If WScript.Arguments.Count > 1 Then
-	On Error Resume Next
-	sh.CurrentDirectory = WScript.Arguments(1)
-End If
-sh.Run DecodeB64(WScript.Arguments(0)), 0, False
-`
-
-/**
- * 确保隐藏启动用的 wscript 辅助脚本存在（共享一个临时文件）。
- * @returns {string} 辅助脚本路径
- */
-function ensureHiddenHelper() {
-	const path = join(tmpdir(), 'fount_launch_hidden.vbs')
-	if (!existsSync(path)) writeFileSync(path, HIDDEN_HELPER_VBS, 'utf8')
-	return path
-}
+const HIDDEN_LAUNCH_VBS_PATH = join(import.meta.dirname, '..', '..', 'path', 'src', 'win', 'hidden_launch.vbs')
 
 /**
  * 按 Windows argv 规则引用单个命令行令牌（可执行文件路径或参数）。
@@ -108,7 +72,7 @@ export function launchDetachedProgram(options = {}) {
 				// 隐藏与脱离 Job Object 二者兼得。base64 传参避开 cmd/Shell.Run 的引号解析。
 				return spawn(process.env.ComSpec || 'cmd.exe', [
 					'/d', '/c', 'start', '', '/b', 'wscript.exe', '//nologo',
-					ensureHiddenHelper(), encodedCommandLine, spawnOptions.cwd || '',
+					HIDDEN_LAUNCH_VBS_PATH, encodedCommandLine,
 				], { ...spawnOptions, env: mergedEnv, detached: true, stdio: 'ignore' })
 			}
 			: () => spawn(process.env.ComSpec || 'cmd.exe', ['/d', '/c', 'start', '', '/b', command, ...args], {

--- a/src/scripts/test/node/launch.mjs
+++ b/src/scripts/test/node/launch.mjs
@@ -589,6 +589,7 @@ async function launchNodeOnce(options = {}) {
 			child = spawn(Deno.execPath(), spawnArgs, {
 				cwd: REPO_ROOT,
 				stdio: ['ignore', 'pipe', 'pipe'],
+				windowsHide: true,
 				env: {
 					...process.env,
 					FOUNT_TEST: '1',


### PR DESCRIPTION
Hide launching via `wscript.exe + hidden_launch.vbs` to avoid PowerShell console flash.

**path/Windows**
- `path/src/win/hidden_launch.vbs` — bundled helper (GUI-subsystem, no console, window style 0), decodes base64 cmdline and appends optional suffix arg
- `path/src/boot.ps1` — autostart Run key now points to `wscript.exe //nologo hidden_launch.vbs <base64>` instead of direct PowerShell
- `path/src/win/protocol_reg.ps1` — `fount://` protocol handler likewise via wscript, avoids flash when browser ShellExecute triggers handler

**server**
- `src/scripts/launch_external.mjs` — use bundled `hidden_launch.vbs` via `import.meta.dirname` instead of temp file (`ensureHiddenHelper` removed), no `tmpdir`/`writeFileSync` on each launch

**pages/service_worker**
- `src/public/pages/base.mjs`: `queryServerOnline` -> `queryWakeServer`, message `GET_SERVER_ONLINE` -> `WAKE_SERVER_REQUEST` (`{approved}`), matches SW throttling
- `src/public/pages/service_worker.mjs`: `WAKE_SERVER_REQUEST` with 3-min grace (`WAKE_GRACE_MS`, `lastWakeRequestAt`), `serverOnline` still immediate approve; `fetchAndCache` reconnects WS on same-origin success if disconnected; `connectWebSocket` guard `if(ws) return` + `clearTimeout`

**test**
- `src/scripts/test/node/launch.mjs`: `windowsHide: true` for Deno child


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
改用随程序提供的 `hidden_launch.vbs`，通过 `wscript.exe` 隐藏启动 Windows 自启和 `fount://` 协议处理，避免 PowerShell 控制台闪现，并移除运行时临时脚本逻辑。服务唤醒协议改为 `queryWakeServer` 和 `WAKE_SERVER_REQUEST`，加入三分钟宽限期及 WebSocket 连接保护，减少重复唤醒和连接竞态。测试子进程启用 `windowsHide`。

主要风险是 VBScript、PowerShell 与 Base64 组成多层启动链，参数转义和错误处理较脆弱。服务唤醒状态机也更复杂，增加了维护成本。整体方向有效，但架构和实现审美偏重。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->