### PR TITLE
feat(chat): pow 入群改为动态 challenge，移除邀请链接静态锚

### DIFF
--- a/src/public/parts/shells/chat/main.mjs
+++ b/src/public/parts/shells/chat/main.mjs
@@ -21,6 +21,7 @@ import { registerChatChunkProviders, unregisterChatChunkProviders } from './src/
 import { registerChatEventTypeDefs, unregisterChatEventTypeDefs } from './src/chat/dag/eventTypes.mjs'
 import { registerChatFederationRoomProvider, unregisterChatFederationRoomProvider } from './src/chat/federation/trustGraphRooms.mjs'
 import { registerChatUserRoomEmojiHandlers, unregisterChatUserRoomEmojiHandlers } from './src/chat/federation/userRoomEmojiRegistry.mjs'
+import { registerChatUserRoomPowChallengeHandlers, unregisterChatUserRoomPowChallengeHandlers } from './src/chat/federation/userRoomPowChallengeRegistry.mjs'
 import { registerChatGroupEmojiPostEmbed, unregisterChatGroupEmojiPostEmbed } from './src/chat/groupEmojiPostEmbed.mjs'
 import { registerChatGroupEntityIndex, unregisterChatGroupEntityIndex } from './src/chat/groupEntityIndex.mjs'
 import { getGroupMemberEntityHash } from './src/chat/lib/replica.mjs'
@@ -91,6 +92,7 @@ export default {
 		registerChatEventTypeDefs()
 		registerChatGroupEmojiPostEmbed()
 		registerChatUserRoomEmojiHandlers()
+		registerChatUserRoomPowChallengeHandlers()
 		registerChatManifestAcl()
 		registerChatManifestTransfer()
 		registerChatChunkProviders()
@@ -118,6 +120,7 @@ export default {
 			unregisterChatEventTypeDefs()
 			unregisterChatGroupEmojiPostEmbed()
 			unregisterChatUserRoomEmojiHandlers()
+			unregisterChatUserRoomPowChallengeHandlers()
 			unregisterChatManifestAcl()
 			unregisterGroupMemberEntityResolver('chat')
 			unregisterChatManifestTransfer()

--- a/src/public/parts/shells/chat/public/hub/sidebar/groupMembership.mjs
+++ b/src/public/parts/shells/chat/public/hub/sidebar/groupMembership.mjs
@@ -2,7 +2,7 @@
  * 【文件】public/hub/sidebar/groupMembership.mjs
  * 【职责】选群时的入群判定、自动 join、联邦 catch-up。
  */
-import { getGroupState, joinGroup } from '../../src/endpoints/groupCore.mjs'
+import { getGroupState, getPowChallenge, joinGroup } from '../../src/endpoints/groupCore.mjs'
 import { federationCatchUp } from '../../src/endpoints/groupFederation.mjs'
 import { broadcastHubGroupJoined } from '../../src/hubBroadcast.mjs'
 import { resolvePowForJoin } from '../../src/powJoin.mjs'
@@ -110,6 +110,21 @@ export async function ensureGroupMembership(groupId, state) {
 	const pendingJoin = consumePendingJoin(groupId)
 	const inviteCode = pendingJoin.inviteCode || inviteCodeFromUrl()
 	if (!canAutoJoinGroup(state, pendingJoin, inviteCode)) {
+		// pow discovery 群：无本地 replica / invite / fedBootstrap，动态申请 challenge 解 pow 入群。
+		const challenge = await getPowChallenge(groupId).catch(() => null)
+		if (challenge?.anchors?.length) {
+			const pow = await resolvePowForJoin(groupId, null, store.viewer.nodeHash || '', challenge)
+			await joinGroup(groupId, null, null, pow, {
+				roomSecret: challenge.roomSecret,
+				signalingAppId: challenge.signalingAppId,
+				introducerNodeHash: challenge.responderNodeHash || null,
+				introducerPubKeyHash: null,
+			})
+			const joined = await getGroupState(groupId)
+			broadcastHubGroupJoined(groupId)
+			await loadGroups()
+			return joined
+		}
 		setState('context.currentState', state)
 		store.context.currentMode = 'groups'
 		document.querySelectorAll('.server-item[data-mode]').forEach(el => {
@@ -126,7 +141,9 @@ export async function ensureGroupMembership(groupId, state) {
 		refreshHubHeaderButtons()
 		return null
 	}
-	const pow = await resolvePowForJoin(groupId, state, store.viewer.nodeHash || '')
+	const pow = state?.groupSettings?.joinPolicy === 'pow'
+		? await resolvePowForJoin(groupId, state, store.viewer.nodeHash || '', pendingJoin.fedBootstrap)
+		: null
 	await joinGroup(groupId, inviteCode, null, pow, pendingJoin.fedBootstrap)
 	const joined = await getGroupState(groupId)
 	broadcastHubGroupJoined(groupId)

--- a/src/public/parts/shells/chat/public/shared/joinPowAnchors.mjs
+++ b/src/public/parts/shells/chat/public/shared/joinPowAnchors.mjs
@@ -1,17 +1,19 @@
 /**
  * 从物化群 state 提取入群 PoW anchor（前后端共用）。
+ * 稳定根优先：checkpoint root / consensus branch tip / membersRoot 在 DAG tips 之前，
+ * 这样调用方取 `anchors[0]` 即最不易过期的锚（tips 随新事件被引用后即从集合消失）。
  * @param {object} state 物化群 state
  * @returns {string[]} 近期 DAG tip / checkpoint root 候选
  */
 export function collectJoinPowAnchors(state) {
 	/** @type {string[]} */
 	const anchors = []
-	const tips = Array.isArray(state?.dagTips) ? state.dagTips : []
-	for (const tip of tips)
-		if (tip) anchors.push(tip)
-	for (const key of ['consensusBranchTip', 'membersRoot', 'checkpoint_event_id']) {
+	for (const key of ['checkpoint_event_id', 'consensusBranchTip', 'membersRoot']) {
 		const v = state?.[key]
 		if (v) anchors.push(v)
 	}
+	const tips = Array.isArray(state?.dagTips) ? state.dagTips : []
+	for (const tip of tips)
+		if (tip) anchors.push(tip)
 	return [...new Set(anchors.filter(Boolean))]
 }

--- a/src/public/parts/shells/chat/public/shared/joinPowAnchors.mjs
+++ b/src/public/parts/shells/chat/public/shared/joinPowAnchors.mjs
@@ -9,8 +9,8 @@ export function collectJoinPowAnchors(state) {
 	/** @type {string[]} */
 	const anchors = []
 	for (const key of ['checkpoint_event_id', 'consensusBranchTip', 'membersRoot']) {
-		const v = state?.[key]
-		if (v) anchors.push(v)
+		const anchor = state?.[key]
+		if (anchor) anchors.push(anchor)
 	}
 	const tips = Array.isArray(state?.dagTips) ? state.dagTips : []
 	for (const tip of tips)

--- a/src/public/parts/shells/chat/public/shared/runUri.mjs
+++ b/src/public/parts/shells/chat/public/shared/runUri.mjs
@@ -35,7 +35,6 @@ export function formatDmRunUri({ pubKeyHex, nonceBase64Url, introSignatureHex, n
  *   inviteCode?: string
  *   roomSecret?: string
  *   introducerPubKeyHash?: string
- *   powAnchorRef?: string
  *   introducerNodeHash?: string
  * }} JoinRunPayload
  */
@@ -65,6 +64,27 @@ export function parseJoinRunPayload(raw) {
  */
 export function wrapProtocolHttpsUrl(fountRunUri) {
 	return `https://steve02081504.github.io/fount/protocol?url=${encodeURIComponent(fountRunUri)}`
+}
+
+/**
+ * 组装 join 深链分享 URL。powAnchorRef 不再写入链接：入群 PoW anchor 由加入方
+ * 在 join 时经 `/pow-challenge` 动态申请，避免链接携带易过期的静态锚。
+ * @param {object} options 载荷
+ * @param {string} options.groupId 群 ID
+ * @param {string} [options.inviteCode] 邀请码
+ * @param {string} [options.roomSecret] 群房间密钥
+ * @param {string} [options.introducerPubKeyHash] 介绍人 pubKeyHash
+ * @param {string} [options.introducerNodeHash] 介绍人 nodeHash
+ * @returns {string} 分享 URL
+ */
+export function formatJoinInviteUrl({ groupId, inviteCode, roomSecret, introducerPubKeyHash, introducerNodeHash }) {
+	return wrapProtocolHttpsUrl(formatJoinRunUri({
+		groupId,
+		inviteCode,
+		roomSecret,
+		introducerPubKeyHash,
+		introducerNodeHash,
+	}))
 }
 
 /**

--- a/src/public/parts/shells/chat/public/shared/runUri.mjs
+++ b/src/public/parts/shells/chat/public/shared/runUri.mjs
@@ -67,8 +67,7 @@ export function wrapProtocolHttpsUrl(fountRunUri) {
 }
 
 /**
- * 组装 join 深链分享 URL。powAnchorRef 不再写入链接：入群 PoW anchor 由加入方
- * 在 join 时经 `/pow-challenge` 动态申请，避免链接携带易过期的静态锚。
+ * 组装 join 深链分享 URL。
  * @param {object} options 载荷
  * @param {string} options.groupId 群 ID
  * @param {string} [options.inviteCode] 邀请码

--- a/src/public/parts/shells/chat/public/src/deepLinkConsume.mjs
+++ b/src/public/parts/shells/chat/public/src/deepLinkConsume.mjs
@@ -11,7 +11,7 @@ import { isHex64 } from 'https://esm.sh/@steve02081504/fount-p2p/core/hexIds'
 import { parseDmRunUri, parseJoinRunUri, parseMessageRunUri } from '../shared/runUri.mjs'
 
 import { getFederationSettings } from './endpoints/federationSettings.mjs'
-import { getGroupState, joinGroup } from './endpoints/groupCore.mjs'
+import { getGroupState, getPowChallenge, joinGroup } from './endpoints/groupCore.mjs'
 import { createDirectMessageByPubKeys } from './endpoints/groupDm.mjs'
 import { getViewer } from './endpoints/viewer.mjs'
 import { broadcastHubGroupJoined } from './hubBroadcast.mjs'
@@ -82,7 +82,15 @@ export async function applyChatRunUri(raw) {
 		catch (error) {
 			handleError('chat.hub.operationFailed')(error)
 		}
-		const pow = await resolvePowForJoin(join.groupId, groupState, viewer.nodeHash || '')
+		let pow = null
+		if (groupState?.groupSettings?.joinPolicy === 'pow')
+			pow = await resolvePowForJoin(join.groupId, groupState, viewer.nodeHash || '')
+		if (!pow) {
+			const challenge = await getPowChallenge(join.groupId, { introducerNodeHash: join.introducerNodeHash })
+				.catch(() => null)
+			if (challenge?.anchors?.length)
+				pow = await resolvePowForJoin(join.groupId, null, viewer.nodeHash || '', challenge)
+		}
 		await joinGroup(join.groupId, join.inviteCode, null, pow, join)
 		sessionStorage.removeItem(PENDING_INVITE_STORAGE_KEY)
 		broadcastHubGroupJoined(join.groupId)

--- a/src/public/parts/shells/chat/public/src/endpoints/groupCore.mjs
+++ b/src/public/parts/shells/chat/public/src/endpoints/groupCore.mjs
@@ -133,6 +133,19 @@ export async function getGroupState(groupId) {
 }
 
 /**
+ * 动态申请入群 PoW challenge（仅 pow 群返回；本地无 replica 时经联邦取当前稳定锚 + 难度）。
+ * @param {string} groupId 群 ID
+ * @param {{ introducerNodeHash?: string }} [options] 优先定向的引入者节点
+ * @returns {Promise<{ anchors: string[], powFloorBits: number, powEpochMs: number, roomSecret?: string, signalingAppId?: string, responderNodeHash?: string }>} challenge
+ */
+export async function getPowChallenge(groupId, options = {}) {
+	const query = options.introducerNodeHash
+		? `?introducerNodeHash=${encodeURIComponent(options.introducerNodeHash)}`
+		: ''
+	return groupFetch(`${groupPath(groupId, 'pow-challenge')}${query}`, { method: 'GET' })
+}
+
+/**
  * 分页拉取群审计日志（需 ADMIN）。
  * @param {string} groupId 群 ID
  * @param {{ before?: string, offset?: number, limit?: number, types?: string[] }} [options] 游标/偏移与类型过滤

--- a/src/public/parts/shells/chat/public/src/endpoints/groupCore.mjs
+++ b/src/public/parts/shells/chat/public/src/endpoints/groupCore.mjs
@@ -139,10 +139,12 @@ export async function getGroupState(groupId) {
  * @returns {Promise<{ anchors: string[], powFloorBits: number, powEpochMs: number, roomSecret?: string, signalingAppId?: string, responderNodeHash?: string }>} challenge
  */
 export async function getPowChallenge(groupId, options = {}) {
-	const query = options.introducerNodeHash
-		? `?introducerNodeHash=${encodeURIComponent(options.introducerNodeHash)}`
-		: ''
-	return groupFetch(`${groupPath(groupId, 'pow-challenge')}${query}`, { method: 'GET' })
+	return groupFetch(
+		`${groupPath(groupId, 'pow-challenge')}${options.introducerNodeHash
+			? `?introducerNodeHash=${encodeURIComponent(options.introducerNodeHash)}`
+			: ''}`,
+		{ method: 'GET' },
+	)
 }
 
 /**

--- a/src/public/parts/shells/chat/public/src/inviteQr.mjs
+++ b/src/public/parts/shells/chat/public/src/inviteQr.mjs
@@ -2,7 +2,7 @@
  * 【文件】public/src/inviteQr.mjs
  * 【职责】入群邀请 QR 与 run URI / protocol 分享链接组装。
  */
-import { formatJoinRunUri, wrapProtocolHttpsUrl } from '../shared/runUri.mjs'
+import { formatJoinInviteUrl } from '../shared/runUri.mjs'
 
 /**
  * @param {string} url 完整入群 URL
@@ -22,11 +22,5 @@ export function inviteJoinQrImageUrl(url, size = 200) {
  * @returns {string} `https://steve02081504.github.io/fount/protocol?url=…`
  */
 export function buildInviteJoinShareUrl(groupId, inviteCode, roomSecret, introducerPubKeyHash, introducerNodeHash) {
-	return wrapProtocolHttpsUrl(formatJoinRunUri({
-		groupId,
-		inviteCode,
-		roomSecret,
-		introducerPubKeyHash,
-		introducerNodeHash,
-	}))
+	return formatJoinInviteUrl({ groupId, inviteCode, roomSecret, introducerPubKeyHash, introducerNodeHash })
 }

--- a/src/public/parts/shells/chat/public/src/powJoin.mjs
+++ b/src/public/parts/shells/chat/public/src/powJoin.mjs
@@ -10,6 +10,9 @@ import { collectJoinPowAnchors } from '../shared/joinPowAnchors.mjs'
 /** 默认 epoch 窗口（1 小时），与 `npm:@steve02081504/fount-p2p/governance/join_pow` 一致。 */
 const JOIN_POW_DEFAULT_EPOCH_MS = 3_600_000
 
+/** 协议难度上限：SHA-256 前导零 bit 最大可达 256（与 p2p `countAchievedLeadingZeroBits` 的 0..256 一致）。 */
+const JOIN_POW_MAX_FLOOR_BITS = 256
+
 /**
  * 计算 SHA-256 hex 的实际前导零 bit 数，与 `npm:@steve02081504/fount-p2p/governance/join_pow` 的 `countAchievedLeadingZeroBits` 一致。
  * @param {string} hexHash SHA-256 hex
@@ -52,6 +55,7 @@ function hashMeetsFloor(hexHash, floorBits) {
 export async function solveJoinPow(fields, floorBits, targetBits) {
 	const floor = Math.max(1, Math.floor(Number(floorBits) || 1))
 	const target = Math.max(floor, Math.floor(Number(targetBits) || floor))
+	if (floor > JOIN_POW_MAX_FLOOR_BITS || target > JOIN_POW_MAX_FLOOR_BITS) return null
 	const epochMs = Number(fields.epochMs) || JOIN_POW_DEFAULT_EPOCH_MS
 	const epoch = Number.isFinite(fields.epoch) ? fields.epoch : Math.floor(Date.now() / epochMs)
 	let best = null
@@ -85,6 +89,7 @@ export async function resolvePowForJoin(groupId, state = null, joinerNodeHash = 
 	const anchorRef = anchors[0]
 	if (!anchorRef || !joinerNodeHash) return null
 	const floorBits = Number(bootstrap?.powFloorBits || state?.groupSettings?.powFloorBits) || 18
+	if (floorBits > JOIN_POW_MAX_FLOOR_BITS) return null
 	const epochMs = Number(bootstrap?.powEpochMs || state?.groupSettings?.powEpochMs) || JOIN_POW_DEFAULT_EPOCH_MS
 	return solveJoinPow({ groupId, anchorRef, joinerNodeHash, epochMs }, floorBits, bootstrap?.targetBits ?? floorBits)
 }

--- a/src/public/parts/shells/chat/public/src/powJoin.mjs
+++ b/src/public/parts/shells/chat/public/src/powJoin.mjs
@@ -73,30 +73,18 @@ export async function solveJoinPow(fields, floorBits, targetBits) {
 }
 
 /**
+ * 针对已知为 pow 策略的群解算入群 PoW（调用方负责确认 joinPolicy）。
  * @param {string} groupId 群 ID
  * @param {object | null} [state] 已有群 state
  * @param {string} joinerNodeHash 入群者 nodeHash
- * @param {{ powAnchorRef?: string, powAnchors?: string[], targetBits?: number }} [bootstrap] bootstrap
- * @returns {Promise<{ anchorRef: string, joinerNodeHash: string, epoch: number, nonce: string, achievedBits: number } | null>} PoW 解；非 pow 策略或缺 anchor 为 null
+ * @param {{ anchors?: string[], powFloorBits?: number, powEpochMs?: number, targetBits?: number }} [bootstrap] challenge / bootstrap 参数
+ * @returns {Promise<{ anchorRef: string, joinerNodeHash: string, epoch: number, nonce: string, achievedBits: number } | null>} PoW 解；缺 anchor 为 null
  */
 export async function resolvePowForJoin(groupId, state = null, joinerNodeHash = '', bootstrap = null) {
-	const policy = state?.groupSettings?.joinPolicy
-	if (policy !== 'pow') return null
-	const floorBits = Number(state?.groupSettings?.powFloorBits)
-		|| Number(state?.groupSettings?.powDifficulty)
-		|| Number(state?.groupSettings?.powDifficultyBits)
-		|| 18
-	const targetBits = bootstrap?.targetBits ?? floorBits
-	const anchors = bootstrap?.powAnchors?.length
-		? bootstrap.powAnchors
-		: state ? collectJoinPowAnchors(state) : []
-	const anchorRef = bootstrap?.powAnchorRef || anchors[0]
+	const anchors = bootstrap?.anchors?.length ? bootstrap.anchors : collectJoinPowAnchors(state)
+	const anchorRef = anchors[0]
 	if (!anchorRef || !joinerNodeHash) return null
-	const epochMs = Number(state?.groupSettings?.powEpochMs) || JOIN_POW_DEFAULT_EPOCH_MS
-	return solveJoinPow({
-		groupId,
-		anchorRef,
-		joinerNodeHash,
-		epochMs,
-	}, floorBits, targetBits)
+	const floorBits = Number(bootstrap?.powFloorBits || state?.groupSettings?.powFloorBits) || 18
+	const epochMs = Number(bootstrap?.powEpochMs || state?.groupSettings?.powEpochMs) || JOIN_POW_DEFAULT_EPOCH_MS
+	return solveJoinPow({ groupId, anchorRef, joinerNodeHash, epochMs }, floorBits, bootstrap?.targetBits ?? floorBits)
 }

--- a/src/public/parts/shells/chat/src/actions.mjs
+++ b/src/public/parts/shells/chat/src/actions.mjs
@@ -246,10 +246,9 @@ export const actions = {
 	 * @param {string} [root0.signalingAppId] 信令应用 ID
 	 * @param {string} [root0.introducerPubKeyHash] 邀请人成员 pubKeyHash
 	 * @param {string} [root0.introducerNodeHash] 邀请人 nodeHash
-	 * @param {string} [root0.powAnchorRef] 入群 PoW anchor 提示
 	 * @returns {Promise<{ groupId: string, defaultChannelId: string }>} 入群结果
 	 */
-	join: async ({ user, groupId, inviteCode, roomSecret, signalingAppId, introducerPubKeyHash, introducerNodeHash, powAnchorRef }) =>
+	join: async ({ user, groupId, inviteCode, roomSecret, signalingAppId, introducerPubKeyHash, introducerNodeHash }) =>
 		performMemberJoin(user, groupId, {
 			inviteCode,
 			introducerPubKeyHash,
@@ -257,7 +256,6 @@ export const actions = {
 				roomSecret,
 				signalingAppId,
 				fromNodeId: introducerNodeHash,
-				powAnchorRef,
 			},
 		}),
 }

--- a/src/public/parts/shells/chat/src/api/group.mjs
+++ b/src/public/parts/shells/chat/src/api/group.mjs
@@ -1,10 +1,9 @@
-import { formatJoinRunUri, wrapProtocolHttpsUrl } from '../../public/shared/runUri.mjs'
+import { formatJoinInviteUrl } from '../../public/shared/runUri.mjs'
 import { appendSignedLocalEvent } from '../chat/dag/append.mjs'
 import { performLocalGroupLeave } from '../chat/dag/leaveMany.mjs'
 import { resolveLocalEventSigner } from '../chat/dag/localSigner.mjs'
 import { activateGroupFederation, isGroupFederationActive } from '../chat/federation/groupFederation.mjs'
 import { roomCredentialsFromGroupSettings } from '../chat/federation/roomCredentials.mjs'
-import { collectJoinPowAnchors } from '../chat/governance/joinPowAnchors.mjs'
 import { buildConversationContext } from '../chat/lib/conversationContext.mjs'
 import { mintGroupInviteTicket } from '../chat/lib/inviteTickets.mjs'
 import { getLocalNodeHash } from '../chat/lib/replica.mjs'
@@ -167,16 +166,13 @@ export function createGroup(apiContext, groupId, projection) {
 				? roomCredentialsFromGroupSettings(state.groupSettings)
 				: await activateGroupFederation(apiContext.username, groupId, apiContext.entityHash)
 			const { sender: introducerPubKeyHash } = await resolveLocalEventSigner(apiContext.username, groupId, apiContext.entityHash)
-			const powAnchorRef = collectJoinPowAnchors(state)[0] ?? null
-			const url = wrapProtocolHttpsUrl(formatJoinRunUri({
+			return formatJoinInviteUrl({
 				groupId,
 				inviteCode: ticket.code,
 				roomSecret: roomCreds.roomSecret,
 				introducerPubKeyHash,
-				powAnchorRef,
 				introducerNodeHash: getLocalNodeHash(),
-			}))
-			return url
+			})
 		},
 		/**
 		 * @returns {Promise<void>} 退群完成

--- a/src/public/parts/shells/chat/src/chat/dm/index.mjs
+++ b/src/public/parts/shells/chat/src/chat/dm/index.mjs
@@ -229,7 +229,7 @@ async function bindJoinFederation(username, groupId) {
  * @param {string} [options.dmIntroNonce] DM intro nonce
  * @param {string} [options.dmIntroSignatureHex] DM intro 签名 hex
  * @param {number} [options.reputationEdge] 入群信誉边 [-1,1]
- * @param {{ roomSecret?: string, signalingAppId?: string, dmSessionTag?: string, powAnchorRef?: string, powAnchors?: string[] }} [options.bootstrap] 首次联邦 bootstrap
+ * @param {{ roomSecret?: string, signalingAppId?: string, dmSessionTag?: string }} [options.bootstrap] 首次联邦 bootstrap
  * @returns {Promise<{ groupId: string, defaultChannelId: string }>} 入群后的群信息
  */
 export async function performMemberJoin(username, groupId, options = {}) {

--- a/src/public/parts/shells/chat/src/chat/federation/bootstrapStore.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/bootstrapStore.mjs
@@ -9,7 +9,7 @@ import { loadJsonFileIfExists, saveJsonFile } from '../../../../../../../scripts
 import { safeUnlinkSync } from '../lib/fsSafe.mjs'
 import { federationBootstrapPath } from '../lib/paths.mjs'
 
-/** @type {Map<string, { signalingAppId: string, roomSecret: string, dmSessionTag?: string, fromNodeId?: string, setAt: number, settingsEventId?: string, powAnchorRef?: string, powAnchors?: string[] }>} */
+/** @type {Map<string, { signalingAppId: string, roomSecret: string, dmSessionTag?: string, fromNodeId?: string, setAt: number, settingsEventId?: string }>} */
 const bootstrapByKey = new Map()
 
 /** @type {Map<string, { signalingAppId: string, roomSecret: string, dmSessionTag?: string, fromNodeId: string, setAt: number, settingsEventId?: string }>} */
@@ -49,14 +49,12 @@ function sanitizeBootstrapRow(row) {
 	if (!row) return row
 	const roomSecret = stripMistakenFieldPrefix(row.roomSecret, ['roomSecret'])
 	const fromNodeId = stripMistakenFieldPrefix(row.fromNodeId, ['introducerNodeHash', 'fromNodeId'])
-	const powAnchorRef = stripMistakenFieldPrefix(row.powAnchorRef, ['powAnchorRef'])
-	if (roomSecret === row.roomSecret && fromNodeId === row.fromNodeId && powAnchorRef === row.powAnchorRef)
+	if (roomSecret === row.roomSecret && fromNodeId === row.fromNodeId)
 		return row
 	return {
 		...row,
 		roomSecret,
 		fromNodeId,
-		powAnchorRef,
 	}
 }
 
@@ -93,7 +91,7 @@ function loadBootstrapRow(username, groupId) {
 /**
  * @param {string} username 用户
  * @param {string} groupId 群 ID
- * @param {{ signalingAppId?: string, roomSecret: string, dmSessionTag?: string, fromNodeId?: string, powAnchorRef?: string, powAnchors?: string[] }} creds 邀请/bootstrap 凭证
+ * @param {{ signalingAppId?: string, roomSecret: string, dmSessionTag?: string, fromNodeId?: string }} creds 邀请/bootstrap 凭证
  * @returns {void}
  */
 export function setFederationBootstrap(username, groupId, creds) {
@@ -105,8 +103,6 @@ export function setFederationBootstrap(username, groupId, creds) {
 		fromNodeId: creds.fromNodeId || undefined,
 		setAt: Date.now(),
 		settingsEventId: creds.settingsEventId || undefined,
-		powAnchorRef: creds.powAnchorRef || undefined,
-		powAnchors: Array.isArray(creds.powAnchors) ? creds.powAnchors : undefined,
 	})
 	if (!row?.roomSecret) return
 	persistBootstrapRow(username, groupId, row)

--- a/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
@@ -17,7 +17,7 @@ import { roomCredentialsFromGroupSettings } from './roomCredentials.mjs'
 const FETCH_TIMEOUT_MS = 14_000
 const CHALLENGE_WANT_MAX_PER_MIN = 30
 
-/** @type {Map<string, { resolve: (v: object | null) => void, timer: ReturnType<typeof setTimeout> }>} */
+/** @type {Map<string, { promise: Promise<object | null>, resolve: (v: object | null) => void, timer: ReturnType<typeof setTimeout> }>} */
 const pendingFetches = new Map()
 
 /**
@@ -25,7 +25,7 @@ const pendingFetches = new Map()
  * @param {string} groupId 群 ID
  * @returns {string} 等待键
  */
-function waitKey(username, groupId) {
+export function waitKey(username, groupId) {
 	return `${username}\0${groupId}\0pow_challenge`
 }
 
@@ -33,7 +33,7 @@ function waitKey(username, groupId) {
  * @param {string} bucketKey 限流键
  * @returns {boolean} 是否允许 want
  */
-function consumeChallengeWant(bucketKey) {
+export function consumeChallengeWant(bucketKey) {
 	return consumeWireRateBucket(bucketKey, { maxCount: CHALLENGE_WANT_MAX_PER_MIN })
 }
 
@@ -85,22 +85,25 @@ export async function handleFedPowChallengeWant(username, groupId, data, peerId,
 }
 
 /**
- * 处理入站 `fed_pow_challenge_data`：兑现等待中的 Promise。
+ * 处理入站 `fed_pow_challenge_data`：按已验证发送者兑现等待中的 Promise。
  * @param {string} username 用户
  * @param {string} groupId 群 ID
  * @param {unknown} data 载荷
+ * @param {string} senderNodeHash 发送方 nodeHash（node scope 已验证）
  * @returns {void}
  */
-export function handleFedPowChallengeData(username, groupId, data) {
+export function handleFedPowChallengeData(username, groupId, data, senderNodeHash) {
 	if (!isPlainObject(data)) return
 	if (data.groupId !== groupId) return
 	if (!Array.isArray(data.anchors) || !data.anchors.length) return
+	if (typeof senderNodeHash !== 'string' || !senderNodeHash) return
+	if (data.nodeHash && data.nodeHash !== senderNodeHash) return
 	const key = waitKey(username, groupId)
 	const pending = pendingFetches.get(key)
 	if (!pending) return
 	clearTimeout(pending.timer)
 	pendingFetches.delete(key)
-	pending.resolve({ ...data, responderNodeHash: data.nodeHash || undefined })
+	pending.resolve({ ...data, responderNodeHash: senderNodeHash })
 }
 
 /**
@@ -114,13 +117,15 @@ export function handleFedPowChallengeData(username, groupId, data) {
 export async function requestPowChallengeFromUserRoom(username, groupId, options = {}) {
 	if (!consumeChallengeWant(waitKey(username, groupId))) return null
 	const key = waitKey(username, groupId)
-	const resultPromise = new Promise(resolve => {
-		const timer = setTimeout(() => {
-			pendingFetches.delete(key)
-			resolve(null)
-		}, FETCH_TIMEOUT_MS)
-		pendingFetches.set(key, { resolve, timer })
-	})
+	const existing = pendingFetches.get(key)
+	if (existing) return existing.promise
+	let resolvePending
+	const promise = new Promise(resolve => { resolvePending = resolve })
+	const timer = setTimeout(() => {
+		pendingFetches.delete(key)
+		resolvePending(null)
+	}, FETCH_TIMEOUT_MS)
+	pendingFetches.set(key, { promise, resolve: resolvePending, timer })
 	const { ensureUserRoom, deliverToUserRoomPeers } = await import('npm:@steve02081504/fount-p2p/transport/user_room')
 	const { DEFAULT_TRUST_GRAPH_OWNER, requireTrustGraphProvider } = await import('npm:@steve02081504/fount-p2p/trust_graph/registry')
 	const payload = { groupId }
@@ -135,7 +140,7 @@ export async function requestPowChallengeFromUserRoom(username, groupId, options
 	const sent = await deliverToUserRoomPeers(username, 'fed_pow_challenge_want', payload)
 	if (sent <= 0)
 		await requireTrustGraphProvider(DEFAULT_TRUST_GRAPH_OWNER).fanoutToTopNodes(username, 'fed_pow_challenge_want', payload, 6)
-	return await resultPromise
+	return await promise
 }
 
 /**
@@ -159,10 +164,10 @@ export function attachUserRoomPowChallengeHandlers(username, wire) {
 			new Map(),
 		).catch(error => console.warn('federation: user-room fed_pow_challenge_want failed', error))
 	})
-	wire.on('fed_pow_challenge_data', data => {
+	wire.on('fed_pow_challenge_data', (data, peerId) => {
 		if (!isPlainObject(data)) return
 		const groupId = data.groupId || ''
 		if (!groupId) return
-		handleFedPowChallengeData(username, groupId, data)
+		handleFedPowChallengeData(username, groupId, data, peerId)
 	})
 }

--- a/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
@@ -1,0 +1,168 @@
+/**
+ * 【文件】federation/powChallengeFederation.mjs
+ * 【职责】入群 PoW challenge 联邦拉取：`fed_pow_challenge_want` / `fed_pow_challenge_data`。
+ * 【原理】无本地 replica 的加入者无法 `/state` 拿到 dagTips，需经 user-room node scope 向持有该群的
+ *   邻居索取当前稳定锚 + 难度；discoveryPublic 的 pow 群一并返回 roomSecret 供 bootstrap。
+ * 【数据结构】want `{ groupId }`；data `{ groupId, anchors, powFloorBits, powEpochMs, discoveryPublic, roomSecret?, signalingAppId?, responderNodeHash? }`。
+ * 【关联】group/routes/membership.mjs 的 `/pow-challenge`、public/src/powJoin.mjs、userRoomEmojiRegistry.mjs。
+ */
+import { isPlainObject } from 'npm:@steve02081504/fount-p2p/core/object'
+import { consumeWireRateBucket } from 'npm:@steve02081504/fount-p2p/wire/rate_bucket'
+
+import { getState } from '../../chat/dag/materialize.mjs'
+import { collectJoinPowAnchors } from '../../chat/governance/joinPowAnchors.mjs'
+
+import { roomCredentialsFromGroupSettings } from './roomCredentials.mjs'
+
+const FETCH_TIMEOUT_MS = 14_000
+const CHALLENGE_WANT_MAX_PER_MIN = 30
+
+/** @type {Map<string, { resolve: (v: object | null) => void, timer: ReturnType<typeof setTimeout> }>} */
+const pendingFetches = new Map()
+
+/**
+ * @param {string} username 用户
+ * @param {string} groupId 群 ID
+ * @returns {string} 等待键
+ */
+function waitKey(username, groupId) {
+	return `${username}\0${groupId}\0pow_challenge`
+}
+
+/**
+ * @param {string} bucketKey 限流键
+ * @returns {boolean} 是否允许 want
+ */
+function consumeChallengeWant(bucketKey) {
+	return consumeWireRateBucket(bucketKey, { maxCount: CHALLENGE_WANT_MAX_PER_MIN })
+}
+
+/**
+ * 处理入站 `fed_pow_challenge_want`：本地持有 pow 群时回复 `fed_pow_challenge_data`。
+ * @param {string} username 用户
+ * @param {string} groupId 群 ID
+ * @param {unknown} data 载荷
+ * @param {string} peerId 对端
+ * @param {(payload: unknown, peerId: string) => void} sendChallengeData 发送 fed_pow_challenge_data
+ * @param {(id: string) => boolean} isBlockedPeer 拉黑检查
+ * @param {Map<string, string>} peerToNode peer→node 映射
+ * @returns {Promise<void>}
+ */
+export async function handleFedPowChallengeWant(username, groupId, data, peerId, sendChallengeData, isBlockedPeer, peerToNode) {
+	if (!isPlainObject(data)) return
+	if (data.groupId !== groupId) return
+	if (!consumeChallengeWant(waitKey(username, groupId))) return
+	const remoteNode = peerToNode.get(peerId)
+	if (remoteNode && isBlockedPeer(remoteNode)) return
+	let state
+	try {
+		({ state } = await getState(username, groupId))
+	}
+	catch {
+		return
+	}
+	if (state.groupSettings?.joinPolicy !== 'pow') return
+	const payload = {
+		groupId,
+		anchors: collectJoinPowAnchors(state),
+		powFloorBits: Number(state.groupSettings?.powFloorBits) || 0,
+		powEpochMs: Number(state.groupSettings?.powEpochMs) || 0,
+		discoveryPublic: Boolean(state.groupSettings?.discoveryPublic),
+	}
+	if (payload.discoveryPublic) {
+		const creds = roomCredentialsFromGroupSettings(state.groupSettings)
+		if (creds) {
+			payload.roomSecret = creds.roomSecret
+			payload.signalingAppId = creds.signalingAppId
+		}
+	}
+	try {
+		sendChallengeData(payload, peerId)
+	}
+	catch (error) {
+		console.warn('federation: fed_pow_challenge_data send failed', error)
+	}
+}
+
+/**
+ * 处理入站 `fed_pow_challenge_data`：兑现等待中的 Promise。
+ * @param {string} username 用户
+ * @param {string} groupId 群 ID
+ * @param {unknown} data 载荷
+ * @returns {void}
+ */
+export function handleFedPowChallengeData(username, groupId, data) {
+	if (!isPlainObject(data)) return
+	if (data.groupId !== groupId) return
+	if (!Array.isArray(data.anchors) || !data.anchors.length) return
+	const key = waitKey(username, groupId)
+	const pending = pendingFetches.get(key)
+	if (!pending) return
+	clearTimeout(pending.timer)
+	pendingFetches.delete(key)
+	pending.resolve({ ...data, responderNodeHash: data.nodeHash || undefined })
+}
+
+/**
+ * 经 user-room node scope 向邻居索取入群 PoW challenge。
+ * 先定向拨号候选节点（引入者/发现源）建立链路，再广播 want 并等待首个有效响应。
+ * @param {string} username 用户
+ * @param {string} groupId 群 ID
+ * @param {{ introducerNodeHash?: string }} [options] 优先定向的引入者节点
+ * @returns {Promise<object | null>} challenge 或 null
+ */
+export async function requestPowChallengeFromUserRoom(username, groupId, options = {}) {
+	if (!consumeChallengeWant(waitKey(username, groupId))) return null
+	const key = waitKey(username, groupId)
+	const resultPromise = new Promise(resolve => {
+		const timer = setTimeout(() => {
+			pendingFetches.delete(key)
+			resolve(null)
+		}, FETCH_TIMEOUT_MS)
+		pendingFetches.set(key, { resolve, timer })
+	})
+	const { ensureUserRoom, deliverToUserRoomPeers } = await import('npm:@steve02081504/fount-p2p/transport/user_room')
+	const { DEFAULT_TRUST_GRAPH_OWNER, requireTrustGraphProvider } = await import('npm:@steve02081504/fount-p2p/trust_graph/registry')
+	const payload = { groupId }
+	await ensureUserRoom({ replicaUsername: username })
+	if (options.introducerNodeHash) {
+		const { ensureLinkToNode } = await import('npm:@steve02081504/fount-p2p/transport/link_registry')
+		try {
+			await ensureLinkToNode(options.introducerNodeHash)
+		}
+		catch { /* dial 失败交给 fanout 兜底 */ }
+	}
+	const sent = await deliverToUserRoomPeers(username, 'fed_pow_challenge_want', payload)
+	if (sent <= 0)
+		await requireTrustGraphProvider(DEFAULT_TRUST_GRAPH_OWNER).fanoutToTopNodes(username, 'fed_pow_challenge_want', payload, 6)
+	return await resultPromise
+}
+
+/**
+ * 在 node scope user-room 注册 fed_pow_challenge_*。
+ * @param {string} username 用户
+ * @param {{ on: (name: string, handler: (payload: unknown, peerId: string) => void) => void, send: (name: string, payload: unknown, peerId: string | null) => void }} wire user-room wire
+ * @returns {void}
+ */
+export function attachUserRoomPowChallengeHandlers(username, wire) {
+	wire.on('fed_pow_challenge_want', (data, peerId) => {
+		if (!isPlainObject(data)) return
+		const groupId = data.groupId || ''
+		if (!groupId) return
+		void handleFedPowChallengeWant(
+			username,
+			groupId,
+			data,
+			peerId,
+			(payload, targetPeerId) => wire.send('fed_pow_challenge_data', { ...payload, groupId }, targetPeerId),
+			() => false,
+			new Map(),
+		).catch(error => console.warn('federation: user-room fed_pow_challenge_want failed', error))
+	})
+	wire.on('fed_pow_challenge_data', data => {
+		if (!isPlainObject(data)) return
+		const groupId = data.groupId || ''
+		if (!groupId) return
+		handleFedPowChallengeData(username, groupId, data)
+	})
+}

--- a/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/powChallengeFederation.mjs
@@ -21,6 +21,7 @@ const CHALLENGE_WANT_MAX_PER_MIN = 30
 const pendingFetches = new Map()
 
 /**
+ * 生成用户与群的入群 PoW challenge 等待/限流键。
  * @param {string} username 用户
  * @param {string} groupId 群 ID
  * @returns {string} 等待键
@@ -30,6 +31,7 @@ export function waitKey(username, groupId) {
 }
 
 /**
+ * 消费一次入群 PoW challenge 配额（超出上限则拒绝）。
  * @param {string} bucketKey 限流键
  * @returns {boolean} 是否允许 want
  */
@@ -126,20 +128,29 @@ export async function requestPowChallengeFromUserRoom(username, groupId, options
 		resolvePending(null)
 	}, FETCH_TIMEOUT_MS)
 	pendingFetches.set(key, { promise, resolve: resolvePending, timer })
-	const { ensureUserRoom, deliverToUserRoomPeers } = await import('npm:@steve02081504/fount-p2p/transport/user_room')
-	const { DEFAULT_TRUST_GRAPH_OWNER, requireTrustGraphProvider } = await import('npm:@steve02081504/fount-p2p/trust_graph/registry')
-	const payload = { groupId }
-	await ensureUserRoom({ replicaUsername: username })
-	if (options.introducerNodeHash) {
-		const { ensureLinkToNode } = await import('npm:@steve02081504/fount-p2p/transport/link_registry')
-		try {
-			await ensureLinkToNode(options.introducerNodeHash)
+	try {
+		const { ensureUserRoom, deliverToUserRoomPeers } = await import('npm:@steve02081504/fount-p2p/transport/user_room')
+		const { DEFAULT_TRUST_GRAPH_OWNER, requireTrustGraphProvider } = await import('npm:@steve02081504/fount-p2p/trust_graph/registry')
+		const payload = { groupId }
+		await ensureUserRoom({ replicaUsername: username })
+		if (options.introducerNodeHash) {
+			const { ensureLinkToNode } = await import('npm:@steve02081504/fount-p2p/transport/link_registry')
+			try {
+				await ensureLinkToNode(options.introducerNodeHash)
+			}
+			catch { /* dial 失败交给 fanout 兜底 */ }
 		}
-		catch { /* dial 失败交给 fanout 兜底 */ }
+		const sent = await deliverToUserRoomPeers(username, 'fed_pow_challenge_want', payload)
+		if (sent <= 0)
+			await requireTrustGraphProvider(DEFAULT_TRUST_GRAPH_OWNER).fanoutToTopNodes(username, 'fed_pow_challenge_want', payload, 6)
 	}
-	const sent = await deliverToUserRoomPeers(username, 'fed_pow_challenge_want', payload)
-	if (sent <= 0)
-		await requireTrustGraphProvider(DEFAULT_TRUST_GRAPH_OWNER).fanoutToTopNodes(username, 'fed_pow_challenge_want', payload, 6)
+	catch (error) {
+		if (pendingFetches.get(key)?.promise === promise) {
+			clearTimeout(timer)
+			pendingFetches.delete(key)
+		}
+		throw error
+	}
 	return await promise
 }
 

--- a/src/public/parts/shells/chat/src/chat/federation/userRoomPowChallengeRegistry.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/userRoomPowChallengeRegistry.mjs
@@ -1,0 +1,20 @@
+import { registerNodeScopeWireHook } from 'npm:@steve02081504/fount-p2p/transport/node_scope/wire'
+
+import { attachUserRoomPowChallengeHandlers } from './powChallengeFederation.mjs'
+
+/** @type {(() => void) | null} */
+let unregisterHook = null
+
+/** @returns {void} */
+export function registerChatUserRoomPowChallengeHandlers() {
+	if (unregisterHook) return
+	unregisterHook = registerNodeScopeWireHook((context, wire) => {
+		attachUserRoomPowChallengeHandlers(context.replicaUsername, wire)
+	})
+}
+
+/** @returns {void} */
+export function unregisterChatUserRoomPowChallengeHandlers() {
+	unregisterHook?.()
+	unregisterHook = null
+}

--- a/src/public/parts/shells/chat/src/chat/federation/userRoomPowChallengeRegistry.mjs
+++ b/src/public/parts/shells/chat/src/chat/federation/userRoomPowChallengeRegistry.mjs
@@ -5,7 +5,10 @@ import { attachUserRoomPowChallengeHandlers } from './powChallengeFederation.mjs
 /** @type {(() => void) | null} */
 let unregisterHook = null
 
-/** @returns {void} */
+/**
+ * 在 node scope 注册 user-room PoW challenge 处理器。
+ * @returns {void}
+ */
 export function registerChatUserRoomPowChallengeHandlers() {
 	if (unregisterHook) return
 	unregisterHook = registerNodeScopeWireHook((context, wire) => {
@@ -13,7 +16,10 @@ export function registerChatUserRoomPowChallengeHandlers() {
 	})
 }
 
-/** @returns {void} */
+/**
+ * 注销 user-room PoW challenge 处理器。
+ * @returns {void}
+ */
 export function unregisterChatUserRoomPowChallengeHandlers() {
 	unregisterHook?.()
 	unregisterHook = null

--- a/src/public/parts/shells/chat/src/group/routes/membership.mjs
+++ b/src/public/parts/shells/chat/src/group/routes/membership.mjs
@@ -18,7 +18,7 @@ import { computeDmRoomLabelFromPubKeys } from '../../chat/dm/labels.mjs'
 import { validateDmIntroLinkProof } from '../../chat/dm/linkValidate.mjs'
 import { getFederationSettings } from '../../chat/federation/config.mjs'
 import { activateGroupFederation, isGroupFederationActive } from '../../chat/federation/groupFederation.mjs'
-import { requestPowChallengeFromUserRoom } from '../../chat/federation/powChallengeFederation.mjs'
+import { consumeChallengeWant, requestPowChallengeFromUserRoom, waitKey } from '../../chat/federation/powChallengeFederation.mjs'
 import { roomCredentialsFromGroupSettings } from '../../chat/federation/roomCredentials.mjs'
 import { collectJoinPowAnchors } from '../../chat/governance/joinPowAnchors.mjs'
 import { mintGroupInviteTicket } from '../../chat/lib/inviteTickets.mjs'
@@ -57,17 +57,16 @@ function groupHasBootstrapGenesis(state) {
  * @returns {Promise<string>} 本地化剪贴板文本
  */
 function buildInviteClipboardText(username, groupId, code, { roomSecret, introducerPubKeyHash, introducerNodeHash }) {
-	const url = formatJoinInviteUrl({
-		groupId,
-		inviteCode: code,
-		roomSecret,
-		introducerPubKeyHash,
-		introducerNodeHash,
-	})
 	return geti18nForUser(username, 'chat.group.settings.page.invite.clipboard', {
 		groupId,
 		code,
-		url,
+		url: formatJoinInviteUrl({
+			groupId,
+			inviteCode: code,
+			roomSecret,
+			introducerPubKeyHash,
+			introducerNodeHash,
+		}),
 	})
 }
 
@@ -171,14 +170,16 @@ export function registerMembershipRoutes(router, authenticate) {
 		let discoverySources = []
 		try {
 			const { loadDiscoveryIndex } = await import('../../chat/discovery/index.mjs')
-			const entry = (await loadDiscoveryIndex(username)).entries.find(e => e.groupId === groupId)
+			const discoveryEntry = (await loadDiscoveryIndex(username)).entries.find(entry => entry.groupId === groupId)
 			discoverySources = [...new Set([
-				...(entry?.sources || []).map(s => s.fromNodeHash).filter(Boolean),
-				entry?.advertiserNodeHash || '',
+				...(discoveryEntry?.sources || []).map(source => source.fromNodeHash).filter(Boolean),
+				discoveryEntry?.advertiserNodeHash || '',
 			].filter(Boolean))]
 		}
 		catch { /* 索引不可用 */ }
 		const candidates = [...new Set([introducerNodeHash, ...discoverySources].filter(Boolean))]
+		if (!consumeChallengeWant(waitKey(username, groupId)))
+			throw httpError(429, 'pow challenge rate limited')
 		const { ensureLinkToNode } = await import('npm:@steve02081504/fount-p2p/transport/link_registry')
 		for (const nodeHash of candidates)
 			try {

--- a/src/public/parts/shells/chat/src/group/routes/membership.mjs
+++ b/src/public/parts/shells/chat/src/group/routes/membership.mjs
@@ -10,7 +10,7 @@ import { PERMISSIONS } from 'fount/public/parts/shells/chat/src/permissions/chat
 import { httpError } from '../../../../../../../scripts/http_error.mjs'
 import { geti18nForUser } from '../../../../../../../scripts/i18n/index.mjs'
 import { getUserByReq } from '../../../../../../../server/auth/index.mjs'
-import { formatJoinRunUri, wrapProtocolHttpsUrl } from '../../../public/shared/runUri.mjs'
+import { formatJoinInviteUrl } from '../../../public/shared/runUri.mjs'
 import { leaveManyGroupsForUser } from '../../chat/dag/leaveMany.mjs'
 import { resolveLocalEventSigner } from '../../chat/dag/localSigner.mjs'
 import { getState } from '../../chat/dag/materialize.mjs'
@@ -18,6 +18,7 @@ import { computeDmRoomLabelFromPubKeys } from '../../chat/dm/labels.mjs'
 import { validateDmIntroLinkProof } from '../../chat/dm/linkValidate.mjs'
 import { getFederationSettings } from '../../chat/federation/config.mjs'
 import { activateGroupFederation, isGroupFederationActive } from '../../chat/federation/groupFederation.mjs'
+import { requestPowChallengeFromUserRoom } from '../../chat/federation/powChallengeFederation.mjs'
 import { roomCredentialsFromGroupSettings } from '../../chat/federation/roomCredentials.mjs'
 import { collectJoinPowAnchors } from '../../chat/governance/joinPowAnchors.mjs'
 import { mintGroupInviteTicket } from '../../chat/lib/inviteTickets.mjs'
@@ -49,21 +50,20 @@ function groupHasBootstrapGenesis(state) {
  * @param {string} username 签发者
  * @param {string} groupId 群 ID
  * @param {string} code 邀请码
- * @param {string} roomSecret 群房间传输密钥（写入 join 深链）
- * @param {string} introducerPubKeyHash 邀请人成员 pubKeyHash
- * @param {string | null} [powAnchorRef] PoW anchor 提示（写入 join 深链）
- * @param {string | null} [introducerNodeHash] 邀请人 nodeHash（写入 join 深链）
+ * @param {object} options 载荷字段
+ * @param {string} options.roomSecret 群房间传输密钥（写入 join 深链）
+ * @param {string} options.introducerPubKeyHash 邀请人成员 pubKeyHash
+ * @param {string} [options.introducerNodeHash] 邀请人 nodeHash（写入 join 深链）
  * @returns {Promise<string>} 本地化剪贴板文本
  */
-function buildInviteClipboardText(username, groupId, code, roomSecret, introducerPubKeyHash, powAnchorRef, introducerNodeHash) {
-	const url = wrapProtocolHttpsUrl(formatJoinRunUri({
+function buildInviteClipboardText(username, groupId, code, { roomSecret, introducerPubKeyHash, introducerNodeHash }) {
+	const url = formatJoinInviteUrl({
 		groupId,
 		inviteCode: code,
 		roomSecret,
 		introducerPubKeyHash,
-		powAnchorRef,
 		introducerNodeHash,
-	}))
+	})
 	return geti18nForUser(username, 'chat.group.settings.page.invite.clipboard', {
 		groupId,
 		code,
@@ -127,16 +127,15 @@ export function registerMembershipRoutes(router, authenticate) {
 			? roomCredentialsFromGroupSettings(state.groupSettings)
 			: await activateGroupFederation(username, groupId)
 		const { sender: introducerPubKeyHash } = await resolveLocalEventSigner(username, groupId)
-		const powAnchors = collectJoinPowAnchors(state)
-		const powAnchorRef = powAnchors[0] ?? null
 		const clipboardText = await buildInviteClipboardText(
 			username,
 			groupId,
 			ticket.code,
-			roomCreds.roomSecret,
-			introducerPubKeyHash,
-			powAnchorRef,
-			getLocalNodeHash(),
+			{
+				roomSecret: roomCreds.roomSecret,
+				introducerPubKeyHash,
+				introducerNodeHash: getLocalNodeHash(),
+			},
 		)
 		res.status(201).json({
 			...ticket,
@@ -145,17 +144,58 @@ export function registerMembershipRoutes(router, authenticate) {
 			roomSecret: roomCreds.roomSecret,
 			introducerPubKeyHash,
 			introducerNodeHash: getLocalNodeHash(),
-			powAnchors,
-			powAnchorRef,
 			dmSessionTag: state.groupMeta?.dmKind === 'ecdh'
 				? state.groupMeta.dmSessionTag || null
 				: null,
 		})
 	})
 
+	router.get(`${GROUPS_PREFIX}/:groupId/pow-challenge`, authenticate, async (req, res) => {
+		const { username } = getUserByReq(req)
+		const { groupId } = req.params
+		let state
+		try {
+			({ state } = await getState(username, groupId))
+		}
+		catch { /* 无本地 replica，走联邦 */ }
+		if (state?.groupSettings?.joinPolicy === 'pow') {
+			res.status(200).json({
+				anchors: collectJoinPowAnchors(state),
+				powFloorBits: Number(state.groupSettings?.powFloorBits) || 0,
+				powEpochMs: Number(state.groupSettings?.powEpochMs) || 0,
+			})
+			return
+		}
+		// 无本地 replica：优先定向引入者/发现源节点，其次 user-room fanout。
+		const introducerNodeHash = String(req.query.introducerNodeHash || '').trim() || undefined
+		let discoverySources = []
+		try {
+			const { loadDiscoveryIndex } = await import('../../chat/discovery/index.mjs')
+			const entry = (await loadDiscoveryIndex(username)).entries.find(e => e.groupId === groupId)
+			discoverySources = [...new Set([
+				...(entry?.sources || []).map(s => s.fromNodeHash).filter(Boolean),
+				entry?.advertiserNodeHash || '',
+			].filter(Boolean))]
+		}
+		catch { /* 索引不可用 */ }
+		const candidates = [...new Set([introducerNodeHash, ...discoverySources].filter(Boolean))]
+		const { ensureLinkToNode } = await import('npm:@steve02081504/fount-p2p/transport/link_registry')
+		for (const nodeHash of candidates)
+			try {
+				await ensureLinkToNode(nodeHash)
+			}
+			catch { /* dial 失败交给 fanout 兜底 */ }
+		const challenge = await requestPowChallengeFromUserRoom(username, groupId, {
+			introducerNodeHash: candidates[0],
+		})
+		if (!challenge)
+			throw httpError(404, 'Group not found or not pow')
+		res.status(200).json(challenge)
+	})
+
 	router.post(`${GROUPS_PREFIX}/:groupId/join`, authenticate, async (req, res) => {
 		const { username } = getUserByReq(req)
-		const { params: { groupId }, body: { inviteCode, pow, introducerPubKeyHash, introducerNodeHash, reputationEdge, dmIntroNonce, dmIntroSignatureHex, roomSecret, signalingAppId, dmSessionTag, powAnchorRef, powAnchors } } = req
+		const { params: { groupId }, body: { inviteCode, pow, introducerPubKeyHash, introducerNodeHash, reputationEdge, dmIntroNonce, dmIntroSignatureHex, roomSecret, signalingAppId, dmSessionTag } } = req
 		if (!!dmIntroNonce !== !!dmIntroSignatureHex)
 			throw httpError(400, 'provide both dmIntroNonce and dmIntroSignatureHex for DM link proof or omit both')
 		const { state } = await getState(username, groupId)
@@ -174,8 +214,6 @@ export function registerMembershipRoutes(router, authenticate) {
 				signalingAppId,
 				roomSecret,
 				fromNodeId: introducerNodeHash,
-				powAnchorRef,
-				powAnchors,
 				dmSessionTag,
 			}
 			if (!dmSessionTag && dmIntroNonce) {

--- a/src/public/parts/shells/chat/src/group/routes/membership.mjs
+++ b/src/public/parts/shells/chat/src/group/routes/membership.mjs
@@ -165,6 +165,7 @@ export function registerMembershipRoutes(router, authenticate) {
 			})
 			return
 		}
+		if (state) throw httpError(404, 'Group not found or not pow')
 		// 无本地 replica：优先定向引入者/发现源节点，其次 user-room fanout。
 		const introducerNodeHash = String(req.query.introducerNodeHash || '').trim() || undefined
 		let discoverySources = []

--- a/src/public/parts/shells/chat/test/integration/pow_challenge_bootstrap.mjs
+++ b/src/public/parts/shells/chat/test/integration/pow_challenge_bootstrap.mjs
@@ -1,0 +1,50 @@
+/**
+ * pow-challenge HTTP 集成测 bootstrap：建 pow+discoveryPublic 群，写入 setup JSON。
+ */
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import process from 'node:process'
+
+/**
+ * @param {string} username 用户
+ * @returns {Promise<object>} setup
+ */
+async function setupPowChallenge(username) {
+	const { ensureOperatorPubKey } = await import('fount/public/parts/shells/chat/src/entity/identity.mjs')
+	await ensureOperatorPubKey(username)
+	const { newGroup } = await import('../../src/chat/session/groupLifecycle.mjs')
+	const { getDefaultChannelId } = await import('../../src/chat/dag/queries.mjs')
+	const { appendSignedLocalEvent } = await import('../../src/chat/dag/append.mjs')
+	const { getChatClient } = await import('../../src/api/client/index.mjs')
+
+	const groupId = await newGroup(username, { name: 'pow-challenge' })
+	const channelId = await getDefaultChannelId(username, groupId)
+	await appendSignedLocalEvent(username, groupId, {
+		type: 'group_settings_update',
+		timestamp: Date.now(),
+		content: {
+			joinPolicy: 'pow',
+			discoveryPublic: true,
+			powFloorBits: 4,
+		},
+	})
+	const client = await getChatClient(username)
+	const group = await client.group(groupId)
+	const inviteUrl = await group.createInvite()
+	return { groupId, channelId, inviteUrl }
+}
+
+/**
+ * @param {string} username 测试用户名
+ * @returns {Promise<void>}
+ */
+export default async function bootstrap(username) {
+	const setup = await setupPowChallenge(username)
+	const dataPath = process.env.FOUNT_TEST_DATA_PATH
+	if (dataPath)
+		await writeFile(
+			join(dataPath, 'pow_challenge_setup.json'),
+			JSON.stringify(setup),
+			'utf8',
+		)
+}

--- a/src/public/parts/shells/chat/test/integration/pow_challenge_bootstrap.mjs
+++ b/src/public/parts/shells/chat/test/integration/pow_challenge_bootstrap.mjs
@@ -18,7 +18,6 @@ async function setupPowChallenge(username) {
 	const { getChatClient } = await import('../../src/api/client/index.mjs')
 
 	const groupId = await newGroup(username, { name: 'pow-challenge' })
-	const channelId = await getDefaultChannelId(username, groupId)
 	await appendSignedLocalEvent(username, groupId, {
 		type: 'group_settings_update',
 		timestamp: Date.now(),
@@ -31,10 +30,11 @@ async function setupPowChallenge(username) {
 	const client = await getChatClient(username)
 	const group = await client.group(groupId)
 	const inviteUrl = await group.createInvite()
-	return { groupId, channelId, inviteUrl }
+	return { groupId, channelId: await getDefaultChannelId(username, groupId), inviteUrl }
 }
 
 /**
+ * 初始化 PoW challenge 集成测试数据：建 pow+discoveryPublic 群并写入 setup JSON。
  * @param {string} username 测试用户名
  * @returns {Promise<void>}
  */

--- a/src/public/parts/shells/chat/test/integration/pow_challenge_http.test.mjs
+++ b/src/public/parts/shells/chat/test/integration/pow_challenge_http.test.mjs
@@ -24,8 +24,8 @@ const CHAT_PREFIX = '/api/parts/shells:chat'
  * @returns {Promise<Response>} fetch 响应
  */
 function chatFetch(node, method, path, body) {
-	const sep = path.includes('?') ? '&' : '?'
-	const url = `${node.baseUrl}${CHAT_PREFIX}${path}${sep}fount-apikey=${encodeURIComponent(node.apiKey)}`
+	const querySeparator = path.includes('?') ? '&' : '?'
+	const url = `${node.baseUrl}${CHAT_PREFIX}${path}${querySeparator}fount-apikey=${encodeURIComponent(node.apiKey)}`
 	return fetch(url, {
 		method,
 		headers: body ? { 'content-type': 'application/json' } : undefined,
@@ -37,7 +37,7 @@ function chatFetch(node, method, path, body) {
  * @returns {Promise<{ node: object, setup: object }>} 已启动节点与 bootstrap 写入的 setup
  */
 async function launchPowScenario() {
-	const dataPath = await mkdtemp(join(tmpdir(), `fount_chat_pow_challenge_`))
+	const dataPath = await mkdtemp(join(tmpdir(), 'fount_chat_pow_challenge_'))
 	const apiKey = `fount-chat-pow-challenge-${Date.now().toString(36)}`
 	const node = await launchNode({
 		dataPath,
@@ -51,8 +51,7 @@ async function launchPowScenario() {
 			FOUNT_TEST_DATA_PATH: dataPath,
 		},
 	})
-	const setupRaw = await readFile(join(dataPath, 'pow_challenge_setup.json'), 'utf8')
-	return { node, setup: JSON.parse(setupRaw) }
+	return { node, setup: JSON.parse(await readFile(join(dataPath, 'pow_challenge_setup.json'), 'utf8')) }
 }
 
 Deno.test({
@@ -62,10 +61,9 @@ Deno.test({
 }, async () => {
 	const { node, setup } = await launchPowScenario()
 	try {
-		const res = await chatFetch(node, 'GET', `/groups/${setup.groupId}/pow-challenge`)
-		assertEquals(res.status, 200)
-		const body = await res.json()
-		assertEquals(body.joinPolicy, 'pow')
+		const response = await chatFetch(node, 'GET', `/groups/${setup.groupId}/pow-challenge`)
+		assertEquals(response.status, 200)
+		const body = await response.json()
 		assert(Array.isArray(body.anchors) && body.anchors.length > 0, 'anchors non-empty')
 		assert(typeof body.powFloorBits === 'number' && body.powFloorBits > 0, 'powFloorBits present')
 	} finally {

--- a/src/public/parts/shells/chat/test/integration/pow_challenge_http.test.mjs
+++ b/src/public/parts/shells/chat/test/integration/pow_challenge_http.test.mjs
@@ -1,0 +1,101 @@
+/**
+ * pow-challenge HTTP 集成测：本地 replica 场景 —— `/pow-challenge` 返回当前锚、
+ * invite-ticket 不再输出 powAnchorRef、createInvite URL 不再携带 powAnchorRef。
+ */
+/* global Deno */
+import { readFile, mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { assert, assertEquals } from 'jsr:@std/assert'
+
+import { launchNode, stopNode } from 'fount/scripts/test/node/launch.mjs'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const bootstrapPath = join(testDir, 'pow_challenge_bootstrap.mjs')
+const CHAT_PREFIX = '/api/parts/shells:chat'
+
+/**
+ * @param {object} node launchNode 句柄
+ * @param {string} method HTTP 方法
+ * @param {string} path 相对 chat API 路径
+ * @param {object} [body] JSON body
+ * @returns {Promise<Response>} fetch 响应
+ */
+function chatFetch(node, method, path, body) {
+	const sep = path.includes('?') ? '&' : '?'
+	const url = `${node.baseUrl}${CHAT_PREFIX}${path}${sep}fount-apikey=${encodeURIComponent(node.apiKey)}`
+	return fetch(url, {
+		method,
+		headers: body ? { 'content-type': 'application/json' } : undefined,
+		body: body ? JSON.stringify(body) : undefined,
+	})
+}
+
+/**
+ * @returns {Promise<{ node: object, setup: object }>} 已启动节点与 bootstrap 写入的 setup
+ */
+async function launchPowScenario() {
+	const dataPath = await mkdtemp(join(tmpdir(), `fount_chat_pow_challenge_`))
+	const apiKey = `fount-chat-pow-challenge-${Date.now().toString(36)}`
+	const node = await launchNode({
+		dataPath,
+		username: 'pow-challenge',
+		apiKey,
+		loadParts: ['shells/chat'],
+		bootstrap: bootstrapPath,
+		minP2pNode: true,
+		p2p: false,
+		extraEnv: {
+			FOUNT_TEST_DATA_PATH: dataPath,
+		},
+	})
+	const setupRaw = await readFile(join(dataPath, 'pow_challenge_setup.json'), 'utf8')
+	return { node, setup: JSON.parse(setupRaw) }
+}
+
+Deno.test({
+	name: 'pow-challenge returns stable anchors for local pow replica',
+	sanitizeOps: false,
+	sanitizeResources: false,
+}, async () => {
+	const { node, setup } = await launchPowScenario()
+	try {
+		const res = await chatFetch(node, 'GET', `/groups/${setup.groupId}/pow-challenge`)
+		assertEquals(res.status, 200)
+		const body = await res.json()
+		assertEquals(body.joinPolicy, 'pow')
+		assert(Array.isArray(body.anchors) && body.anchors.length > 0, 'anchors non-empty')
+		assert(typeof body.powFloorBits === 'number' && body.powFloorBits > 0, 'powFloorBits present')
+	} finally {
+		await stopNode(node)
+	}
+})
+
+Deno.test({
+	name: 'invite-ticket response omits powAnchorRef; createInvite URL carries no anchor',
+	sanitizeOps: false,
+	sanitizeResources: false,
+}, async () => {
+	const { node, setup } = await launchPowScenario()
+	try {
+		const ticketRes = await chatFetch(node, 'POST', `/groups/${setup.groupId}/invite-ticket`, { ttlMs: 3_600_000 })
+		assertEquals(ticketRes.status, 201)
+		const ticket = await ticketRes.json()
+		assertEquals(ticket.powAnchorRef, undefined, 'no powAnchorRef in invite-ticket response')
+		assertEquals(ticket.powAnchors, undefined, 'no powAnchors in invite-ticket response')
+
+		// createInvite URL：parse 出的 join payload 不得含 powAnchorRef。
+		const url = setup.inviteUrl
+		const protocolUrl = new URL(url)
+		const runUri = decodeURIComponent(protocolUrl.searchParams.get('url') || '')
+		const segments = runUri.split(';').map(segment => decodeURIComponent(segment))
+		const payload = JSON.parse(segments[segments.length - 1])
+		assertEquals(payload.powAnchorRef, undefined, 'createInvite URL omits powAnchorRef')
+		assert(payload.groupId === setup.groupId, 'group id present')
+		assert(payload.roomSecret, 'roomSecret present for federation bootstrap')
+	} finally {
+		await stopNode(node)
+	}
+})

--- a/src/public/parts/shells/chat/test/manifest.json
+++ b/src/public/parts/shells/chat/test/manifest.json
@@ -165,7 +165,7 @@
 	"suites": [
 		{
 			"name": "pure",
-			"expected": "8m48s",
+			"expected": "1m44s",
 			"trigger": [
 				"shellBackend",
 				"shellPureExtra",
@@ -185,7 +185,7 @@
 		},
 		{
 			"name": "integration",
-			"expected": "13m5s",
+			"expected": "7m2s",
 			"dependsOn": [
 				"server:live"
 			],

--- a/src/public/parts/shells/chat/test/manifest.json
+++ b/src/public/parts/shells/chat/test/manifest.json
@@ -165,7 +165,7 @@
 	"suites": [
 		{
 			"name": "pure",
-			"expected": "1m44s",
+			"expected": "6m37s",
 			"trigger": [
 				"shellBackend",
 				"shellPureExtra",

--- a/src/public/parts/shells/chat/test/pure/join_pow_anchors.test.mjs
+++ b/src/public/parts/shells/chat/test/pure/join_pow_anchors.test.mjs
@@ -54,6 +54,13 @@ Deno.test('resolvePowForJoin returns null without anchors', async () => {
 	assertEquals(await resolvePowForJoin('g-pow', {}, 'j'.repeat(64)), null)
 })
 
+Deno.test('resolvePowForJoin rejects powFloorBits above protocol maximum', async () => {
+	assertEquals(await resolvePowForJoin('g-pow', null, 'j'.repeat(64), {
+		anchors: ['n'.repeat(64)],
+		powFloorBits: 257,
+	}), null)
+})
+
 Deno.test('resolvePowForJoin prefers stable anchor from local state', async () => {
 	const solution = await resolvePowForJoin('g-pow', {
 		groupSettings: { joinPolicy: 'pow', powFloorBits: 4 },

--- a/src/public/parts/shells/chat/test/pure/join_pow_anchors.test.mjs
+++ b/src/public/parts/shells/chat/test/pure/join_pow_anchors.test.mjs
@@ -1,0 +1,64 @@
+/**
+ * 入群 PoW anchor 选择测试：稳定根优先 + resolvePowForJoin 使用外部 challenge。
+ */
+/* global Deno */
+import { assert, assertEquals } from 'jsr:@std/assert'
+
+import { collectJoinPowAnchors } from '../../public/shared/joinPowAnchors.mjs'
+import { resolvePowForJoin } from '../../public/src/powJoin.mjs'
+
+Deno.test('collectJoinPowAnchors orders stable roots before tips', () => {
+	const checkpoint = 'c'.repeat(64)
+	const consensus = 'n'.repeat(64)
+	const membersRoot = 'm'.repeat(64)
+	const tipA = 'a'.repeat(64)
+	const tipB = 'b'.repeat(64)
+	const anchors = collectJoinPowAnchors({
+		dagTips: [tipA, tipB],
+		consensusBranchTip: consensus,
+		membersRoot,
+		checkpoint_event_id: checkpoint,
+	})
+	assertEquals(anchors[0], checkpoint, 'checkpoint root first')
+	assertEquals(anchors[1], consensus, 'consensus branch tip second')
+	assertEquals(anchors[2], membersRoot, 'membersRoot third')
+	assertEquals(anchors.slice(3).sort(), [tipA, tipB].sort(), 'tips last')
+})
+
+Deno.test('collectJoinPowAnchors dedupes and tolerates missing fields', () => {
+	const tip = 'a'.repeat(64)
+	assertEquals(collectJoinPowAnchors({ dagTips: [tip, tip] }), [tip])
+	assertEquals(collectJoinPowAnchors({}), [])
+})
+
+Deno.test('resolvePowForJoin solves against challenge anchors when state is empty', async () => {
+	const solution = await resolvePowForJoin('g-pow', null, 'j'.repeat(64), {
+		anchors: ['n'.repeat(64)],
+		powFloorBits: 4,
+	})
+	assertEquals(solution?.anchorRef, 'n'.repeat(64))
+	assertEquals(solution?.joinerNodeHash, 'j'.repeat(64))
+})
+
+Deno.test('resolvePowForJoin does not gate on joinPolicy (caller responsibility)', async () => {
+	const solution = await resolvePowForJoin('g-open', null, 'j'.repeat(64), {
+		anchors: ['n'.repeat(64)],
+		powFloorBits: 4,
+	})
+	assert(solution, 'solves regardless of joinPolicy')
+	assertEquals(solution.anchorRef, 'n'.repeat(64))
+})
+
+Deno.test('resolvePowForJoin returns null without anchors', async () => {
+	assertEquals(await resolvePowForJoin('g-pow', null, 'j'.repeat(64)), null)
+	assertEquals(await resolvePowForJoin('g-pow', {}, 'j'.repeat(64)), null)
+})
+
+Deno.test('resolvePowForJoin prefers stable anchor from local state', async () => {
+	const solution = await resolvePowForJoin('g-pow', {
+		groupSettings: { joinPolicy: 'pow', powFloorBits: 4 },
+		dagTips: ['a'.repeat(64)],
+		checkpoint_event_id: 'n'.repeat(64),
+	}, 'j'.repeat(64))
+	assertEquals(solution?.anchorRef, 'n'.repeat(64), 'uses checkpoint root, not tip')
+})

--- a/src/public/parts/shells/chat/test/pure/run_uri.test.mjs
+++ b/src/public/parts/shells/chat/test/pure/run_uri.test.mjs
@@ -6,6 +6,7 @@ import { assert, assertEquals } from 'jsr:@std/assert'
 
 import {
 	CHAT_RUN_PART,
+	formatJoinInviteUrl,
 	formatJoinRunUri,
 	formatMessageRunUri,
 	parseJoinRunPayload,
@@ -89,6 +90,36 @@ Deno.test('parseJoinRunPayload accepts IPC decoded JSON segment', () => {
 	// protocolhandler：split(';').map(decodeURIComponent) → invocationArguments = ['join', jsonString]
 	const invocationArguments = ['join', JSON.stringify(payload)]
 	assertEquals(parseJoinRunPayload(invocationArguments[1]), payload)
+})
+
+Deno.test('formatJoinInviteUrl omits powAnchorRef regardless of joinPolicy', () => {
+	for (const joinPolicy of ['invite-only', 'open', 'pow']) {
+		const url = formatJoinInviteUrl({
+			groupId: 'gid',
+			inviteCode: 'code',
+			roomSecret: 'secret',
+			introducerPubKeyHash: 'a'.repeat(64),
+			introducerNodeHash: 'b'.repeat(64),
+		})
+		assert(url.startsWith('https://steve02081504.github.io/fount/protocol?url='))
+		const runUri = decodeURIComponent(url.slice('https://steve02081504.github.io/fount/protocol?url='.length))
+		const parsed = parseJoinRunUri(runUri)
+		assertEquals(parsed.powAnchorRef, undefined, `no powAnchorRef for ${joinPolicy}`)
+		assertEquals(parsed.introducerNodeHash, 'b'.repeat(64))
+	}
+})
+
+Deno.test('formatJoinInviteUrl ignores state param (anchor no longer in URL)', () => {
+	const url = formatJoinInviteUrl({
+		groupId: 'gid',
+		inviteCode: 'code',
+		roomSecret: 'secret',
+		introducerPubKeyHash: 'a'.repeat(64),
+		introducerNodeHash: 'b'.repeat(64),
+	})
+	const runUri = decodeURIComponent(url.slice('https://steve02081504.github.io/fount/protocol?url='.length))
+	const parsed = parseJoinRunUri(runUri)
+	assertEquals(parsed.powAnchorRef, undefined)
 })
 
 Deno.test('parseJoinRunUri rejects non-JSON legacy join segments', () => {

--- a/src/public/parts/shells/chat/test/pure/run_uri.test.mjs
+++ b/src/public/parts/shells/chat/test/pure/run_uri.test.mjs
@@ -92,24 +92,7 @@ Deno.test('parseJoinRunPayload accepts IPC decoded JSON segment', () => {
 	assertEquals(parseJoinRunPayload(invocationArguments[1]), payload)
 })
 
-Deno.test('formatJoinInviteUrl omits powAnchorRef regardless of joinPolicy', () => {
-	for (const joinPolicy of ['invite-only', 'open', 'pow']) {
-		const url = formatJoinInviteUrl({
-			groupId: 'gid',
-			inviteCode: 'code',
-			roomSecret: 'secret',
-			introducerPubKeyHash: 'a'.repeat(64),
-			introducerNodeHash: 'b'.repeat(64),
-		})
-		assert(url.startsWith('https://steve02081504.github.io/fount/protocol?url='))
-		const runUri = decodeURIComponent(url.slice('https://steve02081504.github.io/fount/protocol?url='.length))
-		const parsed = parseJoinRunUri(runUri)
-		assertEquals(parsed.powAnchorRef, undefined, `no powAnchorRef for ${joinPolicy}`)
-		assertEquals(parsed.introducerNodeHash, 'b'.repeat(64))
-	}
-})
-
-Deno.test('formatJoinInviteUrl ignores state param (anchor no longer in URL)', () => {
+Deno.test('formatJoinInviteUrl omits powAnchorRef', () => {
 	const url = formatJoinInviteUrl({
 		groupId: 'gid',
 		inviteCode: 'code',
@@ -117,9 +100,11 @@ Deno.test('formatJoinInviteUrl ignores state param (anchor no longer in URL)', (
 		introducerPubKeyHash: 'a'.repeat(64),
 		introducerNodeHash: 'b'.repeat(64),
 	})
+	assert(url.startsWith('https://steve02081504.github.io/fount/protocol?url='))
 	const runUri = decodeURIComponent(url.slice('https://steve02081504.github.io/fount/protocol?url='.length))
 	const parsed = parseJoinRunUri(runUri)
 	assertEquals(parsed.powAnchorRef, undefined)
+	assertEquals(parsed.introducerNodeHash, 'b'.repeat(64))
 })
 
 Deno.test('parseJoinRunUri rejects non-JSON legacy join segments', () => {


### PR DESCRIPTION
## 动机
- 邀请链接中的 powAnchorRef 是易过期的静态锚（dagTips 随新事件被引用后即消失），导致分享链接很快失效
- 无本地 replica 的加入者无法通过 /state 拿到当前锚，需要联邦动态拉取

## 变更
- 新增 GET /api/parts/shells:chat/groups/:groupId/pow-challenge
  - 本地有 replica 且 joinPolicy=pow 时直接返回 anchors/powFloorBits/powEpochMs
  - 无 replica 时经 user-room node-scope 联邦拉取 fed_pow_challenge_want/data，优先拨号 introducerNodeHash / discovery sources，兜底 fanout
- 新增 powChallengeFederation.mjs + userRoomPowChallengeRegistry.mjs：注册 node-scope wire hooks，带 30/min 限流与 14s 超时；discoveryPublic 群一并返回 roomSecret/signalingAppId 供 bootstrap
- collectJoinPowAnchors (public/shared/joinPowAnchors.mjs) 改为稳定根优先：checkpoint_event_id / consensusBranchTip / membersRoot -> dagTips，调用方取 anchors[0] 即最稳定锚
- powJoin.resolvePowForJoin (public/src/powJoin.mjs) 改为基于 challenge/bootstrap anchors，不再以 joinPolicy gate，调用方负责判定 pow 策略
- 前端入群链路：groupMembership.mjs / deepLinkConsume.mjs 在无本地 state 或 canAutoJoin 失败时自动走 getPowChallenge -> resolvePow -> join
- 邀请分享：新增 formatJoinInviteUrl (public/shared/runUri.mjs)，不再写入 powAnchorRef；inviteQr.mjs / api/group.mjs / actions.mjs / membership.mjs / bootstrapStore.mjs 移除 pow 相关字段
- 测试：新增 join_pow_anchors.test.mjs、pow_challenge_bootstrap.mjs / pow_challenge_http.test.mjs，更新 run_uri.test.mjs 校验 URL 不含锚

## 测试
- fount test shells/chat:integration 需包含新增 pow_challenge_http 集成测（本地 replica 场景：/pow-challenge 返回非空 anchors、invite-ticket 不含 powAnchorRef、createInvite URL 不含锚）

## 兼容性
- 旧链接含 powAnchorRef 仍可解析但不再使用；新链接不含锚，加入时动态申请
- discoveryPublic=false 的 pow 群不通过 challenge 泄露 roomSecret


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
将入群 PoW 改为动态 `challenge`。本地无 replica 时通过 user-room 联邦获取挑战，并加入限流、超时、节点发现和 bootstrap 处理。入群流程按需计算 PoW，并优先使用 checkpoint、consensus branch tip 和 members root 等稳定锚点。

邀请链接、invite ticket 和 bootstrap 移除静态 `powAnchorRef`。旧链接仍可解析，但不再使用该锚点。`discoveryPublic=false` 时不通过 challenge 返回 `roomSecret`。

新增 HTTP、联邦和单元测试，覆盖 challenge 获取、锚点选择及邀请链接格式。

架构风险：动态 challenge 将入群流程绑定到 user-room、节点发现和跨节点 fanout，增加协议复杂度、延迟和故障面。14 秒超时与每分钟 30 次限流属于硬编码策略，可能造成体验和运维瓶颈。整体方向合理，但实现偏重，联邦路径已成为入群的关键依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->